### PR TITLE
refactor(features): extract shared helpers to collapse duplication

### DIFF
--- a/app/play/binder/[cardId]/page.tsx
+++ b/app/play/binder/[cardId]/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
-import { notFound, redirect } from "next/navigation";
-import { requireParent } from "@/features/auth/guard";
-import { getActiveChild } from "@/features/profiles/active-profile";
+import { notFound } from "next/navigation";
+import { requireActivePlayer } from "@/features/profiles/active-profile";
 import { getCardDetail } from "@/features/binder/service";
 import { Card } from "@/features/card/Card";
 import { SacrificePanel } from "@/features/pull/SacrificePanel";
@@ -11,9 +10,7 @@ export default async function CardDetailPage({
 }: {
   params: Promise<{ cardId: string }>;
 }) {
-  await requireParent();
-  const child = await getActiveChild();
-  if (!child) redirect("/play");
+  const child = await requireActivePlayer();
 
   const { cardId } = await params;
   const detail = await getCardDetail(child.id, cardId);

--- a/app/play/binder/page.tsx
+++ b/app/play/binder/page.tsx
@@ -1,16 +1,12 @@
 import Link from "next/link";
-import { redirect } from "next/navigation";
-import { requireParent } from "@/features/auth/guard";
-import { getActiveChild } from "@/features/profiles/active-profile";
+import { requireActivePlayer } from "@/features/profiles/active-profile";
 import { getBinder } from "@/features/binder/service";
 import { GalaxyView } from "@/features/binder/GalaxyView";
 import { getPendingRewards } from "@/features/rewards/service";
 import { CollectionRewardModal } from "@/features/rewards/CollectionRewardModal";
 
 export default async function BinderPage() {
-  await requireParent();
-  const child = await getActiveChild();
-  if (!child) redirect("/play");
+  const child = await requireActivePlayer();
 
   const [binder, pendingRewards] = await Promise.all([
     getBinder(child.id),

--- a/app/play/home/page.tsx
+++ b/app/play/home/page.tsx
@@ -1,15 +1,11 @@
 import Link from "next/link";
-import { redirect } from "next/navigation";
-import { requireParent } from "@/features/auth/guard";
-import { getActiveChild } from "@/features/profiles/active-profile";
+import { requireActivePlayer } from "@/features/profiles/active-profile";
 import { getSpecialBalances } from "@/features/pull/token-service";
 import { avatarEmoji } from "@/lib/avatars";
 import { switchProfileAction } from "@/features/profiles/actions";
 
 export default async function PlayHomePage() {
-  await requireParent();
-  const child = await getActiveChild();
-  if (!child) redirect("/play"); // U2-SEC-7: invalid/missing profile → picker
+  const child = await requireActivePlayer();
 
   // FR1 (Inc10): surface special-egg tickets on the landing page so they don't
   // silently read as "0 tickets". Inc13 FR3: show every ticket type explicitly

--- a/app/play/learn/[topicId]/page.tsx
+++ b/app/play/learn/[topicId]/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
-import { requireParent } from "@/features/auth/guard";
-import { getActiveChild } from "@/features/profiles/active-profile";
+import { requireActivePlayer } from "@/features/profiles/active-profile";
 import { getTopic } from "@/features/quiz/topics";
 import { QuizFlow } from "@/features/quiz/QuizFlow";
 
@@ -9,9 +8,7 @@ export default async function TopicPage({
 }: {
   params: Promise<{ topicId: string }>;
 }) {
-  await requireParent();
-  const child = await getActiveChild();
-  if (!child) redirect("/play");
+  const child = await requireActivePlayer();
 
   const { topicId } = await params;
   const topic = getTopic(topicId);

--- a/app/play/learn/page.tsx
+++ b/app/play/learn/page.tsx
@@ -1,7 +1,5 @@
 import Link from "next/link";
-import { redirect } from "next/navigation";
-import { requireParent } from "@/features/auth/guard";
-import { getActiveChild } from "@/features/profiles/active-profile";
+import { requireActivePlayer } from "@/features/profiles/active-profile";
 import { TOPICS } from "@/features/quiz/topics";
 import { topicsAwardedToday } from "@/features/quiz/activity";
 import type { QuizSubject } from "@/features/quiz/types";
@@ -12,9 +10,7 @@ const GROUPS: { subject: QuizSubject; label: string; emoji: string }[] = [
 ];
 
 export default async function LearnPage() {
-  await requireParent();
-  const child = await getActiveChild();
-  if (!child) redirect("/play");
+  const child = await requireActivePlayer();
 
   const done = await topicsAwardedToday(child.id);
 

--- a/app/play/pull/page.tsx
+++ b/app/play/pull/page.tsx
@@ -1,15 +1,11 @@
 import Link from "next/link";
-import { redirect } from "next/navigation";
-import { requireParent } from "@/features/auth/guard";
-import { getActiveChild } from "@/features/profiles/active-profile";
+import { requireActivePlayer } from "@/features/profiles/active-profile";
 import { getBalance, getSpecialBalances } from "@/features/pull/token-service";
 import { PullButton } from "@/features/pull/PullButton";
 import { listCards, listThemes } from "@/features/pool/service";
 
 export default async function PullPage() {
-  await requireParent();
-  const child = await getActiveChild();
-  if (!child) redirect("/play");
+  const child = await requireActivePlayer();
 
   const balance = await getBalance(child.id);
   const [allCards, themes, special] = await Promise.all([

--- a/app/play/trade/page.tsx
+++ b/app/play/trade/page.tsx
@@ -1,15 +1,11 @@
 import Link from "next/link";
-import { redirect } from "next/navigation";
-import { requireParent } from "@/features/auth/guard";
-import { getActiveChild } from "@/features/profiles/active-profile";
+import { requireActivePlayer } from "@/features/profiles/active-profile";
 import { listChildren } from "@/features/profiles/service";
 import { listTradableCards } from "@/features/trade/trade-service";
 import { TradeFlow } from "@/features/trade/TradeFlow";
 
 export default async function TradePage() {
-  await requireParent();
-  const child = await getActiveChild();
-  if (!child) redirect("/play"); // U2-SEC-7
+  const child = await requireActivePlayer();
 
   const [myCards, all] = await Promise.all([
     listTradableCards(child.id),

--- a/src/db/child-reads.ts
+++ b/src/db/child-reads.ts
@@ -1,0 +1,14 @@
+import "server-only";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { children } from "./schema";
+
+/**
+ * The single child row for an id, or undefined if absent. Single source of truth
+ * for the by-id `children.findFirst` read shared by the active-profile and
+ * profiles-service paths; callers map the row via toChild or use it as an
+ * existence check.
+ */
+export function findChildRow(id: string) {
+  return db.query.children.findFirst({ where: eq(children.id, id) });
+}

--- a/src/db/collection-reads.ts
+++ b/src/db/collection-reads.ts
@@ -1,0 +1,21 @@
+import "server-only";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { collections } from "./schema";
+
+/**
+ * How many copies of a card a child currently holds, 0 if the (childId, cardId)
+ * collection entry is absent. Single source of truth for the single-entry
+ * ownedCount read shared by the binder card-detail and trade paths. The DB CHECK
+ * `count >= 1` means a present row is always >= 1, so 0 unambiguously signals
+ * "not owned".
+ */
+export async function getCardCount(
+  childId: string,
+  cardId: string,
+): Promise<number> {
+  const row = await db.query.collections.findFirst({
+    where: and(eq(collections.childId, childId), eq(collections.cardId, cardId)),
+  });
+  return row?.count ?? 0;
+}

--- a/src/db/collection-writes.ts
+++ b/src/db/collection-writes.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { sql } from "drizzle-orm";
+import { and, eq, gte, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { collections } from "./schema";
 
@@ -18,4 +18,32 @@ export function addCardCopy(childId: string, cardId: string) {
       target: [collections.childId, collections.cardId],
       set: { count: sql`${collections.count} + 1` },
     });
+}
+
+/**
+ * Remove `count` copies of a card from a child's collection, guarded so the
+ * update only applies while the child still holds at least `minHeld` copies
+ * (default `count + 1`, i.e. never give away the last copy). Returns the
+ * Drizzle builder (not yet awaited) so callers can chain `.returning(...)`,
+ * `await` it, or drop it into a `db.batch([...])`. The `gte` guard makes the
+ * decrement an atomic CAS: a raced/stale caller that no longer holds enough
+ * copies matches zero rows instead of going negative. Single source of truth
+ * for the count decrement shared by trades and sacrifices.
+ */
+export function removeCardCopy(
+  childId: string,
+  cardId: string,
+  count = 1,
+  minHeld = count + 1,
+) {
+  return db
+    .update(collections)
+    .set({ count: sql`${collections.count} - ${count}` })
+    .where(
+      and(
+        eq(collections.childId, childId),
+        eq(collections.cardId, cardId),
+        gte(collections.count, minHeld),
+      ),
+    );
 }

--- a/src/db/collection-writes.ts
+++ b/src/db/collection-writes.ts
@@ -1,0 +1,21 @@
+import "server-only";
+import { sql } from "drizzle-orm";
+import { db } from "@/db";
+import { collections } from "./schema";
+
+/**
+ * Add one copy of a card to a child's collection: insert with count 1, or +1 on
+ * the (childId, cardId) unique conflict. Returns the Drizzle builder (not yet
+ * awaited) so callers can chain `.returning(...)`, `await` it directly, or drop
+ * it into a `db.batch([...])`. Single source of truth for the count upsert
+ * shared by pulls, easter eggs, completion rewards, and trades.
+ */
+export function addCardCopy(childId: string, cardId: string) {
+  return db
+    .insert(collections)
+    .values({ childId, cardId, count: 1 })
+    .onConflictDoUpdate({
+      target: [collections.childId, collections.cardId],
+      set: { count: sql`${collections.count} + 1` },
+    });
+}

--- a/src/features/admin/AdminCardSlot.tsx
+++ b/src/features/admin/AdminCardSlot.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import Image from "next/image";
 import { useState } from "react";
 import type { BinderCard } from "@/lib/types";
-import { RARITY_META } from "@/features/card/rarity";
+import { RarityThumb } from "@/features/card/RarityThumb";
 import { CardModal } from "@/features/card/CardModal";
 import "@/features/binder/rarity-slot.css";
 
@@ -14,7 +13,6 @@ import "@/features/binder/rarity-slot.css";
  */
 export function AdminCardSlot({ entry }: { entry: BinderCard }) {
   const [open, setOpen] = useState(false);
-  const meta = RARITY_META[entry.card.rarity];
 
   return (
     <div data-testid={`admin-card-${entry.card.id}`} className="flex flex-col gap-1">
@@ -25,19 +23,9 @@ export function AdminCardSlot({ entry }: { entry: BinderCard }) {
         aria-label={`Expand ${entry.card.name}`}
         className={`rslot rslot--${entry.card.rarity} relative overflow-hidden rounded-xl bg-white/10 shadow-[var(--shadow-soft)] transition duration-200 hover:-translate-y-1 hover:scale-105`}
       >
-        {entry.count > 1 ? (
-          <span className="absolute right-1 top-1 z-10 rounded-full bg-black/70 px-1.5 text-xs font-bold">
-            x{entry.count}
-          </span>
-        ) : null}
-        <span className="rarity-badge">{meta.label}</span>
-        <Image
-          src={entry.card.imageUrl}
-          alt={entry.card.name}
-          width={256}
-          height={256}
-          loading="lazy"
-          className="aspect-square w-full object-cover"
+        <RarityThumb
+          entry={entry}
+          countClassName="absolute right-1 top-1 z-10 rounded-full bg-black/70 px-1.5 text-xs font-bold"
         />
       </button>
 

--- a/src/features/admin/AdminCardSlot.tsx
+++ b/src/features/admin/AdminCardSlot.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import type { BinderCard } from "@/lib/types";
 import { RarityThumb } from "@/features/card/RarityThumb";
 import { CardModal } from "@/features/card/CardModal";
+import { raritySlotClass } from "@/features/binder/rarity-slot";
 import "@/features/binder/rarity-slot.css";
 
 /**
@@ -21,7 +22,7 @@ export function AdminCardSlot({ entry }: { entry: BinderCard }) {
         onClick={() => setOpen(true)}
         data-testid={`admin-card-expand-${entry.card.id}`}
         aria-label={`Expand ${entry.card.name}`}
-        className={`rslot rslot--${entry.card.rarity} relative overflow-hidden rounded-xl bg-white/10 shadow-[var(--shadow-soft)] transition duration-200 hover:-translate-y-1 hover:scale-105`}
+        className={raritySlotClass(entry.card.rarity)}
       >
         <RarityThumb
           entry={entry}

--- a/src/features/admin/ChildAdminRow.tsx
+++ b/src/features/admin/ChildAdminRow.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { avatarEmoji } from "@/lib/avatars";
+import { AvatarBadge } from "@/features/ui/AvatarBadge";
 import { ProgressBar } from "@/features/binder/ProgressBar";
 import { GrantControl } from "./GrantControl";
 import type { AdminChildRow as Row } from "@/lib/types";
@@ -14,9 +14,7 @@ export function ChildAdminRow({ row, quiz }: { row: Row; quiz?: QuizActivity }) 
     >
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
-          <span className="hero-avatar h-12 w-12 text-2xl" aria-hidden>
-            {avatarEmoji(child.avatar)}
-          </span>
+          <AvatarBadge avatar={child.avatar} className="h-12 w-12 text-2xl" />
           <div className="flex flex-col">
             <span className="font-semibold">{child.name}</span>
             <ProgressBar

--- a/src/features/admin/GrantControl.tsx
+++ b/src/features/admin/GrantControl.tsx
@@ -7,9 +7,9 @@ import {
   grantRarityPickTicketAction,
 } from "@/features/pull/actions";
 import { RARITY_META } from "@/features/card/rarity";
-import { RARITIES, type EggTicket, type Rarity } from "@/lib/types";
+import { RARITIES, zeroRarityCount, type EggTicket, type Rarity } from "@/lib/types";
 
-const ZERO_PICKS: Record<Rarity, number> = { common: 0, rare: 0, epic: 0, legendary: 0 };
+const ZERO_PICKS: Record<Rarity, number> = zeroRarityCount();
 
 /** A counter display with +1 / −1 grant buttons; −1 is disabled at zero. */
 function Stepper({

--- a/src/features/admin/GrantControl.tsx
+++ b/src/features/admin/GrantControl.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState, useTransition, type CSSProperties, type ReactNode } from "react";
 import {
   grantTokensAction,
   grantSpecialTicketAction,
@@ -10,6 +10,53 @@ import { RARITY_META } from "@/features/card/rarity";
 import { RARITIES, type EggTicket, type Rarity } from "@/lib/types";
 
 const ZERO_PICKS: Record<Rarity, number> = { common: 0, rare: 0, epic: 0, legendary: 0 };
+
+/** A counter display with +1 / −1 grant buttons; −1 is disabled at zero. */
+function Stepper({
+  id,
+  childId,
+  count,
+  pending,
+  label,
+  style,
+  onInc,
+  onDec,
+}: {
+  id: string;
+  childId: string;
+  count: number;
+  pending: boolean;
+  label: ReactNode;
+  style?: CSSProperties;
+  onInc: () => void;
+  onDec: () => void;
+}) {
+  return (
+    <span className="flex items-center gap-1">
+      <span data-testid={`${id}-balance-${childId}`} className="tabular-nums" style={style}>
+        {label}
+      </span>
+      <button
+        type="button"
+        onClick={onInc}
+        disabled={pending}
+        data-testid={`grant-${id}-plus1-${childId}`}
+        className="rounded bg-white/15 px-2 py-0.5 hover:bg-white/25 disabled:opacity-50"
+      >
+        +1
+      </button>
+      <button
+        type="button"
+        onClick={onDec}
+        disabled={pending || count < 1}
+        data-testid={`grant-${id}-minus1-${childId}`}
+        className="rounded bg-white/10 px-2 py-0.5 hover:bg-white/20 disabled:opacity-50"
+      >
+        −1
+      </button>
+    </span>
+  );
+}
 
 export function GrantControl({
   childId,
@@ -98,84 +145,44 @@ export function GrantControl({
       </div>
 
       <div className="flex flex-wrap items-center gap-3 text-sm">
-        <span className="flex items-center gap-1">
-          <span data-testid={`epic-balance-${childId}`} className="tabular-nums">
-            ✨ {epic}
-          </span>
-          <button
-            type="button"
-            onClick={() => grantTicket("epic", 1)}
-            disabled={pending}
-            data-testid={`grant-epic-plus1-${childId}`}
-            className="rounded bg-white/15 px-2 py-0.5 hover:bg-white/25 disabled:opacity-50"
-          >
-            +1
-          </button>
-          <button
-            type="button"
-            onClick={() => grantTicket("epic", -1)}
-            disabled={pending || epic < 1}
-            data-testid={`grant-epic-minus1-${childId}`}
-            className="rounded bg-white/10 px-2 py-0.5 hover:bg-white/20 disabled:opacity-50"
-          >
-            −1
-          </button>
-        </span>
-        <span className="flex items-center gap-1">
-          <span data-testid={`lucky-balance-${childId}`} className="tabular-nums">
-            🍀 {lucky}
-          </span>
-          <button
-            type="button"
-            onClick={() => grantTicket("lucky", 1)}
-            disabled={pending}
-            data-testid={`grant-lucky-plus1-${childId}`}
-            className="rounded bg-white/15 px-2 py-0.5 hover:bg-white/25 disabled:opacity-50"
-          >
-            +1
-          </button>
-          <button
-            type="button"
-            onClick={() => grantTicket("lucky", -1)}
-            disabled={pending || lucky < 1}
-            data-testid={`grant-lucky-minus1-${childId}`}
-            className="rounded bg-white/10 px-2 py-0.5 hover:bg-white/20 disabled:opacity-50"
-          >
-            −1
-          </button>
-        </span>
+        <Stepper
+          id="epic"
+          childId={childId}
+          count={epic}
+          pending={pending}
+          label={<>✨ {epic}</>}
+          onInc={() => grantTicket("epic", 1)}
+          onDec={() => grantTicket("epic", -1)}
+        />
+        <Stepper
+          id="lucky"
+          childId={childId}
+          count={lucky}
+          pending={pending}
+          label={<>🍀 {lucky}</>}
+          onInc={() => grantTicket("lucky", 1)}
+          onDec={() => grantTicket("lucky", -1)}
+        />
       </div>
 
       {/* Rarity-pick tickets (Inc16 FR3). */}
       <div className="flex flex-wrap items-center gap-3 text-sm">
         {RARITIES.map((r) => (
-          <span key={r} className="flex items-center gap-1">
-            <span
-              data-testid={`pick-${r}-balance-${childId}`}
-              className="tabular-nums"
-              style={{ color: RARITY_META[r].frame }}
-            >
-              🎯{RARITY_META[r].label[0]} {picks[r]}
-            </span>
-            <button
-              type="button"
-              onClick={() => grantPick(r, 1)}
-              disabled={pending}
-              data-testid={`grant-pick-${r}-plus1-${childId}`}
-              className="rounded bg-white/15 px-2 py-0.5 hover:bg-white/25 disabled:opacity-50"
-            >
-              +1
-            </button>
-            <button
-              type="button"
-              onClick={() => grantPick(r, -1)}
-              disabled={pending || picks[r] < 1}
-              data-testid={`grant-pick-${r}-minus1-${childId}`}
-              className="rounded bg-white/10 px-2 py-0.5 hover:bg-white/20 disabled:opacity-50"
-            >
-              −1
-            </button>
-          </span>
+          <Stepper
+            key={r}
+            id={`pick-${r}`}
+            childId={childId}
+            count={picks[r]}
+            pending={pending}
+            style={{ color: RARITY_META[r].frame }}
+            label={
+              <>
+                🎯{RARITY_META[r].label[0]} {picks[r]}
+              </>
+            }
+            onInc={() => grantPick(r, 1)}
+            onDec={() => grantPick(r, -1)}
+          />
         ))}
       </div>
     </div>

--- a/src/features/admin/UnlockForm.tsx
+++ b/src/features/admin/UnlockForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { unlockAdminAction } from "./unlock-action";
+import { ErrorBanner } from "@/features/ui/ErrorBanner";
 
 /** Passcode entry for the admin gate (U4-FR1). Generic error on failure. */
 export function UnlockForm() {
@@ -43,14 +44,11 @@ export function UnlockForm() {
         className="rounded-xl border border-white/15 bg-black/25 px-4 py-2.5 text-center text-[color:var(--ink)] outline-none transition focus:border-[color:var(--brand-1)] focus:ring-2 focus:ring-[color:var(--brand-1)]/40"
       />
 
-      {error ? (
-        <p
-          data-testid="admin-passcode-error"
-          className="text-center text-sm text-red-300"
-        >
-          Incorrect passcode.
-        </p>
-      ) : null}
+      <ErrorBanner
+        testId="admin-passcode-error"
+        message={error ? "Incorrect passcode." : null}
+        className="text-center text-sm text-red-300"
+      />
 
       <button
         type="submit"

--- a/src/features/admin/UnlockForm.tsx
+++ b/src/features/admin/UnlockForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react";
 import { unlockAdminAction } from "./unlock-action";
 import { ErrorBanner } from "@/features/ui/ErrorBanner";
+import { TEXT_INPUT_CLASS } from "@/features/ui/styles";
 
 /** Passcode entry for the admin gate (U4-FR1). Generic error on failure. */
 export function UnlockForm() {
@@ -41,7 +42,7 @@ export function UnlockForm() {
         autoFocus
         placeholder="Passcode"
         data-testid="admin-passcode-input"
-        className="rounded-xl border border-white/15 bg-black/25 px-4 py-2.5 text-center text-[color:var(--ink)] outline-none transition focus:border-[color:var(--brand-1)] focus:ring-2 focus:ring-[color:var(--brand-1)]/40"
+        className={`${TEXT_INPUT_CLASS} text-center`}
       />
 
       <ErrorBanner

--- a/src/features/admin/gate-token.ts
+++ b/src/features/admin/gate-token.ts
@@ -8,43 +8,7 @@
  * Date.now().
  */
 
-function b64urlEncode(bytes: Uint8Array): string {
-  let bin = "";
-  for (const b of bytes) bin += String.fromCharCode(b);
-  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-function b64urlDecode(s: string): Uint8Array {
-  const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
-  const bin = atob(s.replace(/-/g, "+").replace(/_/g, "/") + pad);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
-}
-
-async function hmac(payload: string, secret: string): Promise<Uint8Array> {
-  const key = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const sig = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    new TextEncoder().encode(payload),
-  );
-  return new Uint8Array(sig);
-}
-
-/** Constant-time byte comparison (no early return on mismatch). */
-function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
-  return diff === 0;
-}
+import { b64urlDecode, b64urlEncode, hmac, timingSafeEqual } from "@/lib/webcrypto";
 
 /** Build a signed token that expires at `expiresAtMs`. */
 export async function makeToken(

--- a/src/features/admin/gate.ts
+++ b/src/features/admin/gate.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { makeToken, verifyToken } from "./gate-token";
+import { env } from "@/lib/env";
 
 /**
  * Admin passcode gate (U4-FR1, Security). The passcode lives only in the
@@ -16,10 +17,6 @@ export const GATE_COOKIE = "kc.admin.gate";
 // activity. Keep in sync with GATE_TTL_MS in middleware.ts.
 export const GATE_TTL_MS = 20_000; // 20s
 const TTL_MS = GATE_TTL_MS;
-
-function secret(): string {
-  return process.env.AUTH_SECRET ?? "";
-}
 
 /** SHA-256 digest of a string (fixed length → safe for constant-time compare). */
 async function sha256(s: string): Promise<Uint8Array> {
@@ -47,7 +44,7 @@ export async function verifyPasscode(input: string): Promise<boolean> {
 
 /** Issue the gate cookie after a successful passcode entry. */
 export async function setGateCookie(): Promise<void> {
-  const token = await makeToken(Date.now() + TTL_MS, secret());
+  const token = await makeToken(Date.now() + TTL_MS, env.authSecret);
   const store = await cookies();
   store.set(GATE_COOKIE, token, {
     httpOnly: true,
@@ -62,7 +59,7 @@ export async function setGateCookie(): Promise<void> {
 export async function hasAdminGate(): Promise<boolean> {
   const store = await cookies();
   const token = store.get(GATE_COOKIE)?.value;
-  return verifyToken(token, secret(), Date.now());
+  return verifyToken(token, env.authSecret, Date.now());
 }
 
 /** Enforce the gate in admin pages/actions; redirect to unlock if missing. */

--- a/src/features/admin/service.ts
+++ b/src/features/admin/service.ts
@@ -3,7 +3,7 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { children, cards, themes, collections } from "@/db/schema";
 import { requireParent } from "@/features/auth/guard";
-import { pickTicketsFromRow } from "@/features/pull/pick-tickets";
+import { toChild } from "@/features/profiles/child-mapper";
 import type { AdminOverview, AdminChildRow } from "@/lib/types";
 
 /** Parent oversight: each child's balance + distinct-owned count, plus pool counts. */
@@ -27,15 +27,7 @@ export async function getAdminOverview(): Promise<AdminOverview> {
         .from(collections)
         .where(eq(collections.childId, c.id));
       return {
-        child: {
-          id: c.id,
-          name: c.name,
-          avatar: c.avatar,
-          pullTokens: c.pullTokens,
-          epicTickets: c.epicTickets,
-          luckyTickets: c.luckyTickets,
-          pickTickets: pickTicketsFromRow(c),
-        },
+        child: toChild(c),
         balance: c.pullTokens,
         epicTickets: c.epicTickets,
         luckyTickets: c.luckyTickets,

--- a/src/features/admin/unlock-action.ts
+++ b/src/features/admin/unlock-action.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { requireParent } from "@/features/auth/guard";
+import { field } from "@/lib/form";
 import { verifyPasscode, setGateCookie } from "./gate";
 import { redirect } from "next/navigation";
 
@@ -13,7 +14,7 @@ export async function unlockAdminAction(
   formData: FormData,
 ): Promise<false | void> {
   await requireParent();
-  const passcode = String(formData.get("passcode") ?? "");
+  const passcode = field(formData, "passcode");
   if (!(await verifyPasscode(passcode))) {
     return false;
   }

--- a/src/features/anim/Confetti.tsx
+++ b/src/features/anim/Confetti.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { useReducedMotion } from "./useReducedMotion";
+import { useMemo } from "react";
+import { useOneShotBurst } from "./useOneShotBurst";
 
 const COLORS = ["#43e6c8", "#ffd45e", "#ff6ba6", "#8b7bff", "#5ee0ff"];
 const MAX_PARTICLES = 80;
@@ -39,19 +39,11 @@ function build(count: number, seed: number): Particle[] {
  * `count` scales the burst (capped). Renders nothing under reduced motion.
  */
 export function Confetti({ fire, count = 60 }: { fire: number; count?: number }) {
-  const reduced = useReducedMotion();
-  const [active, setActive] = useState(false);
   const n = Math.min(MAX_PARTICLES, Math.max(0, count));
   const particles = useMemo(() => build(n, fire), [n, fire]);
+  const visible = useOneShotBurst(fire, 1800);
 
-  useEffect(() => {
-    if (!fire || reduced) return;
-    setActive(true);
-    const t = setTimeout(() => setActive(false), 1800);
-    return () => clearTimeout(t);
-  }, [fire, reduced]);
-
-  if (!active || reduced) return null;
+  if (!visible) return null;
 
   return (
     <div className="confetti-layer" aria-hidden data-testid="confetti">

--- a/src/features/anim/Confetti.tsx
+++ b/src/features/anim/Confetti.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { clamp } from "@/lib/math";
 import { useOneShotBurst } from "./useOneShotBurst";
 
 const COLORS = ["#43e6c8", "#ffd45e", "#ff6ba6", "#8b7bff", "#5ee0ff"];
@@ -39,7 +40,7 @@ function build(count: number, seed: number): Particle[] {
  * `count` scales the burst (capped). Renders nothing under reduced motion.
  */
 export function Confetti({ fire, count = 60 }: { fire: number; count?: number }) {
-  const n = Math.min(MAX_PARTICLES, Math.max(0, count));
+  const n = clamp(count, 0, MAX_PARTICLES);
   const particles = useMemo(() => build(n, fire), [n, fire]);
   const visible = useOneShotBurst(fire, 1800);
 

--- a/src/features/anim/Fireworks.tsx
+++ b/src/features/anim/Fireworks.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { useReducedMotion } from "./useReducedMotion";
+import { useMemo } from "react";
+import { useOneShotBurst } from "./useOneShotBurst";
 
 /**
  * Full-screen fireworks bursts (U6-FR4) — distinct from confetti. Bump `fire`
@@ -47,18 +47,10 @@ function build(seed: number): Spark[] {
 }
 
 export function Fireworks({ fire }: { fire: number }) {
-  const reduced = useReducedMotion();
-  const [active, setActive] = useState(false);
   const sparks = useMemo(() => build(fire), [fire]);
+  const visible = useOneShotBurst(fire, 2200);
 
-  useEffect(() => {
-    if (!fire || reduced) return;
-    setActive(true);
-    const t = setTimeout(() => setActive(false), 2200);
-    return () => clearTimeout(t);
-  }, [fire, reduced]);
-
-  if (!active || reduced) return null;
+  if (!visible) return null;
 
   return (
     <div className="fireworks-layer" aria-hidden>

--- a/src/features/anim/useOneShotBurst.ts
+++ b/src/features/anim/useOneShotBurst.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useReducedMotion } from "./useReducedMotion";
+
+/**
+ * Drives a one-shot animation burst. Bump `fire` (a counter or timestamp) to
+ * trigger; the returned flag is true for `durationMs` then falls back to false.
+ * Always false under reduced motion, so callers can render `null` when it is.
+ */
+export function useOneShotBurst(fire: number, durationMs: number): boolean {
+  const reduced = useReducedMotion();
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    if (!fire || reduced) return;
+    setActive(true);
+    const t = setTimeout(() => setActive(false), durationMs);
+    return () => clearTimeout(t);
+  }, [fire, reduced, durationMs]);
+
+  return active && !reduced;
+}

--- a/src/features/binder/CardSlot.tsx
+++ b/src/features/binder/CardSlot.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { BinderCard } from "@/lib/types";
 import { RarityThumb } from "@/features/card/RarityThumb";
 import { AdminCardSlot } from "@/features/admin/AdminCardSlot";
+import { raritySlotClass } from "./rarity-slot";
 import "./rarity-slot.css";
 
 /** Owned card thumbnail (tappable → detail) or a locked silhouette.
@@ -40,7 +41,7 @@ export function CardSlot({
     <Link
       href={`/play/binder/${entry.card.id}`}
       data-testid={`card-slot-${entry.card.id}`}
-      className={`slot-pop rslot rslot--${entry.card.rarity} relative block overflow-hidden rounded-xl bg-white/10 shadow-[var(--shadow-soft)] transition duration-200 hover:-translate-y-1 hover:scale-105`}
+      className={`slot-pop block ${raritySlotClass(entry.card.rarity)}`}
     >
       <RarityThumb entry={entry} countClassName="badge-count absolute right-1 top-1" />
     </Link>

--- a/src/features/binder/CardSlot.tsx
+++ b/src/features/binder/CardSlot.tsx
@@ -1,7 +1,6 @@
-import Image from "next/image";
 import Link from "next/link";
 import type { BinderCard } from "@/lib/types";
-import { RARITY_META } from "@/features/card/rarity";
+import { RarityThumb } from "@/features/card/RarityThumb";
 import { AdminCardSlot } from "@/features/admin/AdminCardSlot";
 import "./rarity-slot.css";
 
@@ -37,26 +36,13 @@ export function CardSlot({
     return <AdminCardSlot entry={entry} />;
   }
 
-  const meta = RARITY_META[entry.card.rarity];
-
   return (
     <Link
       href={`/play/binder/${entry.card.id}`}
       data-testid={`card-slot-${entry.card.id}`}
       className={`slot-pop rslot rslot--${entry.card.rarity} relative block overflow-hidden rounded-xl bg-white/10 shadow-[var(--shadow-soft)] transition duration-200 hover:-translate-y-1 hover:scale-105`}
     >
-      {entry.count > 1 ? (
-        <span className="badge-count absolute right-1 top-1">x{entry.count}</span>
-      ) : null}
-      <span className="rarity-badge">{meta.label}</span>
-      <Image
-        src={entry.card.imageUrl}
-        alt={entry.card.name}
-        width={256}
-        height={256}
-        loading="lazy"
-        className="aspect-square w-full object-cover"
-      />
+      <RarityThumb entry={entry} countClassName="badge-count absolute right-1 top-1" />
     </Link>
   );
 }

--- a/src/features/binder/SetCompleteCelebration.tsx
+++ b/src/features/binder/SetCompleteCelebration.tsx
@@ -4,6 +4,7 @@ import { useContext, useEffect, useState } from "react";
 import { SoundContext } from "@/features/sound/SoundProvider";
 import { useSound } from "@/features/sound/useSound";
 import { Confetti } from "@/features/anim/Confetti";
+import { storageGet, storageSet } from "@/lib/storage";
 
 /**
  * Fires a fanfare + confetti once per session when a theme set is complete,
@@ -17,18 +18,8 @@ export function SetCompleteCelebration({ themeId }: { themeId: string }) {
   useEffect(() => {
     if (!inPlayArea) return; // outside the play area (e.g. admin) → no celebration
     const key = `kc.snd.celebrated.${themeId}`;
-    let already = false;
-    try {
-      already = sessionStorage.getItem(key) === "1";
-    } catch {
-      /* storage blocked — celebrate anyway */
-    }
-    if (already) return;
-    try {
-      sessionStorage.setItem(key, "1");
-    } catch {
-      /* ignore */
-    }
+    if (storageGet("sessionStorage", key) === "1") return;
+    storageSet("sessionStorage", key, "1");
     play("setComplete");
     setFire((n) => n + 1);
   }, [themeId, play, inPlayArea]);

--- a/src/features/binder/rarity-filter.ts
+++ b/src/features/binder/rarity-filter.ts
@@ -1,4 +1,4 @@
-import { RARITIES, type Rarity } from "@/lib/types";
+import { RARITIES, zeroRarityCount, type Rarity } from "@/lib/types";
 import type { BinderCard, ThemeSection } from "@/lib/types";
 
 /**
@@ -12,7 +12,7 @@ export type RarityCount = Record<Rarity, number>;
 /** Owned-only tally per rarity across the given sections (respects whatever
  * category filtering the caller already applied — Q4.1 AND-filter, Q4.2=A). */
 export function countOwnedByRarity(sections: ThemeSection[]): RarityCount {
-  const counts: RarityCount = { common: 0, rare: 0, epic: 0, legendary: 0 };
+  const counts: RarityCount = zeroRarityCount();
   for (const section of sections) {
     for (const bc of section.cards) {
       if (bc.owned) counts[bc.card.rarity] += 1;

--- a/src/features/binder/rarity-slot.ts
+++ b/src/features/binder/rarity-slot.ts
@@ -1,0 +1,11 @@
+import type { Rarity } from "@/lib/types";
+
+/**
+ * Shared class tail for a rarity-framed card slot (colored frame + glow + hover
+ * lift). Consumed by binder CardSlot (a Link) and admin AdminCardSlot (a button),
+ * which each prepend element-specific classes (e.g. `slot-pop block`).
+ * Callers must also import `./rarity-slot.css` for the frame styling.
+ */
+export function raritySlotClass(rarity: Rarity): string {
+  return `rslot rslot--${rarity} relative overflow-hidden rounded-xl bg-white/10 shadow-[var(--shadow-soft)] transition duration-200 hover:-translate-y-1 hover:scale-105`;
+}

--- a/src/features/binder/service.ts
+++ b/src/features/binder/service.ts
@@ -1,7 +1,8 @@
 import "server-only";
-import { and, eq } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { collections } from "@/db/schema";
+import { getCardCount } from "@/db/collection-reads";
 import { listThemes, listCards } from "@/features/pool/service";
 import { themeProgress } from "@/lib/logic";
 import type { BinderView, CollectionEntry, ThemeSection } from "@/lib/types";
@@ -55,11 +56,9 @@ export async function getCardDetail(
   childId: string,
   cardId: string,
 ): Promise<{ card: import("@/lib/types").Card; count: number } | null> {
-  const row = await db.query.collections.findFirst({
-    where: and(eq(collections.childId, childId), eq(collections.cardId, cardId)),
-  });
-  if (!row || row.count < 1) return null;
+  const count = await getCardCount(childId, cardId);
+  if (count < 1) return null;
   const { getCard } = await import("@/features/pool/service");
   const card = await getCard(cardId);
-  return card ? { card, count: row.count } : null;
+  return card ? { card, count } : null;
 }

--- a/src/features/card/Card.tsx
+++ b/src/features/card/Card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Image from "next/image";
 import type { Card as CardType } from "@/lib/types";
+import { CardImage } from "./CardImage";
 import { rarityClass, RARITY_LABEL } from "./rarity";
 import { useCardTilt } from "./useCardTilt";
 import "./card.css";
@@ -34,14 +34,7 @@ export function Card({
         <span className="badge-count absolute right-2 top-2">x{count}</span>
       ) : null}
 
-      <Image
-        src={card.imageUrl}
-        alt={card.name}
-        width={512}
-        height={512}
-        className="aspect-square w-full object-cover"
-        priority={interactive}
-      />
+      <CardImage src={card.imageUrl} alt={card.name} dim={512} priority={interactive} />
 
       <div className="flex flex-col gap-1.5 bg-black/35 p-3.5 backdrop-blur-sm">
         <div className="flex items-center justify-between gap-2">

--- a/src/features/card/CardImage.tsx
+++ b/src/features/card/CardImage.tsx
@@ -1,0 +1,33 @@
+import Image from "next/image";
+
+/** Shared square card artwork. Every card surface renders the card's imageUrl
+ *  as a square, object-cover thumbnail; only the pixel size and the
+ *  priority/loading hints vary. The default className covers all full-width
+ *  slots; the fixed-size CardMini variant overrides it. */
+export function CardImage({
+  src,
+  alt,
+  dim,
+  priority,
+  loading,
+  className = "aspect-square w-full object-cover",
+}: {
+  src: string;
+  alt: string;
+  dim: number;
+  priority?: boolean;
+  loading?: "lazy" | "eager";
+  className?: string;
+}) {
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      width={dim}
+      height={dim}
+      className={className}
+      priority={priority}
+      loading={loading}
+    />
+  );
+}

--- a/src/features/card/RarityThumb.tsx
+++ b/src/features/card/RarityThumb.tsx
@@ -1,0 +1,34 @@
+import Image from "next/image";
+import type { BinderCard } from "@/lib/types";
+import { RARITY_META } from "@/features/card/rarity";
+import "@/features/binder/rarity-slot.css";
+
+/** Shared inner content for an owned rarity-framed slot (U5-FR2): an optional
+ *  copy-count badge, the rarity corner badge, and the lazy 256px thumbnail.
+ *  Rendered inside a rarity-framed wrapper (Link or button) by the caller, which
+ *  supplies the count badge's className (styling differs between binder/admin). */
+export function RarityThumb({
+  entry,
+  countClassName,
+}: {
+  entry: BinderCard;
+  countClassName: string;
+}) {
+  const meta = RARITY_META[entry.card.rarity];
+  return (
+    <>
+      {entry.count > 1 ? (
+        <span className={countClassName}>x{entry.count}</span>
+      ) : null}
+      <span className="rarity-badge">{meta.label}</span>
+      <Image
+        src={entry.card.imageUrl}
+        alt={entry.card.name}
+        width={256}
+        height={256}
+        loading="lazy"
+        className="aspect-square w-full object-cover"
+      />
+    </>
+  );
+}

--- a/src/features/card/RarityThumb.tsx
+++ b/src/features/card/RarityThumb.tsx
@@ -1,5 +1,5 @@
-import Image from "next/image";
 import type { BinderCard } from "@/lib/types";
+import { CardImage } from "@/features/card/CardImage";
 import { RARITY_META } from "@/features/card/rarity";
 import "@/features/binder/rarity-slot.css";
 
@@ -21,14 +21,7 @@ export function RarityThumb({
         <span className={countClassName}>x{entry.count}</span>
       ) : null}
       <span className="rarity-badge">{meta.label}</span>
-      <Image
-        src={entry.card.imageUrl}
-        alt={entry.card.name}
-        width={256}
-        height={256}
-        loading="lazy"
-        className="aspect-square w-full object-cover"
-      />
+      <CardImage src={entry.card.imageUrl} alt={entry.card.name} dim={256} loading="lazy" />
     </>
   );
 }

--- a/src/features/card/RevealCard.tsx
+++ b/src/features/card/RevealCard.tsx
@@ -6,7 +6,7 @@ import { Card } from "./Card";
 import { shouldAnimate } from "./rarity";
 import { useSound } from "@/features/sound/useSound";
 import { Confetti } from "@/features/anim/Confetti";
-import { isBigReveal, rewardFanfare } from "@/features/sound/sfx";
+import { isBigReveal, playFanfare } from "@/features/sound/sfx";
 import "./card.css";
 
 /**
@@ -24,8 +24,7 @@ export function RevealCard({ card }: { card: CardType }) {
     const finish = () => {
       setDone(true);
       play("reveal", card.rarity);
-      const fanfare = rewardFanfare(card.rarity); // Inc15 FR2: layer for epic/legendary
-      if (fanfare) play(fanfare);
+      playFanfare(play, card.rarity); // Inc15 FR2: layer for epic/legendary
       if (isBigReveal(card.rarity)) setBurst((n) => n + 1);
     };
 

--- a/src/features/card/rarity.ts
+++ b/src/features/card/rarity.ts
@@ -1,3 +1,4 @@
+import { prefersReducedMotion } from "@/lib/motion";
 import type { Rarity } from "@/lib/types";
 
 /** Per-rarity CSS class (frame + effect intensity). Pure → testable. */
@@ -35,6 +36,5 @@ export const RARITY_META: Record<Rarity, RarityMeta> = {
 
 /** True if motion effects should run (respects reduced-motion). Browser-only. */
 export function shouldAnimate(): boolean {
-  if (typeof window === "undefined" || !window.matchMedia) return false;
-  return !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  return !prefersReducedMotion();
 }

--- a/src/features/card/useCardTilt.ts
+++ b/src/features/card/useCardTilt.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useCallback } from "react";
+import { clamp } from "@/lib/math";
 import { shouldAnimate } from "./rarity";
 
 const MAX_TILT = 12; // degrees
@@ -55,8 +56,8 @@ export function useCardTilt(interactive: boolean) {
     const handler = (e: DeviceOrientationEvent) => {
       const gamma = e.gamma ?? 0; // left/right [-90,90]
       const beta = e.beta ?? 0; // front/back
-      const ry = Math.max(-MAX_TILT, Math.min(MAX_TILT, gamma / 4));
-      const rx = Math.max(-MAX_TILT, Math.min(MAX_TILT, (beta - 45) / 4));
+      const ry = clamp(gamma / 4, -MAX_TILT, MAX_TILT);
+      const rx = clamp((beta - 45) / 4, -MAX_TILT, MAX_TILT);
       setVars(rx, ry, 50 + gamma, 50 + (beta - 45));
     };
 

--- a/src/features/pool/writer.ts
+++ b/src/features/pool/writer.ts
@@ -1,7 +1,26 @@
-import { and, eq, notInArray } from "drizzle-orm";
+import { and, eq, notInArray, type SQL } from "drizzle-orm";
+import type { PgColumn, PgTable } from "drizzle-orm/pg-core";
 import { db } from "@/db";
 import { themes, cards, collections } from "@/db/schema";
 import type { Rarity } from "@/lib/types";
+
+/**
+ * Delete rows from `table` whose `nameCol` is not in `keepNames`, optionally
+ * scoped by `base`. An empty `keepNames` deletes every (scoped) row. Returns the
+ * number of rows deleted. Shared by the theme/card delta-sync pruners.
+ */
+async function pruneNotIn(
+  table: PgTable,
+  nameCol: PgColumn,
+  idCol: PgColumn,
+  keepNames: string[],
+  base?: SQL,
+): Promise<number> {
+  const keep = keepNames.length === 0 ? undefined : notInArray(nameCol, keepNames);
+  const where = base && keep ? and(base, keep) : (base ?? keep);
+  const deleted = await db.delete(table).where(where).returning({ id: idCol });
+  return deleted.length;
+}
 
 /** Upsert a theme by name; returns its id (idempotent, U3-BR8). */
 export async function upsertTheme(name: string): Promise<string> {
@@ -80,14 +99,7 @@ export async function updateCardMeta(input: {
  * Returns the number of themes deleted.
  */
 export async function deleteThemesNotIn(keepNames: string[]): Promise<number> {
-  const deleted =
-    keepNames.length === 0
-      ? await db.delete(themes).returning({ id: themes.id })
-      : await db
-          .delete(themes)
-          .where(notInArray(themes.name, keepNames))
-          .returning({ id: themes.id });
-  return deleted.length;
+  return pruneNotIn(themes, themes.name, themes.id, keepNames);
 }
 
 /**
@@ -98,13 +110,5 @@ export async function deleteCardsNotIn(
   themeId: string,
   keepNames: string[],
 ): Promise<number> {
-  const base = eq(cards.themeId, themeId);
-  const deleted =
-    keepNames.length === 0
-      ? await db.delete(cards).where(base).returning({ id: cards.id })
-      : await db
-          .delete(cards)
-          .where(and(base, notInArray(cards.name, keepNames)))
-          .returning({ id: cards.id });
-  return deleted.length;
+  return pruneNotIn(cards, cards.name, cards.id, keepNames, eq(cards.themeId, themeId));
 }

--- a/src/features/profiles/ProfileCard.tsx
+++ b/src/features/profiles/ProfileCard.tsx
@@ -1,4 +1,4 @@
-import { avatarEmoji } from "@/lib/avatars";
+import { AvatarBadge } from "@/features/ui/AvatarBadge";
 import { selectProfileAction } from "./actions";
 
 export function ProfileCard({
@@ -18,12 +18,10 @@ export function ProfileCard({
         data-testid={`profile-card-${id}`}
         className="panel group flex h-52 w-44 flex-col items-center justify-center gap-3 p-4 text-center transition duration-200 hover:-translate-y-1.5 hover:[box-shadow:var(--shadow-soft),var(--shadow-glow)] focus-visible:outline-none focus-visible:[box-shadow:var(--ring-focus)] active:scale-95"
       >
-        <span
-          className="hero-avatar h-28 w-28 text-7xl transition group-hover:scale-105"
-          aria-hidden
-        >
-          {avatarEmoji(avatar)}
-        </span>
+        <AvatarBadge
+          avatar={avatar}
+          className="h-28 w-28 text-7xl transition group-hover:scale-105"
+        />
         <span className="display text-xl font-semibold">{name}</span>
       </button>
     </form>

--- a/src/features/profiles/ProfileForm.tsx
+++ b/src/features/profiles/ProfileForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { AVATAR_PRESETS } from "@/lib/avatars";
+import { TEXT_INPUT_CLASS } from "@/features/ui/styles";
 import { createProfileAction, updateProfileAction } from "./actions";
 
 export function ProfileForm({
@@ -32,7 +33,7 @@ export function ProfileForm({
         onChange={(e) => setName(e.target.value)}
         placeholder="Name"
         data-testid="profile-name-input"
-        className="rounded-xl border border-white/15 bg-black/25 px-4 py-2.5 text-[color:var(--ink)] outline-none transition focus:border-[color:var(--brand-1)] focus:ring-2 focus:ring-[color:var(--brand-1)]/40"
+        className={TEXT_INPUT_CLASS}
       />
 
       <input type="hidden" name="avatar" value={avatar} />

--- a/src/features/profiles/ProfileRow.tsx
+++ b/src/features/profiles/ProfileRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { avatarEmoji } from "@/lib/avatars";
+import { AvatarBadge } from "@/features/ui/AvatarBadge";
 import { ProfileForm } from "./ProfileForm";
 import { RemoveProfileButton } from "./RemoveProfileButton";
 
@@ -51,9 +51,7 @@ export function ProfileRow({
       data-testid={`profile-row-${id}`}
     >
       <span className="flex items-center gap-3">
-        <span className="hero-avatar h-11 w-11 text-xl" aria-hidden>
-          {avatarEmoji(avatar)}
-        </span>
+        <AvatarBadge avatar={avatar} className="h-11 w-11 text-xl" />
         <span className="display font-semibold">{name}</span>
         <span
           className="pill text-xs"

--- a/src/features/profiles/actions.ts
+++ b/src/features/profiles/actions.ts
@@ -15,6 +15,17 @@ import {
   clearActiveProfile,
 } from "./active-profile";
 
+/**
+ * Run a parent-gated profile mutation, revalidating the admin profiles list
+ * and the play picker. Shared body of the create/update/remove entry points.
+ */
+async function parentMutate(run: () => Promise<unknown>): Promise<void> {
+  await requireParent();
+  await run();
+  revalidatePath("/admin/profiles");
+  revalidatePath("/play");
+}
+
 /** Select a child profile, then go to the play home. */
 export async function selectProfileAction(formData: FormData): Promise<void> {
   const childId = field(formData, "childId");
@@ -29,30 +40,25 @@ export async function switchProfileAction(): Promise<void> {
 }
 
 export async function createProfileAction(formData: FormData): Promise<void> {
-  await requireParent();
-  await createChild({
-    name: field(formData, "name"),
-    avatar: field(formData, "avatar"),
-  });
-  revalidatePath("/admin/profiles");
-  revalidatePath("/play");
+  await parentMutate(() =>
+    createChild({
+      name: field(formData, "name"),
+      avatar: field(formData, "avatar"),
+    }),
+  );
 }
 
 export async function updateProfileAction(formData: FormData): Promise<void> {
-  await requireParent();
-  await updateChild(field(formData, "id"), {
-    name: field(formData, "name"),
-    avatar: field(formData, "avatar"),
-  });
-  revalidatePath("/admin/profiles");
-  revalidatePath("/play");
+  await parentMutate(() =>
+    updateChild(field(formData, "id"), {
+      name: field(formData, "name"),
+      avatar: field(formData, "avatar"),
+    }),
+  );
 }
 
 export async function removeProfileAction(formData: FormData): Promise<void> {
-  await requireParent();
-  await removeChild(field(formData, "id"));
-  revalidatePath("/admin/profiles");
-  revalidatePath("/play");
+  await parentMutate(() => removeChild(field(formData, "id")));
 }
 
 export async function signOutAction(): Promise<void> {

--- a/src/features/profiles/actions.ts
+++ b/src/features/profiles/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { signOut as authSignOut } from "@/auth/config";
 import { requireParent } from "@/features/auth/guard";
+import { field } from "@/lib/form";
 import {
   createChild,
   updateChild,
@@ -16,7 +17,7 @@ import {
 
 /** Select a child profile, then go to the play home. */
 export async function selectProfileAction(formData: FormData): Promise<void> {
-  const childId = String(formData.get("childId") ?? "");
+  const childId = field(formData, "childId");
   await setActiveProfile(childId);
   redirect("/play/home");
 }
@@ -30,8 +31,8 @@ export async function switchProfileAction(): Promise<void> {
 export async function createProfileAction(formData: FormData): Promise<void> {
   await requireParent();
   await createChild({
-    name: String(formData.get("name") ?? ""),
-    avatar: String(formData.get("avatar") ?? ""),
+    name: field(formData, "name"),
+    avatar: field(formData, "avatar"),
   });
   revalidatePath("/admin/profiles");
   revalidatePath("/play");
@@ -39,9 +40,9 @@ export async function createProfileAction(formData: FormData): Promise<void> {
 
 export async function updateProfileAction(formData: FormData): Promise<void> {
   await requireParent();
-  await updateChild(String(formData.get("id") ?? ""), {
-    name: String(formData.get("name") ?? ""),
-    avatar: String(formData.get("avatar") ?? ""),
+  await updateChild(field(formData, "id"), {
+    name: field(formData, "name"),
+    avatar: field(formData, "avatar"),
   });
   revalidatePath("/admin/profiles");
   revalidatePath("/play");
@@ -49,7 +50,7 @@ export async function updateProfileAction(formData: FormData): Promise<void> {
 
 export async function removeProfileAction(formData: FormData): Promise<void> {
   await requireParent();
-  await removeChild(String(formData.get("id") ?? ""));
+  await removeChild(field(formData, "id"));
   revalidatePath("/admin/profiles");
   revalidatePath("/play");
 }

--- a/src/features/profiles/active-profile.ts
+++ b/src/features/profiles/active-profile.ts
@@ -3,7 +3,7 @@ import { cookies } from "next/headers";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { children } from "@/db/schema";
-import { pickTicketsFromRow } from "@/features/pull/pick-tickets";
+import { toChild } from "./child-mapper";
 import type { Child } from "@/lib/types";
 
 const COOKIE = "activeChildId";
@@ -54,13 +54,5 @@ export async function getActiveChild(): Promise<Child | null> {
     where: eq(children.id, childId),
   });
   if (!row) return null;
-  return {
-    id: row.id,
-    name: row.name,
-    avatar: row.avatar,
-    pullTokens: row.pullTokens,
-    epicTickets: row.epicTickets,
-    luckyTickets: row.luckyTickets,
-    pickTickets: pickTicketsFromRow(row),
-  };
+  return toChild(row);
 }

--- a/src/features/profiles/active-profile.ts
+++ b/src/features/profiles/active-profile.ts
@@ -1,8 +1,10 @@
 import "server-only";
 import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { children } from "@/db/schema";
+import { requireParent } from "@/features/auth/guard";
 import { toChild } from "./child-mapper";
 import type { Child } from "@/lib/types";
 
@@ -41,6 +43,17 @@ export async function clearActiveProfile(): Promise<void> {
 export async function requireActiveChild(): Promise<Child> {
   const child = await getActiveChild();
   if (!child) throw new Error("No active profile");
+  return child;
+}
+
+/**
+ * Page-level guard for every /play/* screen: enforce parent access, then resolve
+ * the active child, redirecting to the picker when none is selected (U2-SEC-7).
+ */
+export async function requireActivePlayer(): Promise<Child> {
+  await requireParent();
+  const child = await getActiveChild();
+  if (!child) redirect("/play");
   return child;
 }
 

--- a/src/features/profiles/active-profile.ts
+++ b/src/features/profiles/active-profile.ts
@@ -1,10 +1,8 @@
 import "server-only";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { eq } from "drizzle-orm";
-import { db } from "@/db";
-import { children } from "@/db/schema";
 import { requireParent } from "@/features/auth/guard";
+import { findChildRow } from "@/db/child-reads";
 import { toChild } from "./child-mapper";
 import type { Child } from "@/lib/types";
 
@@ -16,9 +14,7 @@ const COOKIE = "activeChildId";
  * selection is a post-auth convenience, not a security boundary.
  */
 export async function setActiveProfile(childId: string): Promise<void> {
-  const exists = await db.query.children.findFirst({
-    where: eq(children.id, childId),
-  });
+  const exists = await findChildRow(childId);
   if (!exists) throw new Error("setActiveProfile: unknown child");
 
   const store = await cookies();
@@ -63,9 +59,7 @@ export async function getActiveChild(): Promise<Child | null> {
   const childId = store.get(COOKIE)?.value;
   if (!childId) return null;
 
-  const row = await db.query.children.findFirst({
-    where: eq(children.id, childId),
-  });
+  const row = await findChildRow(childId);
   if (!row) return null;
   return toChild(row);
 }

--- a/src/features/profiles/active-profile.ts
+++ b/src/features/profiles/active-profile.ts
@@ -34,6 +34,16 @@ export async function clearActiveProfile(): Promise<void> {
   store.delete(COOKIE);
 }
 
+/**
+ * Resolve the active child, throwing if none is selected. Shared guard for
+ * server actions that require an active player.
+ */
+export async function requireActiveChild(): Promise<Child> {
+  const child = await getActiveChild();
+  if (!child) throw new Error("No active profile");
+  return child;
+}
+
 /** Resolve the active child from the cookie, validated against the DB. */
 export async function getActiveChild(): Promise<Child | null> {
   const store = await cookies();

--- a/src/features/profiles/child-mapper.ts
+++ b/src/features/profiles/child-mapper.ts
@@ -1,0 +1,20 @@
+import type { children } from "@/db/schema";
+import { pickTicketsFromRow } from "@/features/pull/pick-tickets";
+import type { Child } from "@/lib/types";
+
+/**
+ * Map a raw `children` DB row to the domain `Child` (pure). Single source of
+ * truth for the row → Child projection shared by the profiles, active-profile,
+ * and admin read paths.
+ */
+export function toChild(row: typeof children.$inferSelect): Child {
+  return {
+    id: row.id,
+    name: row.name,
+    avatar: row.avatar,
+    pullTokens: row.pullTokens,
+    epicTickets: row.epicTickets,
+    luckyTickets: row.luckyTickets,
+    pickTickets: pickTicketsFromRow(row),
+  };
+}

--- a/src/features/profiles/service.ts
+++ b/src/features/profiles/service.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { db } from "@/db";
 import { children } from "@/db/schema";
 import { requireParent } from "@/features/auth/guard";
-import { pickTicketsFromRow } from "@/features/pull/pick-tickets";
+import { toChild } from "./child-mapper";
 import { AVATAR_KEYS } from "@/lib/avatars";
 import type { Child } from "@/lib/types";
 
@@ -12,18 +12,6 @@ const profileSchema = z.object({
   name: z.string().trim().min(1, "Name is required").max(40),
   avatar: z.enum(AVATAR_KEYS as [string, ...string[]]),
 });
-
-function toChild(row: typeof children.$inferSelect): Child {
-  return {
-    id: row.id,
-    name: row.name,
-    avatar: row.avatar,
-    pullTokens: row.pullTokens,
-    epicTickets: row.epicTickets,
-    luckyTickets: row.luckyTickets,
-    pickTickets: pickTicketsFromRow(row),
-  };
-}
 
 /**
  * All child profiles, ordered case-insensitively by name (Inc8 FR4). Stable

--- a/src/features/profiles/service.ts
+++ b/src/features/profiles/service.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { db } from "@/db";
 import { children } from "@/db/schema";
 import { requireParent } from "@/features/auth/guard";
+import { findChildRow } from "@/db/child-reads";
 import { toChild } from "./child-mapper";
 import { AVATAR_KEYS } from "@/lib/avatars";
 import type { Child } from "@/lib/types";
@@ -27,7 +28,7 @@ export async function listChildren(): Promise<Child[]> {
 
 /** Single child profile, or null. */
 export async function getChild(id: string): Promise<Child | null> {
-  const row = await db.query.children.findFirst({ where: eq(children.id, id) });
+  const row = await findChildRow(id);
   return row ? toChild(row) : null;
 }
 

--- a/src/features/pull/CardRoulette.tsx
+++ b/src/features/pull/CardRoulette.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import Image from "next/image";
+import { CardImage } from "@/features/card/CardImage";
 import type { Card, Rarity } from "@/lib/types";
 import { shouldAnimate } from "@/features/card/rarity";
 import { rarityClass } from "@/features/card/rarity";
@@ -86,14 +86,7 @@ export function CardRoulette({
       aria-hidden
     >
       <div className="card__holo" />
-      <Image
-        src={shown.imageUrl}
-        alt=""
-        width={512}
-        height={512}
-        className="aspect-square w-full object-cover"
-        priority
-      />
+      <CardImage src={shown.imageUrl} alt="" dim={512} priority />
     </div>
   );
 }

--- a/src/features/pull/EasterEggPicker.tsx
+++ b/src/features/pull/EasterEggPicker.tsx
@@ -6,6 +6,7 @@ import type { Card as CardType } from "@/lib/types";
 import { Card } from "@/features/card/Card";
 import { RARITY_META } from "@/features/card/rarity";
 import { Fireworks } from "@/features/anim/Fireworks";
+import { ErrorBanner } from "@/features/ui/ErrorBanner";
 import { useSound } from "@/features/sound/useSound";
 import { playFanfare } from "@/features/sound/sfx";
 import { claimEasterEggAction } from "./actions";
@@ -117,11 +118,7 @@ export function EasterEggPicker({
         })}
       </div>
 
-      {error ? (
-        <p data-testid="easter-egg-error" className="panel px-5 py-3 text-center text-sm text-red-300">
-          {error}
-        </p>
-      ) : null}
+      <ErrorBanner testId="easter-egg-error" message={error} />
     </div>
   );
 }

--- a/src/features/pull/EasterEggPicker.tsx
+++ b/src/features/pull/EasterEggPicker.tsx
@@ -7,7 +7,7 @@ import { Card } from "@/features/card/Card";
 import { RARITY_META } from "@/features/card/rarity";
 import { Fireworks } from "@/features/anim/Fireworks";
 import { useSound } from "@/features/sound/useSound";
-import { rewardFanfare } from "@/features/sound/sfx";
+import { playFanfare } from "@/features/sound/sfx";
 import { claimEasterEggAction } from "./actions";
 import type { PullOutcome } from "./pull-service";
 import "@/features/anim/anim.css";
@@ -60,8 +60,7 @@ export function EasterEggPicker({
     setFire((n) => n + 1);
     setPhase("revealed");
     // Inc15 FR2/FR3.3: layer the reward fanfare on the jackpot when epic/legendary.
-    const fanfare = rewardFanfare(result.card.rarity);
-    if (fanfare) play(fanfare);
+    playFanfare(play, result.card.rarity);
     onDone(result);
   }
 

--- a/src/features/pull/EasterEggPicker.tsx
+++ b/src/features/pull/EasterEggPicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Image from "next/image";
+import { CardImage } from "@/features/card/CardImage";
 import { useState } from "react";
 import type { Card as CardType } from "@/lib/types";
 import { Card } from "@/features/card/Card";
@@ -111,13 +111,7 @@ export function EasterEggPicker({
                   ➕ ×{owned}
                 </span>
               )}
-              <Image
-                src={c.imageUrl}
-                alt={c.name}
-                width={200}
-                height={200}
-                className="aspect-square w-full object-cover"
-              />
+              <CardImage src={c.imageUrl} alt={c.name} dim={200} />
             </button>
           );
         })}

--- a/src/features/pull/PullButton.tsx
+++ b/src/features/pull/PullButton.tsx
@@ -12,9 +12,9 @@ import { useSound } from "@/features/sound/useSound";
 import { CountUp } from "@/features/anim/CountUp";
 import { shouldShowAskParent } from "./ticket-display";
 import { RARITY_META } from "@/features/card/rarity";
-import { RARITIES, type EggTicket, type Rarity } from "@/lib/types";
+import { RARITIES, zeroRarityCount, type EggTicket, type Rarity } from "@/lib/types";
 
-const ZERO_PICKS: Record<Rarity, number> = { common: 0, rare: 0, epic: 0, legendary: 0 };
+const ZERO_PICKS: Record<Rarity, number> = zeroRarityCount();
 
 // Special egg tickets share one button shape, differing only in emoji/label (FR4).
 const SPECIAL_TICKETS: { kind: EggTicket; emoji: string; label: string }[] = [

--- a/src/features/pull/PullButton.tsx
+++ b/src/features/pull/PullButton.tsx
@@ -74,64 +74,43 @@ export function PullButton({
     }
   }, [balance, play]);
 
-  function doPull() {
+  // Shared launch flow for every pull kind (normal, special ticket, rarity pick):
+  // sound cues, reset the picker, pin which ticket is redeeming, then dispatch.
+  // On success a normal card pull kicks off the slot-machine build-up (Inc7 FR1);
+  // any easter-egg outcome plays the picker-appear cue instead (Inc15 FR3).
+  function runPull(
+    action: () => Promise<PullOutcome>,
+    redeeming: { ticket: EggTicket | null; pick: Rarity | null },
+  ) {
     play("click");
     play("packOpen");
     setOutcome(null);
-    activeTicket.current = null;
-    activePick.current = null;
+    activeTicket.current = redeeming.ticket;
+    activePick.current = redeeming.pick;
     startTransition(async () => {
-      const res = await pullAction(themeId || undefined);
+      const res = await action();
       setOutcome(res);
       if (res.outOfTokens) {
         play("denied");
-      } else {
-        setBalance(res.newBalance);
-        if (res.easterEgg) {
-          play("easterEgg"); // Inc15 FR3: picker-appear cue
-        } else {
-          // Normal pull: slot-machine build-up before the reveal (Inc7 FR1).
-          setCycling(true);
-        }
+        return;
       }
+      setBalance(res.newBalance);
+      if (res.easterEgg) play("easterEgg");
+      else setCycling(true);
     });
   }
 
+  function doPull() {
+    runPull(() => pullAction(themeId || undefined), { ticket: null, pick: null });
+  }
+
   function doSpecialEgg(kind: EggTicket) {
-    play("click");
-    play("packOpen");
-    setOutcome(null);
-    activeTicket.current = kind;
-    activePick.current = null;
-    startTransition(async () => {
-      const res = await pullSpecialEggAction(kind);
-      setOutcome(res);
-      if (res.outOfTokens) {
-        play("denied");
-      } else {
-        setBalance(res.newBalance);
-        play("easterEgg"); // Inc15 FR3: special-ticket picker-appear cue
-      }
-    });
+    runPull(() => pullSpecialEggAction(kind), { ticket: kind, pick: null });
   }
 
   // Inc16 FR2: redeem a rarity-pick ticket → pick-1-of-5 of that rarity.
   function doRarityPick(rarity: Rarity) {
-    play("click");
-    play("packOpen");
-    setOutcome(null);
-    activeTicket.current = null;
-    activePick.current = rarity;
-    startTransition(async () => {
-      const res = await pullRarityPickAction(rarity);
-      setOutcome(res);
-      if (res.outOfTokens) {
-        play("denied");
-      } else {
-        setBalance(res.newBalance);
-        play("easterEgg");
-      }
-    });
+    runPull(() => pullRarityPickAction(rarity), { ticket: null, pick: rarity });
   }
 
   // On a successful egg claim, decrement the ticket that was spent (FR4/Inc16).

--- a/src/features/pull/PullButton.tsx
+++ b/src/features/pull/PullButton.tsx
@@ -16,6 +16,12 @@ import { RARITIES, type EggTicket, type Rarity } from "@/lib/types";
 
 const ZERO_PICKS: Record<Rarity, number> = { common: 0, rare: 0, epic: 0, legendary: 0 };
 
+// Special egg tickets share one button shape, differing only in emoji/label (FR4).
+const SPECIAL_TICKETS: { kind: EggTicket; emoji: string; label: string }[] = [
+  { kind: "epic", emoji: "✨", label: "Epic" },
+  { kind: "lucky", emoji: "🍀", label: "Lucky" },
+];
+
 export function PullButton({
   childId,
   initialBalance,
@@ -53,6 +59,7 @@ export function PullButton({
   // but greyed so they know a normal ticket is needed for it (B2=B).
   const askParent = shouldShowAskParent(balance, epic, lucky);
   const hasSpecial = epic > 0 || lucky > 0;
+  const specialCounts: Record<EggTicket, number> = { epic, lucky };
 
   // First-duplicate sacrifice hint (Inc13 FR4). Fire once the reveal is on
   // screen (after any roulette) for a normal-pull duplicate the child hasn't
@@ -191,28 +198,18 @@ export function PullButton({
       {/* Special egg tickets — guaranteed pick-1-of-5 (FR4). */}
       {epic > 0 || lucky > 0 ? (
         <div className="flex flex-wrap justify-center gap-3" data-testid="special-tickets">
-          {epic > 0 ? (
+          {SPECIAL_TICKETS.filter((t) => specialCounts[t.kind] > 0).map((t) => (
             <button
+              key={t.kind}
               type="button"
-              onClick={() => doSpecialEgg("epic")}
+              onClick={() => doSpecialEgg(t.kind)}
               disabled={pending}
-              data-testid="special-epic-button"
+              data-testid={`special-${t.kind}-button`}
               className="btn btn--primary press font-bold"
             >
-              ✨ Epic Pick ({epic})
+              {t.emoji} {t.label} Pick ({specialCounts[t.kind]})
             </button>
-          ) : null}
-          {lucky > 0 ? (
-            <button
-              type="button"
-              onClick={() => doSpecialEgg("lucky")}
-              disabled={pending}
-              data-testid="special-lucky-button"
-              className="btn btn--primary press font-bold"
-            >
-              🍀 Lucky Pick ({lucky})
-            </button>
-          ) : null}
+          ))}
         </div>
       ) : null}
 

--- a/src/features/pull/SacrificeHintModal.tsx
+++ b/src/features/pull/SacrificeHintModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { CenteredModal } from "@/features/ui/CenteredModal";
 
 /**
  * First-duplicate easter-egg hint (Inc13 FR4). Kid-friendly one-time modal that
@@ -19,41 +20,33 @@ export function SacrificeHintModal({
   if (!open) return null;
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="sacrifice-hint-title"
-      data-testid="sacrifice-hint-modal"
-    >
-      <div className="panel flex max-w-sm flex-col items-center gap-4 p-6 text-center">
-        <span className="pill pill--gold text-base">✨ Secret trick! ✨</span>
-        <h2 id="sacrifice-hint-title" className="text-xl font-bold">
-          You got a double!
-        </h2>
-        <p className="text-[color:var(--ink)]">
-          Snap! You already have this card. Got doubles? You can trade them in to
-          power up and win a rarer card! ✨
-        </p>
-        <div className="flex flex-wrap justify-center gap-3">
-          <Link
-            href={`/play/binder/${cardId}`}
-            onClick={onClose}
-            data-testid="sacrifice-hint-show-me"
-            className="btn btn--primary press font-bold"
-          >
-            Show me!
-          </Link>
-          <button
-            type="button"
-            onClick={onClose}
-            data-testid="sacrifice-hint-dismiss"
-            className="btn btn--ghost"
-          >
-            Got it
-          </button>
-        </div>
+    <CenteredModal testId="sacrifice-hint-modal" labelledBy="sacrifice-hint-title">
+      <span className="pill pill--gold text-base">✨ Secret trick! ✨</span>
+      <h2 id="sacrifice-hint-title" className="text-xl font-bold">
+        You got a double!
+      </h2>
+      <p className="text-[color:var(--ink)]">
+        Snap! You already have this card. Got doubles? You can trade them in to
+        power up and win a rarer card! ✨
+      </p>
+      <div className="flex flex-wrap justify-center gap-3">
+        <Link
+          href={`/play/binder/${cardId}`}
+          onClick={onClose}
+          data-testid="sacrifice-hint-show-me"
+          className="btn btn--primary press font-bold"
+        >
+          Show me!
+        </Link>
+        <button
+          type="button"
+          onClick={onClose}
+          data-testid="sacrifice-hint-dismiss"
+          className="btn btn--ghost"
+        >
+          Got it
+        </button>
       </div>
-    </div>
+    </CenteredModal>
   );
 }

--- a/src/features/pull/SacrificePanel.tsx
+++ b/src/features/pull/SacrificePanel.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from "react";
 import Link from "next/link";
 import { RARITY_LABEL } from "@/features/card/rarity";
 import { useSound } from "@/features/sound/useSound";
-import { playFanfare } from "@/features/sound/sfx";
+import { playReward } from "@/features/sound/sfx";
 import { ErrorBanner } from "@/features/ui/ErrorBanner";
 import { sacrificeAction } from "./actions";
 
@@ -33,9 +33,8 @@ export function SacrificePanel({
       try {
         const res = await sacrificeAction(cardId);
         setResult({ ticketRarity: res.ticketRarity });
-        play("setComplete");
-        // Inc15/16: fanfare for an epic/legendary pick ticket earned.
-        playFanfare(play, res.ticketRarity);
+        // Inc15/16: set-complete cue + fanfare for an epic/legendary pick ticket.
+        playReward(play, res.ticketRarity);
       } catch {
         setError("Couldn't sacrifice — you need at least 3 copies.");
         play("denied");

--- a/src/features/pull/SacrificePanel.tsx
+++ b/src/features/pull/SacrificePanel.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { RARITY_LABEL } from "@/features/card/rarity";
 import { useSound } from "@/features/sound/useSound";
 import { playFanfare } from "@/features/sound/sfx";
+import { ErrorBanner } from "@/features/ui/ErrorBanner";
 import { sacrificeAction } from "./actions";
 
 /**
@@ -75,11 +76,11 @@ export function SacrificePanel({
       <p className="text-xs text-[color:var(--ink-mute)]">
         Burns 3 copies for a random card of the same or higher tier.
       </p>
-      {error ? (
-        <p data-testid="sacrifice-error" className="text-sm text-red-300">
-          {error}
-        </p>
-      ) : null}
+      <ErrorBanner
+        testId="sacrifice-error"
+        message={error}
+        className="text-sm text-red-300"
+      />
     </div>
   );
 }

--- a/src/features/pull/SacrificePanel.tsx
+++ b/src/features/pull/SacrificePanel.tsx
@@ -4,7 +4,7 @@ import { useState, useTransition } from "react";
 import Link from "next/link";
 import { RARITY_LABEL } from "@/features/card/rarity";
 import { useSound } from "@/features/sound/useSound";
-import { rewardFanfare } from "@/features/sound/sfx";
+import { playFanfare } from "@/features/sound/sfx";
 import { sacrificeAction } from "./actions";
 
 /**
@@ -34,8 +34,7 @@ export function SacrificePanel({
         setResult({ ticketRarity: res.ticketRarity });
         play("setComplete");
         // Inc15/16: fanfare for an epic/legendary pick ticket earned.
-        const fanfare = rewardFanfare(res.ticketRarity);
-        if (fanfare) play(fanfare);
+        playFanfare(play, res.ticketRarity);
       } catch {
         setError("Couldn't sacrifice — you need at least 3 copies.");
         play("denied");

--- a/src/features/pull/actions.ts
+++ b/src/features/pull/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { requireParent } from "@/features/auth/guard";
-import { getActiveChild } from "@/features/profiles/active-profile";
+import { requireActiveChild } from "@/features/profiles/active-profile";
 import {
   pull,
   pullSpecialEgg,
@@ -15,38 +15,54 @@ import {
 import { grant, grantSpecial, grantPickTicket } from "./token-service";
 import type { EggTicket, Rarity } from "@/lib/types";
 
-/** Pull for the current active child (C1). Optional category (Inc8 FR3). */
-export async function pullAction(themeId?: string): Promise<PullOutcome> {
-  const child = await getActiveChild();
-  if (!child) throw new Error("No active profile");
-  const outcome = await pull(child.id, themeId);
+/**
+ * Run a pull-family action for the active child and revalidate the pull +
+ * binder views. Shared body of the four pull/claim entry points.
+ */
+async function activePull<T>(run: (childId: string) => Promise<T>): Promise<T> {
+  const child = await requireActiveChild();
+  const result = await run(child.id);
   revalidatePath("/play/pull");
   revalidatePath("/play/binder");
-  return outcome;
+  return result;
+}
+
+/**
+ * Parent-gated grant of `amount` (validated as a nonzero integer) via `run`,
+ * revalidating the given admin path plus the pull view. Shared body of the
+ * three grant entry points.
+ */
+async function parentGrant(
+  amount: number,
+  adminPath: string,
+  run: (n: number) => Promise<number>,
+): Promise<number> {
+  await requireParent();
+  const n = Math.trunc(Number(amount));
+  if (!Number.isFinite(n) || n === 0) throw new Error("Invalid grant amount");
+  const balance = await run(n);
+  revalidatePath(adminPath);
+  revalidatePath("/play/pull");
+  return balance;
+}
+
+/** Pull for the current active child (C1). Optional category (Inc8 FR3). */
+export async function pullAction(themeId?: string): Promise<PullOutcome> {
+  return activePull((childId) => pull(childId, themeId));
 }
 
 /** Spend a special egg ticket for a guaranteed pick-1-of-5 (Inc9 FR4). */
 export async function pullSpecialEggAction(
   kind: EggTicket,
 ): Promise<PullOutcome> {
-  const child = await getActiveChild();
-  if (!child) throw new Error("No active profile");
-  const outcome = await pullSpecialEgg(child.id, kind);
-  revalidatePath("/play/pull");
-  revalidatePath("/play/binder");
-  return outcome;
+  return activePull((childId) => pullSpecialEgg(childId, kind));
 }
 
 /** Redeem a rarity-pick ticket for a pick-1-of-5 of that rarity (Inc16 FR2). */
 export async function pullRarityPickAction(
   rarity: Rarity,
 ): Promise<PullOutcome> {
-  const child = await getActiveChild();
-  if (!child) throw new Error("No active profile");
-  const outcome = await pullRarityPick(child.id, rarity);
-  revalidatePath("/play/pull");
-  revalidatePath("/play/binder");
-  return outcome;
+  return activePull((childId) => pullRarityPick(childId, rarity));
 }
 
 /** Claim the picked card from an easter-egg offer (U6-FR2). */
@@ -54,20 +70,14 @@ export async function claimEasterEggAction(
   offer: string,
   chosenCardId: string,
 ): Promise<PullOutcome> {
-  const child = await getActiveChild();
-  if (!child) throw new Error("No active profile");
-  const outcome = await claimEasterEgg(child.id, offer, chosenCardId);
-  revalidatePath("/play/pull");
-  revalidatePath("/play/binder");
-  return outcome;
+  return activePull((childId) => claimEasterEgg(childId, offer, chosenCardId));
 }
 
 /** Sacrifice 3 copies of a card for a rarity-pick ticket (Inc16 FR1). */
 export async function sacrificeAction(
   cardId: string,
 ): Promise<SacrificeResult> {
-  const child = await getActiveChild();
-  if (!child) throw new Error("No active profile");
+  const child = await requireActiveChild();
   const result = await sacrifice(child.id, cardId);
   revalidatePath("/play/binder");
   revalidatePath(`/play/binder/${cardId}`);
@@ -80,13 +90,7 @@ export async function grantTokensAction(
   childId: string,
   amount: number,
 ): Promise<number> {
-  await requireParent();
-  const n = Math.trunc(Number(amount));
-  if (!Number.isFinite(n) || n === 0) throw new Error("Invalid grant amount");
-  const balance = await grant(childId, n);
-  revalidatePath("/admin/profiles");
-  revalidatePath("/play/pull");
-  return balance;
+  return parentGrant(amount, "/admin/profiles", (n) => grant(childId, n));
 }
 
 /** Parent grants a special egg ticket to a child (Inc9 FR4). */
@@ -95,13 +99,7 @@ export async function grantSpecialTicketAction(
   kind: EggTicket,
   amount: number,
 ): Promise<number> {
-  await requireParent();
-  const n = Math.trunc(Number(amount));
-  if (!Number.isFinite(n) || n === 0) throw new Error("Invalid grant amount");
-  const balance = await grantSpecial(childId, kind, n);
-  revalidatePath("/admin");
-  revalidatePath("/play/pull");
-  return balance;
+  return parentGrant(amount, "/admin", (n) => grantSpecial(childId, kind, n));
 }
 
 /** Parent grants a rarity-pick ticket to a child (Inc16 FR3). */
@@ -110,11 +108,5 @@ export async function grantRarityPickTicketAction(
   rarity: Rarity,
   amount: number,
 ): Promise<number> {
-  await requireParent();
-  const n = Math.trunc(Number(amount));
-  if (!Number.isFinite(n) || n === 0) throw new Error("Invalid grant amount");
-  const count = await grantPickTicket(childId, rarity, n);
-  revalidatePath("/admin");
-  revalidatePath("/play/pull");
-  return count;
+  return parentGrant(amount, "/admin", (n) => grantPickTicket(childId, rarity, n));
 }

--- a/src/features/pull/easter-egg.ts
+++ b/src/features/pull/easter-egg.ts
@@ -1,5 +1,6 @@
 import type { Card, Rarity } from "@/lib/types";
 import type { Rng } from "@/lib/logic";
+import { sample } from "@/lib/rng";
 
 /**
  * Easter-egg logic (U6-FR2). PURE — server-side trigger + choice selection,
@@ -25,12 +26,7 @@ function pickChoicesByTier(
   rng: Rng,
 ): Card[] {
   const eligible = pool.filter((c) => tiers.includes(c.rarity));
-  // Fisher–Yates on a copy.
-  for (let i = eligible.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
-    [eligible[i], eligible[j]] = [eligible[j], eligible[i]];
-  }
-  return eligible.slice(0, Math.min(n, eligible.length));
+  return sample(eligible, n, rng);
 }
 
 /**

--- a/src/features/pull/offer.ts
+++ b/src/features/pull/offer.ts
@@ -1,11 +1,16 @@
 /**
- * Signed easter-egg offer (U6-FR2, Security). PURE + isomorphic (Web Crypto):
- * proves the server rolled the egg and pins the exact 5 candidate cards, so the
- * claim can't be swapped for an un-offered card. Carries no secret — just an
- * HMAC over the payload. `secret` + `nowMs` are injected (kept pure/testable).
+ * Signed easter-egg offer (U6-FR2, Security). Proves the server rolled the egg
+ * and pins the exact 5 candidate cards, so the claim can't be swapped for an
+ * un-offered card. Thin wrapper over the shared HMAC token in lib/signed-token.
  */
 
-export interface OfferPayload {
+import {
+  signToken,
+  verifyToken,
+  type SignedPayload,
+} from "@/lib/signed-token";
+
+export interface OfferPayload extends SignedPayload {
   childId: string;
   cardIds: string[];
   exp: number; // epoch ms
@@ -15,84 +20,25 @@ export interface OfferPayload {
   pickRarity?: "common" | "rare" | "epic" | "legendary";
 }
 
-function b64urlEncode(bytes: Uint8Array): string {
-  let bin = "";
-  for (const b of bytes) bin += String.fromCharCode(b);
-  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-function b64urlDecode(s: string): Uint8Array {
-  const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
-  const bin = atob(s.replace(/-/g, "+").replace(/_/g, "/") + pad);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
-}
-
-async function hmac(payload: string, secret: string): Promise<Uint8Array> {
-  const key = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
+function isOfferPayload(p: unknown): p is OfferPayload {
+  const o = p as OfferPayload;
+  return (
+    typeof o?.childId === "string" &&
+    Array.isArray(o.cardIds) &&
+    typeof o.exp === "number"
   );
-  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload));
-  return new Uint8Array(sig);
-}
-
-function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
-  return diff === 0;
 }
 
 /** Sign an offer → `base64url(json).base64url(hmac)`. */
-export async function makeOffer(
-  payload: OfferPayload,
-  secret: string,
-): Promise<string> {
-  const json = JSON.stringify(payload);
-  const encoded = b64urlEncode(new TextEncoder().encode(json));
-  const sig = await hmac(json, secret);
-  return `${encoded}.${b64urlEncode(sig)}`;
+export function makeOffer(payload: OfferPayload, secret: string): Promise<string> {
+  return signToken(payload, secret);
 }
 
 /** Return the payload iff the signature is valid AND not expired, else null. */
-export async function verifyOffer(
+export function verifyOffer(
   token: string | undefined | null,
   secret: string,
   nowMs: number,
 ): Promise<OfferPayload | null> {
-  if (!token || !secret) return null;
-  const dot = token.indexOf(".");
-  if (dot <= 0) return null;
-
-  let json: string;
-  let providedSig: Uint8Array;
-  try {
-    json = new TextDecoder().decode(b64urlDecode(token.slice(0, dot)));
-    providedSig = b64urlDecode(token.slice(dot + 1));
-  } catch {
-    return null;
-  }
-
-  const expected = await hmac(json, secret);
-  if (!timingSafeEqual(expected, providedSig)) return null;
-
-  let payload: OfferPayload;
-  try {
-    payload = JSON.parse(json) as OfferPayload;
-  } catch {
-    return null;
-  }
-  if (
-    typeof payload?.childId !== "string" ||
-    !Array.isArray(payload.cardIds) ||
-    typeof payload.exp !== "number"
-  ) {
-    return null;
-  }
-  return payload.exp > nowMs ? payload : null;
+  return verifyToken(token, secret, nowMs, isOfferPayload);
 }

--- a/src/features/pull/pick-tickets.ts
+++ b/src/features/pull/pick-tickets.ts
@@ -24,6 +24,18 @@ export function pickTicketColumn(rarity: Rarity): keyof PickTicketRow {
   return COLUMN[rarity];
 }
 
+/**
+ * Children columns that hold a grantable/spendable integer balance: a normal
+ * pull token, either special egg ticket, or one of the four rarity-pick tickets.
+ * Shared by token-service (grant) and pull-service (spend), which drive atomic
+ * per-column updates off the string key.
+ */
+export type BalanceColumn =
+  | "pullTokens"
+  | "epicTickets"
+  | "luckyTickets"
+  | keyof PickTicketRow;
+
 /** Build the `Record<Rarity, number>` view from a children row. */
 export function pickTicketsFromRow(row: PickTicketRow): Record<Rarity, number> {
   return {

--- a/src/features/pull/pick-tickets.ts
+++ b/src/features/pull/pick-tickets.ts
@@ -1,4 +1,4 @@
-import { RARITIES, type Rarity } from "@/lib/types";
+import { RARITIES, type EggTicket, type Rarity } from "@/lib/types";
 
 /**
  * Rarity-pick ticket helpers (Inc16 FR2). Maps the four per-rarity columns to a
@@ -22,6 +22,11 @@ const COLUMN: Record<Rarity, keyof PickTicketRow> = {
 /** Drizzle column key for a rarity's pick-ticket counter. */
 export function pickTicketColumn(rarity: Rarity): keyof PickTicketRow {
   return COLUMN[rarity];
+}
+
+/** Drizzle column key for a special egg ticket's counter (Inc9 FR4). */
+export function specialTicketColumn(kind: EggTicket): BalanceColumn {
+  return kind === "epic" ? "epicTickets" : "luckyTickets";
 }
 
 /**

--- a/src/features/pull/pull-service.ts
+++ b/src/features/pull/pull-service.ts
@@ -12,7 +12,7 @@ import {
 } from "./easter-egg";
 import { rollUpgradeTier, SACRIFICE_COST } from "./sacrifice";
 import { pickTicketColumn } from "./pick-tickets";
-import { makeOffer, verifyOffer } from "./offer";
+import { makeOffer, verifyOffer, type OfferPayload } from "./offer";
 import { grantCompletionRewards } from "@/features/rewards/service";
 import { requireParent } from "@/features/auth/guard";
 import type { Card, PullResult, Rarity, EggTicket } from "@/lib/types";
@@ -162,6 +162,38 @@ export async function pull(
 }
 
 /**
+ * Shared tail for ticket-gated eggs (special epic/lucky + rarity-pick): the
+ * ticket is NOT spent here — spent atomically at claim (single-use), and the
+ * offer pins the ticket via `offerExtra`. Builds the signed offer over the given
+ * choices, annotates owned counts, and returns the current (unchanged) normal
+ * token balance.
+ */
+async function makeTicketEggOutcome(
+  childId: string,
+  choices: Card[],
+  offerExtra: Partial<OfferPayload>,
+): Promise<EasterEggOutcome> {
+  const cardIds = choices.map((c) => c.id);
+  const offer = await makeOffer(
+    { childId, cardIds, exp: Date.now() + OFFER_TTL_MS, ...offerExtra },
+    authSecret(),
+  );
+  const ownedCounts = await ownedCountsFor(childId, cardIds);
+  const balRow = await db.query.children.findFirst({
+    where: eq(children.id, childId),
+    columns: { pullTokens: true },
+  });
+  return {
+    outOfTokens: false,
+    easterEgg: true,
+    choices,
+    ownedCounts,
+    offer,
+    newBalance: balRow?.pullTokens ?? 0,
+  };
+}
+
+/**
  * Guaranteed easter egg via a special ticket (Inc9 FR4). Offers the pick-1-of-5
  * for the ticket's tier from the FULL pool. The special ticket is NOT spent here
  * — it's spent atomically at claim (single-use), and the offer pins the kind.
@@ -184,30 +216,7 @@ export async function pullSpecialEgg(
       : pickCommonRareChoices(pool, 5);
   if (choices.length === 0) throw new Error("pullSpecialEgg: no eligible cards");
 
-  const offer = await makeOffer(
-    {
-      childId,
-      cardIds: choices.map((c) => c.id),
-      exp: Date.now() + OFFER_TTL_MS,
-      ticket: kind,
-    },
-    authSecret(),
-  );
-
-  const ownedCounts = await ownedCountsFor(childId, choices.map((c) => c.id));
-  // Special egg costs no normal token; balance unchanged until claim.
-  const balRow = await db.query.children.findFirst({
-    where: eq(children.id, childId),
-    columns: { pullTokens: true },
-  });
-  return {
-    outOfTokens: false,
-    easterEgg: true,
-    choices,
-    ownedCounts,
-    offer,
-    newBalance: balRow?.pullTokens ?? 0,
-  };
+  return makeTicketEggOutcome(childId, choices, { ticket: kind });
 }
 
 /**
@@ -230,29 +239,7 @@ export async function pullRarityPick(
   const choices = pickRarityChoices(pool, rarity, 5);
   if (choices.length === 0) throw new Error("pullRarityPick: no eligible cards");
 
-  const offer = await makeOffer(
-    {
-      childId,
-      cardIds: choices.map((c) => c.id),
-      exp: Date.now() + OFFER_TTL_MS,
-      pickRarity: rarity,
-    },
-    authSecret(),
-  );
-
-  const ownedCounts = await ownedCountsFor(childId, choices.map((c) => c.id));
-  const balRow = await db.query.children.findFirst({
-    where: eq(children.id, childId),
-    columns: { pullTokens: true },
-  });
-  return {
-    outOfTokens: false,
-    easterEgg: true,
-    choices,
-    ownedCounts,
-    offer,
-    newBalance: balRow?.pullTokens ?? 0,
-  };
+  return makeTicketEggOutcome(childId, choices, { pickRarity: rarity });
 }
 
 /**
@@ -295,11 +282,11 @@ export async function claimEasterEgg(
     newBalance = spent[0].pullTokens; // normal balance unchanged
   } else if (payload.ticket) {
     // Special egg: spend the pinned special ticket, not a normal token.
-    const col =
-      payload.ticket === "epic" ? children.epicTickets : children.luckyTickets;
+    const key = payload.ticket === "epic" ? "epicTickets" : "luckyTickets";
+    const col = children[key];
     const spent = await db
       .update(children)
-      .set({ [payload.ticket === "epic" ? "epicTickets" : "luckyTickets"]: sql`${col} - 1` })
+      .set({ [key]: sql`${col} - 1` })
       .where(and(eq(children.id, childId), gte(col, 1)))
       .returning({ pullTokens: children.pullTokens });
     if (spent.length === 0) return { outOfTokens: true };

--- a/src/features/pull/pull-service.ts
+++ b/src/features/pull/pull-service.ts
@@ -15,6 +15,7 @@ import {
 } from "./easter-egg";
 import { rollUpgradeTier, SACRIFICE_COST } from "./sacrifice";
 import { pickTicketColumn, specialTicketColumn, type BalanceColumn } from "./pick-tickets";
+import { getBalance } from "./token-service";
 import { makeOffer, verifyOffer, type OfferPayload } from "./offer";
 import { grantCompletionRewards } from "@/features/rewards/service";
 import { requireParent } from "@/features/auth/guard";
@@ -197,11 +198,7 @@ async function makeTicketEggOutcome(
   choices: Card[],
   offerExtra: Partial<OfferPayload>,
 ): Promise<EasterEggOutcome> {
-  const balRow = await db.query.children.findFirst({
-    where: eq(children.id, childId),
-    columns: { pullTokens: true },
-  });
-  return eggOutcome(childId, choices, balRow?.pullTokens ?? 0, offerExtra);
+  return eggOutcome(childId, choices, await getBalance(childId), offerExtra);
 }
 
 /**

--- a/src/features/pull/pull-service.ts
+++ b/src/features/pull/pull-service.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { and, eq, gte, inArray, sql } from "drizzle-orm";
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import { db } from "@/db";
 import { children, collections } from "@/db/schema";
 import { drawCard } from "@/lib/logic";
@@ -194,6 +195,32 @@ async function makeTicketEggOutcome(
 }
 
 /**
+ * Shared body for the ticket-gated egg entry points: guard on the ticket
+ * column (>= 1 held), draw the pick-1-of-5 from the FULL pool, and hand off to
+ * makeTicketEggOutcome. The ticket is NOT spent here — spent atomically at claim
+ * (single-use); `offerExtra` pins which column claim decrements. Returns
+ * out-of-tokens when no ticket is held.
+ */
+async function offerTicketEgg(
+  childId: string,
+  col: AnyPgColumn,
+  offerExtra: Partial<OfferPayload>,
+  chooseFrom: (pool: Card[]) => Card[],
+  label: string,
+): Promise<PullOutcome> {
+  const [row] = await db
+    .select({ n: col })
+    .from(children)
+    .where(eq(children.id, childId));
+  if (!row || row.n < 1) return { outOfTokens: true };
+
+  const choices = chooseFrom(await listCards());
+  if (choices.length === 0) throw new Error(`${label}: no eligible cards`);
+
+  return makeTicketEggOutcome(childId, choices, offerExtra);
+}
+
+/**
  * Guaranteed easter egg via a special ticket (Inc9 FR4). Offers the pick-1-of-5
  * for the ticket's tier from the FULL pool. The special ticket is NOT spent here
  * — it's spent atomically at claim (single-use), and the offer pins the kind.
@@ -203,20 +230,9 @@ export async function pullSpecialEgg(
   kind: EggTicket,
 ): Promise<PullOutcome> {
   const col = kind === "epic" ? children.epicTickets : children.luckyTickets;
-  const [row] = await db
-    .select({ n: col })
-    .from(children)
-    .where(eq(children.id, childId));
-  if (!row || row.n < 1) return { outOfTokens: true };
-
-  const pool = await listCards();
-  const choices =
-    kind === "epic"
-      ? pickEasterEggChoices(pool, 5)
-      : pickCommonRareChoices(pool, 5);
-  if (choices.length === 0) throw new Error("pullSpecialEgg: no eligible cards");
-
-  return makeTicketEggOutcome(childId, choices, { ticket: kind });
+  const chooseFrom = (pool: Card[]) =>
+    kind === "epic" ? pickEasterEggChoices(pool, 5) : pickCommonRareChoices(pool, 5);
+  return offerTicketEgg(childId, col, { ticket: kind }, chooseFrom, "pullSpecialEgg");
 }
 
 /**
@@ -229,17 +245,8 @@ export async function pullRarityPick(
   rarity: Rarity,
 ): Promise<PullOutcome> {
   const col = children[pickTicketColumn(rarity)];
-  const [row] = await db
-    .select({ n: col })
-    .from(children)
-    .where(eq(children.id, childId));
-  if (!row || row.n < 1) return { outOfTokens: true };
-
-  const pool = await listCards();
-  const choices = pickRarityChoices(pool, rarity, 5);
-  if (choices.length === 0) throw new Error("pullRarityPick: no eligible cards");
-
-  return makeTicketEggOutcome(childId, choices, { pickRarity: rarity });
+  const chooseFrom = (pool: Card[]) => pickRarityChoices(pool, rarity, 5);
+  return offerTicketEgg(childId, col, { pickRarity: rarity }, chooseFrom, "pullRarityPick");
 }
 
 /**

--- a/src/features/pull/pull-service.ts
+++ b/src/features/pull/pull-service.ts
@@ -13,7 +13,7 @@ import {
   pickRarityChoices,
 } from "./easter-egg";
 import { rollUpgradeTier, SACRIFICE_COST } from "./sacrifice";
-import { pickTicketColumn } from "./pick-tickets";
+import { pickTicketColumn, type BalanceColumn } from "./pick-tickets";
 import { makeOffer, verifyOffer, type OfferPayload } from "./offer";
 import { grantCompletionRewards } from "@/features/rewards/service";
 import { requireParent } from "@/features/auth/guard";
@@ -286,7 +286,7 @@ export async function claimEasterEgg(
   // Atomic spend — one column (rarity-pick, special ticket, or normal token).
   // The pinned offer field picks which; missing both spends a normal token.
   // Single-use: the guarded decrement makes the signed offer un-replayable.
-  const key: SpendableColumn = payload.pickRarity
+  const key: BalanceColumn = payload.pickRarity
     ? pickTicketColumn(payload.pickRarity)
     : payload.ticket
       ? payload.ticket === "epic"
@@ -299,16 +299,6 @@ export async function claimEasterEgg(
   return grantCardOutcome(childId, card, newBalance);
 }
 
-/** Children columns that hold a spendable balance (normal token or a ticket). */
-type SpendableColumn =
-  | "pullTokens"
-  | "epicTickets"
-  | "luckyTickets"
-  | "commonPickTickets"
-  | "rarePickTickets"
-  | "epicPickTickets"
-  | "legendaryPickTickets";
-
 /**
  * Atomic guarded decrement of one spendable column (single-use claim). Returns
  * the child's resulting normal token balance, or null if nothing was spent
@@ -317,7 +307,7 @@ type SpendableColumn =
  */
 async function spendOneColumn(
   childId: string,
-  key: SpendableColumn,
+  key: BalanceColumn,
 ): Promise<number | null> {
   const col = children[key];
   const spent = await db

--- a/src/features/pull/pull-service.ts
+++ b/src/features/pull/pull-service.ts
@@ -58,6 +58,34 @@ function authSecret(): string {
 }
 
 /**
+ * Assemble a pick-1-of-N easter-egg outcome: sign the offer (pure crypto,
+ * always FIRST so a caller's later side-effect can't double-fire on failure),
+ * annotate owned counts, and return with the given normal-token balance.
+ * `offerExtra` pins the claim column (special/rarity ticket) when present.
+ */
+async function eggOutcome(
+  childId: string,
+  choices: Card[],
+  newBalance: number,
+  offerExtra: Partial<OfferPayload> = {},
+): Promise<EasterEggOutcome> {
+  const cardIds = choices.map((c) => c.id);
+  const offer = await makeOffer(
+    { childId, cardIds, exp: Date.now() + OFFER_TTL_MS, ...offerExtra },
+    authSecret(),
+  );
+  const ownedCounts = await ownedCountsFor(childId, cardIds);
+  return {
+    outOfTokens: false,
+    easterEgg: true,
+    choices,
+    ownedCounts,
+    offer,
+    newBalance,
+  };
+}
+
+/**
  * Build a signed pick-1-of-N easter-egg offer, refund the token (re-spent on
  * claim), and return the outcome. Sign FIRST (pure crypto) so a failure can't
  * double-refund. Shared by both eggs (epic+ and common/rare).
@@ -67,27 +95,12 @@ async function makeEggOutcome(
   choices: Card[],
   newBalance: number,
 ): Promise<EasterEggOutcome> {
-  const offer = await makeOffer(
-    {
-      childId,
-      cardIds: choices.map((c) => c.id),
-      exp: Date.now() + OFFER_TTL_MS,
-    },
-    authSecret(),
-  );
-  const ownedCounts = await ownedCountsFor(childId, choices.map((c) => c.id));
+  const outcome = await eggOutcome(childId, choices, newBalance + 1);
   await db
     .update(children)
     .set({ pullTokens: sql`${children.pullTokens} + 1` })
     .where(eq(children.id, childId));
-  return {
-    outOfTokens: false,
-    easterEgg: true,
-    choices,
-    ownedCounts,
-    offer,
-    newBalance: newBalance + 1,
-  };
+  return outcome;
 }
 
 /**
@@ -183,24 +196,11 @@ async function makeTicketEggOutcome(
   choices: Card[],
   offerExtra: Partial<OfferPayload>,
 ): Promise<EasterEggOutcome> {
-  const cardIds = choices.map((c) => c.id);
-  const offer = await makeOffer(
-    { childId, cardIds, exp: Date.now() + OFFER_TTL_MS, ...offerExtra },
-    authSecret(),
-  );
-  const ownedCounts = await ownedCountsFor(childId, cardIds);
   const balRow = await db.query.children.findFirst({
     where: eq(children.id, childId),
     columns: { pullTokens: true },
   });
-  return {
-    outOfTokens: false,
-    easterEgg: true,
-    choices,
-    ownedCounts,
-    offer,
-    newBalance: balRow?.pullTokens ?? 0,
-  };
+  return eggOutcome(childId, choices, balRow?.pullTokens ?? 0, offerExtra);
 }
 
 /**

--- a/src/features/pull/pull-service.ts
+++ b/src/features/pull/pull-service.ts
@@ -90,6 +90,36 @@ async function makeEggOutcome(
 }
 
 /**
+ * Grant one copy of a card to the child and return the standard card outcome:
+ * atomically upsert the collection count, apply any (theme, rarity)
+ * set-completion bonus (Inc16 FR5), and return with the duplicate flag plus the
+ * given balance. Shared card-grant tail of pull() and claimEasterEgg().
+ */
+async function grantCardOutcome(
+  childId: string,
+  card: Card,
+  newBalance: number,
+): Promise<PullOutcome> {
+  const [entry] = await db
+    .insert(collections)
+    .values({ childId, cardId: card.id, count: 1 })
+    .onConflictDoUpdate({
+      target: [collections.childId, collections.cardId],
+      set: { count: sql`${collections.count} + 1` },
+    })
+    .returning({ count: collections.count });
+
+  await grantCompletionRewards(childId, [card.id]);
+
+  return {
+    outOfTokens: false,
+    card,
+    isDuplicate: entry.count > 1,
+    newBalance,
+  };
+}
+
+/**
  * Pull one card for a child. Atomic, no double-spend (U4-BR1/BR2).
  * 1) conditional spend, 2) draw, 3) upsert count, 4) refund on write failure.
  * `themeId` (Inc8 FR3) limits the normal draw to one category; eggs stay global.
@@ -129,25 +159,8 @@ export async function pull(
     const drawPool = themeId ? pool.filter((c) => c.themeId === themeId) : pool;
     const card = drawCard(drawPool.length > 0 ? drawPool : pool);
 
-    // 3) Upsert collection count atomically.
-    const [entry] = await db
-      .insert(collections)
-      .values({ childId, cardId: card.id, count: 1 })
-      .onConflictDoUpdate({
-        target: [collections.childId, collections.cardId],
-        set: { count: sql`${collections.count} + 1` },
-      })
-      .returning({ count: collections.count });
-
-    // Inc16 FR5: adding this card may complete a (theme, rarity) set → bonus.
-    await grantCompletionRewards(childId, [card.id]);
-
-    return {
-      outOfTokens: false,
-      card,
-      isDuplicate: entry.count > 1,
-      newBalance,
-    };
+    // 3) Upsert collection count atomically + apply any set-completion bonus.
+    return await grantCardOutcome(childId, card, newBalance);
   } catch (err) {
     // 4) Best-effort refund (U4-BR6).
     try {
@@ -287,24 +300,7 @@ export async function claimEasterEgg(
   const newBalance = await spendOneColumn(childId, key);
   if (newBalance === null) return { outOfTokens: true };
 
-  const [entry] = await db
-    .insert(collections)
-    .values({ childId, cardId: card.id, count: 1 })
-    .onConflictDoUpdate({
-      target: [collections.childId, collections.cardId],
-      set: { count: sql`${collections.count} + 1` },
-    })
-    .returning({ count: collections.count });
-
-  // Inc16 FR5: claimed card may complete a (theme, rarity) set → bonus.
-  await grantCompletionRewards(childId, [card.id]);
-
-  return {
-    outOfTokens: false,
-    card,
-    isDuplicate: entry.count > 1,
-    newBalance,
-  };
+  return grantCardOutcome(childId, card, newBalance);
 }
 
 /** Children columns that hold a spendable balance (normal token or a ticket). */

--- a/src/features/pull/pull-service.ts
+++ b/src/features/pull/pull-service.ts
@@ -3,7 +3,7 @@ import { and, eq, gte, inArray, sql } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import { db } from "@/db";
 import { children, collections } from "@/db/schema";
-import { addCardCopy } from "@/db/collection-writes";
+import { addCardCopy, removeCardCopy } from "@/db/collection-writes";
 import { drawCard } from "@/lib/logic";
 import { listCards, getCard } from "@/features/pool/service";
 import {
@@ -350,16 +350,7 @@ export async function sacrifice(
   if (!source) throw new Error("sacrifice: card not found");
 
   // Atomic CAS: only succeeds if the child still holds enough copies.
-  const burned = await db
-    .update(collections)
-    .set({ count: sql`${collections.count} - ${SACRIFICE_COST}` })
-    .where(
-      and(
-        eq(collections.childId, childId),
-        eq(collections.cardId, cardId),
-        gte(collections.count, SACRIFICE_COST),
-      ),
-    )
+  const burned = await removeCardCopy(childId, cardId, SACRIFICE_COST, SACRIFICE_COST)
     .returning({ count: collections.count });
 
   if (burned.length === 0) {

--- a/src/features/pull/pull-service.ts
+++ b/src/features/pull/pull-service.ts
@@ -3,6 +3,7 @@ import { and, eq, gte, inArray, sql } from "drizzle-orm";
 import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import { db } from "@/db";
 import { children, collections } from "@/db/schema";
+import { addCardCopy } from "@/db/collection-writes";
 import { drawCard } from "@/lib/logic";
 import { listCards, getCard } from "@/features/pool/service";
 import {
@@ -100,14 +101,9 @@ async function grantCardOutcome(
   card: Card,
   newBalance: number,
 ): Promise<PullOutcome> {
-  const [entry] = await db
-    .insert(collections)
-    .values({ childId, cardId: card.id, count: 1 })
-    .onConflictDoUpdate({
-      target: [collections.childId, collections.cardId],
-      set: { count: sql`${collections.count} + 1` },
-    })
-    .returning({ count: collections.count });
+  const [entry] = await addCardCopy(childId, card.id).returning({
+    count: collections.count,
+  });
 
   await grantCompletionRewards(childId, [card.id]);
 

--- a/src/features/pull/pull-service.ts
+++ b/src/features/pull/pull-service.ts
@@ -13,7 +13,7 @@ import {
   pickRarityChoices,
 } from "./easter-egg";
 import { rollUpgradeTier, SACRIFICE_COST } from "./sacrifice";
-import { pickTicketColumn, type BalanceColumn } from "./pick-tickets";
+import { pickTicketColumn, specialTicketColumn, type BalanceColumn } from "./pick-tickets";
 import { makeOffer, verifyOffer, type OfferPayload } from "./offer";
 import { grantCompletionRewards } from "@/features/rewards/service";
 import { requireParent } from "@/features/auth/guard";
@@ -238,7 +238,7 @@ export async function pullSpecialEgg(
   childId: string,
   kind: EggTicket,
 ): Promise<PullOutcome> {
-  const col = kind === "epic" ? children.epicTickets : children.luckyTickets;
+  const col = children[specialTicketColumn(kind)];
   const chooseFrom = (pool: Card[]) =>
     kind === "epic" ? pickEasterEggChoices(pool, 5) : pickCommonRareChoices(pool, 5);
   return offerTicketEgg(childId, col, { ticket: kind }, chooseFrom, "pullSpecialEgg");
@@ -289,9 +289,7 @@ export async function claimEasterEgg(
   const key: BalanceColumn = payload.pickRarity
     ? pickTicketColumn(payload.pickRarity)
     : payload.ticket
-      ? payload.ticket === "epic"
-        ? "epicTickets"
-        : "luckyTickets"
+      ? specialTicketColumn(payload.ticket)
       : "pullTokens";
   const newBalance = await spendOneColumn(childId, key);
   if (newBalance === null) return { outOfTokens: true };

--- a/src/features/pull/pull-service.ts
+++ b/src/features/pull/pull-service.ts
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { children, collections } from "@/db/schema";
 import { addCardCopy, removeCardCopy } from "@/db/collection-writes";
 import { drawCard } from "@/lib/logic";
+import { env } from "@/lib/env";
 import { listCards, getCard } from "@/features/pool/service";
 import {
   rollEasterEgg,
@@ -53,9 +54,6 @@ export type PullOutcome =
   | { outOfTokens: true };
 
 const OFFER_TTL_MS = 120_000; // 2 min
-function authSecret(): string {
-  return process.env.AUTH_SECRET ?? "";
-}
 
 /** Refund one normal pull token (add 1). Shared by the egg re-spend path and
  * pull()'s best-effort write-failure refund. */
@@ -81,7 +79,7 @@ async function eggOutcome(
   const cardIds = choices.map((c) => c.id);
   const offer = await makeOffer(
     { childId, cardIds, exp: Date.now() + OFFER_TTL_MS, ...offerExtra },
-    authSecret(),
+    env.authSecret,
   );
   const ownedCounts = await ownedCountsFor(childId, cardIds);
   return {
@@ -273,7 +271,7 @@ export async function claimEasterEgg(
   offer: string,
   chosenCardId: string,
 ): Promise<PullOutcome> {
-  const payload = await verifyOffer(offer, authSecret(), Date.now());
+  const payload = await verifyOffer(offer, env.authSecret, Date.now());
   if (!payload) throw new Error("claimEasterEgg: invalid or expired offer");
   if (payload.childId !== childId) throw new Error("claimEasterEgg: child mismatch");
   if (!payload.cardIds.includes(chosenCardId)) {

--- a/src/features/pull/pull-service.ts
+++ b/src/features/pull/pull-service.ts
@@ -57,6 +57,15 @@ function authSecret(): string {
   return process.env.AUTH_SECRET ?? "";
 }
 
+/** Refund one normal pull token (add 1). Shared by the egg re-spend path and
+ * pull()'s best-effort write-failure refund. */
+function refundPullToken(childId: string) {
+  return db
+    .update(children)
+    .set({ pullTokens: sql`${children.pullTokens} + 1` })
+    .where(eq(children.id, childId));
+}
+
 /**
  * Assemble a pick-1-of-N easter-egg outcome: sign the offer (pure crypto,
  * always FIRST so a caller's later side-effect can't double-fire on failure),
@@ -96,10 +105,7 @@ async function makeEggOutcome(
   newBalance: number,
 ): Promise<EasterEggOutcome> {
   const outcome = await eggOutcome(childId, choices, newBalance + 1);
-  await db
-    .update(children)
-    .set({ pullTokens: sql`${children.pullTokens} + 1` })
-    .where(eq(children.id, childId));
+  await refundPullToken(childId);
   return outcome;
 }
 
@@ -173,10 +179,7 @@ export async function pull(
   } catch (err) {
     // 4) Best-effort refund (U4-BR6).
     try {
-      await db
-        .update(children)
-        .set({ pullTokens: sql`${children.pullTokens} + 1` })
-        .where(eq(children.id, childId));
+      await refundPullToken(childId);
     } catch (refundErr) {
       console.error(`pull: refund failed for ${childId}`, refundErr);
     }

--- a/src/features/pull/pull-service.ts
+++ b/src/features/pull/pull-service.ts
@@ -267,39 +267,18 @@ export async function claimEasterEgg(
   const card = await getCard(chosenCardId);
   if (!card) throw new Error("claimEasterEgg: card not found");
 
-  // Atomic spend — one ticket (special, rarity-pick, or normal). Single-use.
-  let newBalance: number;
-  if (payload.pickRarity) {
-    // Rarity-pick ticket (Inc16 FR2): spend the matching {rarity}_pick_tickets.
-    const key = pickTicketColumn(payload.pickRarity);
-    const col = children[key];
-    const spent = await db
-      .update(children)
-      .set({ [key]: sql`${col} - 1` })
-      .where(and(eq(children.id, childId), gte(col, 1)))
-      .returning({ pullTokens: children.pullTokens });
-    if (spent.length === 0) return { outOfTokens: true };
-    newBalance = spent[0].pullTokens; // normal balance unchanged
-  } else if (payload.ticket) {
-    // Special egg: spend the pinned special ticket, not a normal token.
-    const key = payload.ticket === "epic" ? "epicTickets" : "luckyTickets";
-    const col = children[key];
-    const spent = await db
-      .update(children)
-      .set({ [key]: sql`${col} - 1` })
-      .where(and(eq(children.id, childId), gte(col, 1)))
-      .returning({ pullTokens: children.pullTokens });
-    if (spent.length === 0) return { outOfTokens: true };
-    newBalance = spent[0].pullTokens; // normal balance unchanged
-  } else {
-    const spent = await db
-      .update(children)
-      .set({ pullTokens: sql`${children.pullTokens} - 1` })
-      .where(and(eq(children.id, childId), gte(children.pullTokens, 1)))
-      .returning({ balance: children.pullTokens });
-    if (spent.length === 0) return { outOfTokens: true };
-    newBalance = spent[0].balance;
-  }
+  // Atomic spend — one column (rarity-pick, special ticket, or normal token).
+  // The pinned offer field picks which; missing both spends a normal token.
+  // Single-use: the guarded decrement makes the signed offer un-replayable.
+  const key: SpendableColumn = payload.pickRarity
+    ? pickTicketColumn(payload.pickRarity)
+    : payload.ticket
+      ? payload.ticket === "epic"
+        ? "epicTickets"
+        : "luckyTickets"
+      : "pullTokens";
+  const newBalance = await spendOneColumn(childId, key);
+  if (newBalance === null) return { outOfTokens: true };
 
   const [entry] = await db
     .insert(collections)
@@ -319,6 +298,35 @@ export async function claimEasterEgg(
     isDuplicate: entry.count > 1,
     newBalance,
   };
+}
+
+/** Children columns that hold a spendable balance (normal token or a ticket). */
+type SpendableColumn =
+  | "pullTokens"
+  | "epicTickets"
+  | "luckyTickets"
+  | "commonPickTickets"
+  | "rarePickTickets"
+  | "epicPickTickets"
+  | "legendaryPickTickets";
+
+/**
+ * Atomic guarded decrement of one spendable column (single-use claim). Returns
+ * the child's resulting normal token balance, or null if nothing was spent
+ * (guard failed → no copies left). Decrementing `pullTokens` returns its new
+ * value; decrementing a ticket column leaves `pullTokens` unchanged.
+ */
+async function spendOneColumn(
+  childId: string,
+  key: SpendableColumn,
+): Promise<number | null> {
+  const col = children[key];
+  const spent = await db
+    .update(children)
+    .set({ [key]: sql`${col} - 1` })
+    .where(and(eq(children.id, childId), gte(col, 1)))
+    .returning({ pullTokens: children.pullTokens });
+  return spent.length === 0 ? null : spent[0].pullTokens;
 }
 
 export interface SacrificeResult {

--- a/src/features/pull/sacrifice-hint.ts
+++ b/src/features/pull/sacrifice-hint.ts
@@ -4,24 +4,16 @@
  * failure just means the hint may show again, which is acceptable.
  */
 
+import { storageGet, storageSet } from "@/lib/storage";
+
 export function hintKey(childId: string): string {
   return `sacrifice-hint-seen:${childId}`;
 }
 
 export function hasSeenSacrificeHint(childId: string): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem(hintKey(childId)) === "1";
-  } catch {
-    return false;
-  }
+  return storageGet("localStorage", hintKey(childId)) === "1";
 }
 
 export function markSacrificeHintSeen(childId: string): void {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(hintKey(childId), "1");
-  } catch {
-    // private mode / disabled storage — hint may re-show, acceptable.
-  }
+  storageSet("localStorage", hintKey(childId), "1");
 }

--- a/src/features/pull/token-service.ts
+++ b/src/features/pull/token-service.ts
@@ -6,10 +6,40 @@ import { requireParent } from "@/features/auth/guard";
 import { pickTicketColumn } from "./pick-tickets";
 import type { EggTicket, Rarity } from "@/lib/types";
 
-const TICKET_COL = {
-  epic: children.epicTickets,
-  lucky: children.luckyTickets,
-} as const;
+/** Children columns holding a grantable, clamp-≥0 integer balance. */
+type GrantableColumn =
+  | "pullTokens"
+  | "epicTickets"
+  | "luckyTickets"
+  | "commonPickTickets"
+  | "rarePickTickets"
+  | "epicPickTickets"
+  | "legendaryPickTickets";
+
+/**
+ * Parent-only clamped grant/adjust of one integer children column (U4-BR8):
+ * validate the delta, apply GREATEST(0, col + delta) atomically, and return the
+ * new balance. Shared body of grant / grantSpecial / grantPickTicket.
+ */
+async function grantColumn(
+  childId: string,
+  key: GrantableColumn,
+  delta: number,
+  label: string,
+): Promise<number> {
+  await requireParent();
+  if (!Number.isInteger(delta)) throw new Error(`${label}: delta must be an integer`);
+
+  const col = children[key];
+  const [row] = await db
+    .update(children)
+    .set({ [key]: sql`GREATEST(0, ${col} + ${delta})` })
+    .where(eq(children.id, childId))
+    .returning({ balance: col });
+
+  if (!row) throw new Error(`${label}: child not found`);
+  return row.balance;
+}
 
 /** Current pull-token balance (F2). */
 export async function getBalance(childId: string): Promise<number> {
@@ -40,18 +70,7 @@ export async function grantSpecial(
   kind: EggTicket,
   delta: number,
 ): Promise<number> {
-  await requireParent();
-  if (!Number.isInteger(delta)) throw new Error("grantSpecial: delta must be an integer");
-
-  const col = TICKET_COL[kind];
-  const [row] = await db
-    .update(children)
-    .set({ [kind === "epic" ? "epicTickets" : "luckyTickets"]: sql`GREATEST(0, ${col} + ${delta})` })
-    .where(eq(children.id, childId))
-    .returning({ balance: col });
-
-  if (!row) throw new Error("grantSpecial: child not found");
-  return row.balance;
+  return grantColumn(childId, kind === "epic" ? "epicTickets" : "luckyTickets", delta, "grantSpecial");
 }
 
 /**
@@ -63,19 +82,7 @@ export async function grantPickTicket(
   rarity: Rarity,
   delta: number,
 ): Promise<number> {
-  await requireParent();
-  if (!Number.isInteger(delta)) throw new Error("grantPickTicket: delta must be an integer");
-
-  const key = pickTicketColumn(rarity);
-  const col = children[key];
-  const [row] = await db
-    .update(children)
-    .set({ [key]: sql`GREATEST(0, ${col} + ${delta})` })
-    .where(eq(children.id, childId))
-    .returning({ balance: col });
-
-  if (!row) throw new Error("grantPickTicket: child not found");
-  return row.balance;
+  return grantColumn(childId, pickTicketColumn(rarity), delta, "grantPickTicket");
 }
 
 /**
@@ -83,15 +90,5 @@ export async function grantPickTicket(
  * Returns the new balance.
  */
 export async function grant(childId: string, delta: number): Promise<number> {
-  await requireParent();
-  if (!Number.isInteger(delta)) throw new Error("grant: delta must be an integer");
-
-  const [row] = await db
-    .update(children)
-    .set({ pullTokens: sql`GREATEST(0, ${children.pullTokens} + ${delta})` })
-    .where(eq(children.id, childId))
-    .returning({ balance: children.pullTokens });
-
-  if (!row) throw new Error("grant: child not found");
-  return row.balance;
+  return grantColumn(childId, "pullTokens", delta, "grant");
 }

--- a/src/features/pull/token-service.ts
+++ b/src/features/pull/token-service.ts
@@ -3,7 +3,7 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { children } from "@/db/schema";
 import { requireParent } from "@/features/auth/guard";
-import { pickTicketColumn, type BalanceColumn } from "./pick-tickets";
+import { pickTicketColumn, specialTicketColumn, type BalanceColumn } from "./pick-tickets";
 import type { EggTicket, Rarity } from "@/lib/types";
 
 /**
@@ -60,7 +60,7 @@ export async function grantSpecial(
   kind: EggTicket,
   delta: number,
 ): Promise<number> {
-  return grantColumn(childId, kind === "epic" ? "epicTickets" : "luckyTickets", delta, "grantSpecial");
+  return grantColumn(childId, specialTicketColumn(kind), delta, "grantSpecial");
 }
 
 /**

--- a/src/features/pull/token-service.ts
+++ b/src/features/pull/token-service.ts
@@ -3,18 +3,8 @@ import { eq, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { children } from "@/db/schema";
 import { requireParent } from "@/features/auth/guard";
-import { pickTicketColumn } from "./pick-tickets";
+import { pickTicketColumn, type BalanceColumn } from "./pick-tickets";
 import type { EggTicket, Rarity } from "@/lib/types";
-
-/** Children columns holding a grantable, clamp-≥0 integer balance. */
-type GrantableColumn =
-  | "pullTokens"
-  | "epicTickets"
-  | "luckyTickets"
-  | "commonPickTickets"
-  | "rarePickTickets"
-  | "epicPickTickets"
-  | "legendaryPickTickets";
 
 /**
  * Parent-only clamped grant/adjust of one integer children column (U4-BR8):
@@ -23,7 +13,7 @@ type GrantableColumn =
  */
 async function grantColumn(
   childId: string,
-  key: GrantableColumn,
+  key: BalanceColumn,
   delta: number,
   label: string,
 ): Promise<number> {

--- a/src/features/quiz/actions.ts
+++ b/src/features/quiz/actions.ts
@@ -1,14 +1,13 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { getActiveChild } from "@/features/profiles/active-profile";
+import { requireActiveChild } from "@/features/profiles/active-profile";
 import { buildQuiz, submitQuiz, type BuiltQuiz } from "./quiz-service";
 import type { QuizOutcome } from "./types";
 
 /** Start a quiz for the active child (Inc11). Server picks questions + signs. */
 export async function startQuizAction(topicId: string): Promise<BuiltQuiz> {
-  const child = await getActiveChild();
-  if (!child) throw new Error("No active profile");
+  const child = await requireActiveChild();
   return buildQuiz(child.id, topicId);
 }
 
@@ -17,8 +16,7 @@ export async function submitQuizAction(
   offer: string,
   picks: string[],
 ): Promise<QuizOutcome> {
-  const child = await getActiveChild();
-  if (!child) throw new Error("No active profile");
+  const child = await requireActiveChild();
   const outcome = await submitQuiz(child.id, offer, picks);
   revalidatePath("/play/home");
   revalidatePath("/play/learn");

--- a/src/features/quiz/math-gen.ts
+++ b/src/features/quiz/math-gen.ts
@@ -4,23 +4,10 @@
  * computed, never guessed — safe answer keys for a kid.
  */
 
+import type { Rng } from "@/lib/logic";
+import { randInt, shuffle } from "@/lib/rng";
+
 import type { QuizQuestion } from "./types";
-
-type Rng = () => number;
-
-function randInt(rng: Rng, min: number, max: number): number {
-  // inclusive both ends; clamp guards against rng()===1.
-  return min + Math.min(max - min, Math.floor(rng() * (max - min + 1)));
-}
-
-function shuffle<T>(arr: T[], rng: Rng): T[] {
-  const a = [...arr];
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = randInt(rng, 0, i);
-    [a[i], a[j]] = [a[j], a[i]];
-  }
-  return a;
-}
 
 /** Build 4 unique options around `answer` (>= 0), shuffled, answer included.
  * `spread` extra near-miss deltas let larger answers get plausible distractors. */

--- a/src/features/quiz/quiz-offer.ts
+++ b/src/features/quiz/quiz-offer.ts
@@ -1,96 +1,46 @@
 /**
- * Signed quiz offer (Inc11, Security). PURE + isomorphic (Web Crypto). Pins the
- * exact correct-answer vector the server served so scoring is server-authoritative:
- * the client submits only its picks, never the keys. Mirrors pull/offer.ts.
- * Carries no secret — just an HMAC over the payload.
+ * Signed quiz offer (Inc11, Security). Pins the exact correct-answer vector the
+ * server served so scoring is server-authoritative: the client submits only its
+ * picks, never the keys. Thin wrapper over the shared HMAC token in
+ * lib/signed-token (mirrors pull/offer.ts).
  */
 
-export interface QuizOfferPayload {
+import {
+  signToken,
+  verifyToken,
+  type SignedPayload,
+} from "@/lib/signed-token";
+
+export interface QuizOfferPayload extends SignedPayload {
   childId: string;
   topic: string;
   answers: string[]; // correct option per served question, in order
   exp: number; // epoch ms
 }
 
-function b64urlEncode(bytes: Uint8Array): string {
-  let bin = "";
-  for (const b of bytes) bin += String.fromCharCode(b);
-  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-function b64urlDecode(s: string): Uint8Array {
-  const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
-  const bin = atob(s.replace(/-/g, "+").replace(/_/g, "/") + pad);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
-}
-
-async function hmac(payload: string, secret: string): Promise<Uint8Array> {
-  const key = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
+function isQuizOfferPayload(p: unknown): p is QuizOfferPayload {
+  const o = p as QuizOfferPayload;
+  return (
+    typeof o?.childId === "string" &&
+    typeof o?.topic === "string" &&
+    Array.isArray(o.answers) &&
+    typeof o.exp === "number"
   );
-  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload));
-  return new Uint8Array(sig);
-}
-
-function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
-  return diff === 0;
 }
 
 /** Sign → `base64url(json).base64url(hmac)`. */
-export async function makeQuizOffer(
+export function makeQuizOffer(
   payload: QuizOfferPayload,
   secret: string,
 ): Promise<string> {
-  const json = JSON.stringify(payload);
-  const encoded = b64urlEncode(new TextEncoder().encode(json));
-  const sig = await hmac(json, secret);
-  return `${encoded}.${b64urlEncode(sig)}`;
+  return signToken(payload, secret);
 }
 
 /** Return the payload iff signature valid AND not expired, else null. */
-export async function verifyQuizOffer(
+export function verifyQuizOffer(
   token: string | undefined | null,
   secret: string,
   nowMs: number,
 ): Promise<QuizOfferPayload | null> {
-  if (!token || !secret) return null;
-  const dot = token.indexOf(".");
-  if (dot <= 0) return null;
-
-  let json: string;
-  let providedSig: Uint8Array;
-  try {
-    json = new TextDecoder().decode(b64urlDecode(token.slice(0, dot)));
-    providedSig = b64urlDecode(token.slice(dot + 1));
-  } catch {
-    return null;
-  }
-
-  const expected = await hmac(json, secret);
-  if (!timingSafeEqual(expected, providedSig)) return null;
-
-  let payload: QuizOfferPayload;
-  try {
-    payload = JSON.parse(json) as QuizOfferPayload;
-  } catch {
-    return null;
-  }
-  if (
-    typeof payload?.childId !== "string" ||
-    typeof payload?.topic !== "string" ||
-    !Array.isArray(payload.answers) ||
-    typeof payload.exp !== "number"
-  ) {
-    return null;
-  }
-  return payload.exp > nowMs ? payload : null;
+  return verifyToken(token, secret, nowMs, isQuizOfferPayload);
 }

--- a/src/features/quiz/quiz-service.ts
+++ b/src/features/quiz/quiz-service.ts
@@ -7,6 +7,7 @@ import { generateMathQuestions, isMathTopic } from "./math-gen";
 import { GRAMMAR_BANKS, isGrammarTopic } from "./grammar-bank";
 import { makeQuizOffer, verifyQuizOffer } from "./quiz-offer";
 import { sgtDayKey, decideAward } from "./cap";
+import { sample } from "@/lib/rng";
 import {
   QUIZ_LENGTH,
   type ClientQuestion,
@@ -18,16 +19,6 @@ const OFFER_TTL_MS = 10 * 60_000; // 10 min
 
 function authSecret(): string {
   return process.env.AUTH_SECRET ?? "";
-}
-
-/** Pick `n` random items from `arr` (Fisher-Yates prefix). */
-function sample<T>(arr: T[], n: number, rng: () => number): T[] {
-  const a = [...arr];
-  for (let i = 0; i < Math.min(n, a.length); i++) {
-    const j = i + Math.min(a.length - 1 - i, Math.floor(rng() * (a.length - i)));
-    [a[i], a[j]] = [a[j], a[i]];
-  }
-  return a.slice(0, n);
 }
 
 function buildQuestions(topicId: string, rng: () => number): QuizQuestion[] {

--- a/src/features/quiz/quiz-service.ts
+++ b/src/features/quiz/quiz-service.ts
@@ -8,6 +8,7 @@ import { GRAMMAR_BANKS, isGrammarTopic } from "./grammar-bank";
 import { makeQuizOffer, verifyQuizOffer } from "./quiz-offer";
 import { sgtDayKey, decideAward } from "./cap";
 import { sample } from "@/lib/rng";
+import { env } from "@/lib/env";
 import {
   QUIZ_LENGTH,
   type ClientQuestion,
@@ -16,10 +17,6 @@ import {
 } from "./types";
 
 const OFFER_TTL_MS = 10 * 60_000; // 10 min
-
-function authSecret(): string {
-  return process.env.AUTH_SECRET ?? "";
-}
 
 function buildQuestions(topicId: string, rng: () => number): QuizQuestion[] {
   if (isMathTopic(topicId)) return generateMathQuestions(topicId, QUIZ_LENGTH, rng);
@@ -56,7 +53,7 @@ export async function buildQuiz(
       answers: questions.map((q) => q.correct),
       exp: nowMs + OFFER_TTL_MS,
     },
-    authSecret(),
+    env.authSecret,
   );
   // Inc13 FR6: send the answer key + explanation to the client for immediate
   // per-question feedback. Award stays server-authoritative (re-scored against
@@ -76,7 +73,7 @@ export async function submitQuiz(
   picks: string[],
   nowMs: number = Date.now(),
 ): Promise<QuizOutcome> {
-  const payload = await verifyQuizOffer(offer, authSecret(), nowMs);
+  const payload = await verifyQuizOffer(offer, env.authSecret, nowMs);
   if (!payload) throw new Error("submitQuiz: invalid or expired offer");
   if (payload.childId !== childId) throw new Error("submitQuiz: child mismatch");
 

--- a/src/features/rewards/CollectionRewardModal.tsx
+++ b/src/features/rewards/CollectionRewardModal.tsx
@@ -7,7 +7,7 @@ import { RARITY_LABEL } from "@/features/card/rarity";
 import { Fireworks } from "@/features/anim/Fireworks";
 import { useSound } from "@/features/sound/useSound";
 import { CenteredModal } from "@/features/ui/CenteredModal";
-import { playFanfare } from "@/features/sound/sfx";
+import { playFanfare, playReward } from "@/features/sound/sfx";
 import type { PendingReward } from "./service";
 import { markRewardsShownAction } from "./actions";
 import "@/features/anim/anim.css";
@@ -33,9 +33,8 @@ export function CollectionRewardModal({ rewards }: { rewards: PendingReward[] })
   useEffect(() => {
     if (rewards.length === 0) return;
     markRewardsShownAction(rewards.map((r) => r.id));
-    play("setComplete");
     setFire((n) => n + 1);
-    playFanfare(play, rewards[0].rarity);
+    playReward(play, rewards[0].rarity);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/features/rewards/CollectionRewardModal.tsx
+++ b/src/features/rewards/CollectionRewardModal.tsx
@@ -6,6 +6,7 @@ import { Card } from "@/features/card/Card";
 import { RARITY_LABEL } from "@/features/card/rarity";
 import { Fireworks } from "@/features/anim/Fireworks";
 import { useSound } from "@/features/sound/useSound";
+import { CenteredModal } from "@/features/ui/CenteredModal";
 import { playFanfare } from "@/features/sound/sfx";
 import type { PendingReward } from "./service";
 import { markRewardsShownAction } from "./actions";
@@ -52,30 +53,23 @@ export function CollectionRewardModal({ rewards }: { rewards: PendingReward[] })
   }
 
   return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
-      role="dialog"
-      aria-modal="true"
-      data-testid="collection-reward-modal"
-    >
-      <div className="panel flex max-w-sm flex-col items-center gap-4 p-6 text-center">
-        <span className="pill pill--gold text-base">🏆 Set complete! 🏆</span>
-        <h2 className="text-xl font-bold">
-          You collected every {RARITY_LABEL[r.rarity]} {r.themeName}!
-        </h2>
-        <p className="text-sm text-[color:var(--ink-soft)]">Here&apos;s your bonus card:</p>
-        <Card card={r.card} interactive size="lg" />
-        <Fireworks fire={fire} />
-        <button
-          type="button"
-          onClick={next}
-          data-testid="collection-reward-next"
-          className="btn btn--primary press font-bold"
-        >
-          {idx + 1 < rewards.length ? "Next 🎁" : "Awesome! 🎉"}
-        </button>
-      </div>
-    </div>,
+    <CenteredModal testId="collection-reward-modal">
+      <span className="pill pill--gold text-base">🏆 Set complete! 🏆</span>
+      <h2 className="text-xl font-bold">
+        You collected every {RARITY_LABEL[r.rarity]} {r.themeName}!
+      </h2>
+      <p className="text-sm text-[color:var(--ink-soft)]">Here&apos;s your bonus card:</p>
+      <Card card={r.card} interactive size="lg" />
+      <Fireworks fire={fire} />
+      <button
+        type="button"
+        onClick={next}
+        data-testid="collection-reward-next"
+        className="btn btn--primary press font-bold"
+      >
+        {idx + 1 < rewards.length ? "Next 🎁" : "Awesome! 🎉"}
+      </button>
+    </CenteredModal>,
     document.body,
   );
 }

--- a/src/features/rewards/CollectionRewardModal.tsx
+++ b/src/features/rewards/CollectionRewardModal.tsx
@@ -6,7 +6,7 @@ import { Card } from "@/features/card/Card";
 import { RARITY_LABEL } from "@/features/card/rarity";
 import { Fireworks } from "@/features/anim/Fireworks";
 import { useSound } from "@/features/sound/useSound";
-import { rewardFanfare } from "@/features/sound/sfx";
+import { playFanfare } from "@/features/sound/sfx";
 import type { PendingReward } from "./service";
 import { markRewardsShownAction } from "./actions";
 import "@/features/anim/anim.css";
@@ -34,8 +34,7 @@ export function CollectionRewardModal({ rewards }: { rewards: PendingReward[] })
     markRewardsShownAction(rewards.map((r) => r.id));
     play("setComplete");
     setFire((n) => n + 1);
-    const fanfare = rewardFanfare(rewards[0].rarity);
-    if (fanfare) play(fanfare);
+    playFanfare(play, rewards[0].rarity);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -47,8 +46,7 @@ export function CollectionRewardModal({ rewards }: { rewards: PendingReward[] })
     const n = idx + 1;
     if (n < rewards.length) {
       setFire((k) => k + 1);
-      const fanfare = rewardFanfare(rewards[n].rarity);
-      if (fanfare) play(fanfare);
+      playFanfare(play, rewards[n].rarity);
     }
     setIdx(n);
   }

--- a/src/features/rewards/service.ts
+++ b/src/features/rewards/service.ts
@@ -1,9 +1,9 @@
 import "server-only";
-import { and, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull } from "drizzle-orm";
 import { db } from "@/db";
 import { collections, collectionRewards } from "@/db/schema";
-import { listCards } from "@/features/pool/service";
-import { listThemes } from "@/features/pool/service";
+import { addCardCopy } from "@/db/collection-writes";
+import { listCards, listThemes } from "@/features/pool/service";
 import { pickUpgradeCard } from "@/features/pull/sacrifice";
 import type { Card, Rarity } from "@/lib/types";
 import { isRaritySetComplete, raritySetsFor } from "./collection-reward";
@@ -70,13 +70,7 @@ export async function grantCompletionRewards(
         .returning({ id: collectionRewards.id });
       if (claimed.length === 0) continue; // already rewarded elsewhere
 
-      await db
-        .insert(collections)
-        .values({ childId, cardId: rewardCard.id, count: 1 })
-        .onConflictDoUpdate({
-          target: [collections.childId, collections.cardId],
-          set: { count: sql`${collections.count} + 1` },
-        });
+      await addCardCopy(childId, rewardCard.id);
 
       owned.add(rewardCard.id);
       granted.push({ themeId, rarity, card: rewardCard });

--- a/src/features/sound/AudioEngine.ts
+++ b/src/features/sound/AudioEngine.ts
@@ -66,6 +66,27 @@ export function acquireContext(): AudioContext | null {
 }
 
 /**
+ * Create a gain node with a standard attack/decay envelope (rise to `peak` over
+ * `attack`, decay to silence at `at + dur`), wired to `dest`. Shared by the SFX
+ * and music engines. Returns the gain node so the caller can feed a source into it.
+ */
+export function gainEnvelope(
+  ctx: AudioContext,
+  dest: AudioNode,
+  at: number,
+  peak: number,
+  dur: number,
+  attack: number,
+): GainNode {
+  const g = ctx.createGain();
+  g.gain.setValueAtTime(0.0001, at);
+  g.gain.exponentialRampToValueAtTime(peak, at + attack);
+  g.gain.exponentialRampToValueAtTime(0.0001, at + dur);
+  g.connect(dest);
+  return g;
+}
+
+/**
  * Play a synthesized SFX. `intensity` (0..1) scales loudness; `attenuate`
  * softens output under reduced-motion. Never throws.
  */
@@ -88,11 +109,7 @@ export function play(
 
     // Envelope helper for one voice.
     const voice = (freq: number, startAt: number, wave = spec.wave) => {
-      const g = c.createGain();
-      g.gain.setValueAtTime(0.0001, startAt);
-      g.gain.exponentialRampToValueAtTime(peak, startAt + 0.012);
-      g.gain.exponentialRampToValueAtTime(0.0001, startAt + dur);
-      g.connect(master);
+      const g = gainEnvelope(c, master, startAt, peak, dur, 0.012);
 
       if (wave === "noise") {
         const src = c.createBufferSource();

--- a/src/features/sound/AudioEngine.ts
+++ b/src/features/sound/AudioEngine.ts
@@ -3,6 +3,7 @@
  * no audio files. Lazily unlocks the AudioContext on the first user gesture and
  * degrades to a silent no-op if Web Audio is unavailable or blocked (NFR4).
  */
+import { clamp } from "@/lib/math";
 import { sfxSpec, type SfxName } from "./sfx";
 
 type Ctx = AudioContext;
@@ -101,7 +102,7 @@ export function play(
     const spec = sfxSpec(name);
     const now = c.currentTime;
     const dur = spec.durationMs / 1000;
-    const clampedI = Math.max(0, Math.min(1, intensity));
+    const clampedI = clamp(intensity, 0, 1);
     const peak = spec.gain * (0.4 + 0.6 * clampedI) * (attenuate ? 0.4 : 1);
     const master = c.createGain();
     master.gain.value = 1;

--- a/src/features/sound/MusicEngine.ts
+++ b/src/features/sound/MusicEngine.ts
@@ -6,7 +6,7 @@
  * Look-ahead scheduler: every tick we queue the notes for the next slice of
  * time, so playback stays smooth without a media file.
  */
-import { acquireContext } from "./AudioEngine";
+import { acquireContext, gainEnvelope } from "./AudioEngine";
 
 // C-major pentatonic (warm, no "wrong" notes) across two octaves.
 const ARP = [261.63, 293.66, 329.63, 392.0, 440.0, 523.25, 587.33, 659.25];
@@ -22,11 +22,7 @@ let step = 0;
 let running = false;
 
 function noteAt(ctx: AudioContext, freq: number, at: number, dur: number, gain: number, wave: OscillatorType) {
-  const g = ctx.createGain();
-  g.gain.setValueAtTime(0.0001, at);
-  g.gain.exponentialRampToValueAtTime(gain, at + 0.04);
-  g.gain.exponentialRampToValueAtTime(0.0001, at + dur);
-  g.connect(master!);
+  const g = gainEnvelope(ctx, master!, at, gain, dur, 0.04);
   const osc = ctx.createOscillator();
   osc.type = wave;
   osc.frequency.setValueAtTime(freq, at);

--- a/src/features/sound/SoundProvider.tsx
+++ b/src/features/sound/SoundProvider.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { prefersReducedMotion } from "@/lib/motion";
 import type { Rarity } from "@/lib/types";
 import { play as enginePlay, unlock } from "./AudioEngine";
 import { startBgm, stopBgm } from "./bgm";
@@ -29,11 +30,6 @@ export interface SoundContextValue {
 }
 
 export const SoundContext = createContext<SoundContextValue | null>(null);
-
-function prefersReducedMotion(): boolean {
-  if (typeof window === "undefined" || !window.matchMedia) return false;
-  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-}
 
 export function SoundProvider({ children }: { children: ReactNode }) {
   // Start from defaults for a stable first render, then hydrate from storage.

--- a/src/features/sound/settings.ts
+++ b/src/features/sound/settings.ts
@@ -3,39 +3,19 @@
  * Namespaced localStorage keys; no PII. Defaults: SFX on, BGM off (starts on first tap).
  */
 
+import { storageGet, storageSet } from "@/lib/storage";
+
 export const SFX_KEY = "kc.snd.sfx";
 export const BGM_KEY = "kc.snd.bgm";
 
-function store(): Storage | null {
-  try {
-    // Present in the browser; undefined during SSR / node tests unless stubbed.
-    const ls = (globalThis as { localStorage?: Storage }).localStorage;
-    return ls ?? null;
-  } catch {
-    return null;
-  }
-}
-
 function read(key: string, fallback: boolean): boolean {
-  const ls = store();
-  if (!ls) return fallback;
-  try {
-    const v = ls.getItem(key);
-    if (v === null) return fallback;
-    return v === "1";
-  } catch {
-    return fallback;
-  }
+  const v = storageGet("localStorage", key);
+  if (v === null) return fallback;
+  return v === "1";
 }
 
 function write(key: string, value: boolean): void {
-  const ls = store();
-  if (!ls) return;
-  try {
-    ls.setItem(key, value ? "1" : "0");
-  } catch {
-    /* storage blocked (private mode / quota) — silent, non-fatal */
-  }
+  storageSet("localStorage", key, value ? "1" : "0");
 }
 
 export function getSfxEnabled(): boolean {

--- a/src/features/sound/sfx.ts
+++ b/src/features/sound/sfx.ts
@@ -85,6 +85,16 @@ export function playFanfare(play: (name: SfxName) => void, rarity: Rarity): void
   if (fanfare) play(fanfare);
 }
 
+/**
+ * Full reward chime: the set-complete cue plus the tier fanfare (if any).
+ * Consolidates the "setComplete + fanfare" pair fired at every reward-commit
+ * site (sacrifice, trade, collection reward).
+ */
+export function playReward(play: (name: SfxName) => void, rarity: Rarity): void {
+  play("setComplete");
+  playFanfare(play, rarity);
+}
+
 const RARITY_INTENSITY: Record<Rarity, number> = {
   common: 0.3,
   rare: 0.55,

--- a/src/features/sound/sfx.ts
+++ b/src/features/sound/sfx.ts
@@ -75,6 +75,16 @@ export function rewardFanfare(rarity: Rarity): SfxName | null {
   return null;
 }
 
+/**
+ * Layer the tier fanfare (if any) on top of a reveal via the given `play`.
+ * No-op for common/rare. Consolidates the repeated "compute + null-check" call
+ * done at every reward site.
+ */
+export function playFanfare(play: (name: SfxName) => void, rarity: Rarity): void {
+  const fanfare = rewardFanfare(rarity);
+  if (fanfare) play(fanfare);
+}
+
 const RARITY_INTENSITY: Record<Rarity, number> = {
   common: 0.3,
   rare: 0.55,

--- a/src/features/trade/TradeFlow.tsx
+++ b/src/features/trade/TradeFlow.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import Image from "next/image";
 import Link from "next/link";
 import { useState, useTransition } from "react";
 import type { Card as CardType } from "@/lib/types";
+import { CardImage } from "@/features/card/CardImage";
 import { RARITY_META } from "@/features/card/rarity";
 import { AvatarBadge } from "@/features/ui/AvatarBadge";
 import { useSound } from "@/features/sound/useSound";
@@ -242,13 +242,7 @@ function CardGrid({
             style={{ borderColor: meta.frame }}
           >
             <span className="rarity-badge">{meta.label}</span>
-            <Image
-              src={t.card.imageUrl}
-              alt={t.card.name}
-              width={200}
-              height={200}
-              className="aspect-square w-full object-cover"
-            />
+            <CardImage src={t.card.imageUrl} alt={t.card.name} dim={200} />
             <span className="pill absolute bottom-1 right-1 text-xs">×{t.count}</span>
           </button>
         );
@@ -263,7 +257,7 @@ function CardMini({ card, label }: { card: CardType; label: string }) {
     <div className="flex flex-col items-center gap-1">
       <span className="text-xs text-[color:var(--ink-soft)]">{label}</span>
       <div className="relative overflow-hidden rounded-xl border-2" style={{ borderColor: meta.frame }}>
-        <Image src={card.imageUrl} alt={card.name} width={110} height={110} className="aspect-square w-[110px] object-cover" />
+        <CardImage src={card.imageUrl} alt={card.name} dim={110} className="aspect-square w-[110px] object-cover" />
       </div>
       <span className="text-xs font-semibold">{meta.label}</span>
     </div>

--- a/src/features/trade/TradeFlow.tsx
+++ b/src/features/trade/TradeFlow.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useState, useTransition } from "react";
 import type { Card as CardType } from "@/lib/types";
 import { RARITY_META } from "@/features/card/rarity";
-import { avatarEmoji } from "@/lib/avatars";
+import { AvatarBadge } from "@/features/ui/AvatarBadge";
 import { useSound } from "@/features/sound/useSound";
 import { playFanfare } from "@/features/sound/sfx";
 import { getMatchesAction, executeTradeAction } from "./actions";
@@ -143,9 +143,7 @@ export function TradeFlow({
                   data-testid={`trade-friend-${f.id}`}
                   className="panel flex items-center gap-2 px-4 py-3 transition hover:bg-white/10 disabled:opacity-50"
                 >
-                  <span className="hero-avatar h-9 w-9 text-lg" aria-hidden>
-                    {avatarEmoji(f.avatar)}
-                  </span>
+                  <AvatarBadge avatar={f.avatar} className="h-9 w-9 text-lg" />
                   <span className="font-semibold">{f.name}</span>
                 </button>
               ))}

--- a/src/features/trade/TradeFlow.tsx
+++ b/src/features/trade/TradeFlow.tsx
@@ -6,6 +6,7 @@ import type { Card as CardType } from "@/lib/types";
 import { CardImage } from "@/features/card/CardImage";
 import { RARITY_META } from "@/features/card/rarity";
 import { AvatarBadge } from "@/features/ui/AvatarBadge";
+import { ErrorBanner } from "@/features/ui/ErrorBanner";
 import { useSound } from "@/features/sound/useSound";
 import { playFanfare } from "@/features/sound/sfx";
 import { getMatchesAction, executeTradeAction } from "./actions";
@@ -108,11 +109,7 @@ export function TradeFlow({
 
   return (
     <div className="flex w-full max-w-2xl flex-col items-center gap-5">
-      {error ? (
-        <p data-testid="trade-error" className="panel px-5 py-3 text-center text-sm text-red-300">
-          {error}
-        </p>
-      ) : null}
+      <ErrorBanner testId="trade-error" message={error} />
 
       {/* Step 1 — pick your duplicate */}
       {phase === "pick-mine" ? (

--- a/src/features/trade/TradeFlow.tsx
+++ b/src/features/trade/TradeFlow.tsx
@@ -8,7 +8,7 @@ import { RARITY_META } from "@/features/card/rarity";
 import { AvatarBadge } from "@/features/ui/AvatarBadge";
 import { ErrorBanner } from "@/features/ui/ErrorBanner";
 import { useSound } from "@/features/sound/useSound";
-import { playFanfare } from "@/features/sound/sfx";
+import { playReward } from "@/features/sound/sfx";
 import { getMatchesAction, executeTradeAction } from "./actions";
 import type { TradableCard } from "./trade-logic";
 
@@ -76,9 +76,8 @@ export function TradeFlow({
     startTransition(async () => {
       const res = await executeTradeAction(mine!.card.id, friend!.id, theirs!.card.id);
       if (res.ok) {
-        play("setComplete");
-        // Inc15 FR2: layer the reward fanfare when the card you got is epic/legendary.
-        playFanfare(play, res.got.rarity);
+        // Inc15 FR2: set-complete cue + fanfare when the card you got is epic/legendary.
+        playReward(play, res.got.rarity);
         setResult({ gave: res.gave, got: res.got });
         setPhase("done");
       } else {

--- a/src/features/trade/TradeFlow.tsx
+++ b/src/features/trade/TradeFlow.tsx
@@ -7,7 +7,7 @@ import type { Card as CardType } from "@/lib/types";
 import { RARITY_META } from "@/features/card/rarity";
 import { avatarEmoji } from "@/lib/avatars";
 import { useSound } from "@/features/sound/useSound";
-import { rewardFanfare } from "@/features/sound/sfx";
+import { playFanfare } from "@/features/sound/sfx";
 import { getMatchesAction, executeTradeAction } from "./actions";
 import type { TradableCard } from "./trade-logic";
 
@@ -77,8 +77,7 @@ export function TradeFlow({
       if (res.ok) {
         play("setComplete");
         // Inc15 FR2: layer the reward fanfare when the card you got is epic/legendary.
-        const fanfare = rewardFanfare(res.got.rarity);
-        if (fanfare) play(fanfare);
+        playFanfare(play, res.got.rarity);
         setResult({ gave: res.gave, got: res.got });
         setPhase("done");
       } else {

--- a/src/features/trade/TradeFlow.tsx
+++ b/src/features/trade/TradeFlow.tsx
@@ -94,11 +94,7 @@ export function TradeFlow({
     return (
       <div className="panel flex max-w-md flex-col items-center gap-4 p-6 text-center" data-testid="trade-done">
         <h1 className="text-2xl font-bold title-pop">Trade complete! 🎉</h1>
-        <div className="flex items-center justify-center gap-4">
-          <CardMini card={result.gave} label="You gave" />
-          <span className="text-2xl">🔄</span>
-          <CardMini card={result.got} label="You got" />
-        </div>
+        <SwapRow give={result.gave} giveLabel="You gave" get={result.got} getLabel="You got" />
         <div className="flex gap-3">
           <button type="button" onClick={reset} data-testid="trade-again" className="btn btn--primary">
             Trade again
@@ -124,9 +120,7 @@ export function TradeFlow({
         <section className="flex w-full flex-col items-center gap-3" data-testid="trade-pick-mine">
           <h2 className="text-xl font-bold">1. Pick your double to trade</h2>
           {myCards.length === 0 ? (
-            <p className="panel px-5 py-3 text-center text-sm text-[color:var(--ink-soft)]">
-              You have no doubles yet — collect a duplicate first! ➕
-            </p>
+            <Hint>You have no doubles yet — collect a duplicate first! ➕</Hint>
           ) : (
             <CardGrid cards={myCards} onPick={chooseMine} testid="mine" />
           )}
@@ -138,9 +132,7 @@ export function TradeFlow({
         <section className="flex w-full flex-col items-center gap-3" data-testid="trade-pick-friend">
           <h2 className="text-xl font-bold">2. Trade with which friend?</h2>
           {friends.length === 0 ? (
-            <p className="panel px-5 py-3 text-center text-sm text-[color:var(--ink-soft)]">
-              No other players yet — ask a parent to add one.
-            </p>
+            <Hint>No other players yet — ask a parent to add one.</Hint>
           ) : (
             <div className="flex flex-wrap justify-center gap-3">
               {friends.map((f) => (
@@ -170,9 +162,9 @@ export function TradeFlow({
             3. Pick {friend.name}&apos;s {RARITY_META[mine.card.rarity].label} double
           </h2>
           {theirCards.length === 0 ? (
-            <p className="panel px-5 py-3 text-center text-sm text-[color:var(--ink-soft)]">
+            <Hint>
               {friend.name} has no {RARITY_META[mine.card.rarity].label} doubles to swap.
-            </p>
+            </Hint>
           ) : (
             <CardGrid cards={theirCards} onPick={chooseTheirs} testid="theirs" />
           )}
@@ -183,11 +175,7 @@ export function TradeFlow({
       {phase === "confirm" && mine && theirs ? (
         <section className="panel flex flex-col items-center gap-4 p-6 text-center" data-testid="trade-confirm">
           <h2 className="text-xl font-bold">Ready to trade?</h2>
-          <div className="flex items-center justify-center gap-4">
-            <CardMini card={mine.card} label="You give" />
-            <span className="text-2xl">🔄</span>
-            <CardMini card={theirs.card} label="You get" />
-          </div>
+          <SwapRow give={mine.card} giveLabel="You give" get={theirs.card} getLabel="You get" />
           <div className="flex gap-3">
             <button
               type="button"
@@ -204,6 +192,32 @@ export function TradeFlow({
           </div>
         </section>
       ) : null}
+    </div>
+  );
+}
+
+function Hint({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="panel px-5 py-3 text-center text-sm text-[color:var(--ink-soft)]">{children}</p>
+  );
+}
+
+function SwapRow({
+  give,
+  giveLabel,
+  get,
+  getLabel,
+}: {
+  give: CardType;
+  giveLabel: string;
+  get: CardType;
+  getLabel: string;
+}) {
+  return (
+    <div className="flex items-center justify-center gap-4">
+      <CardMini card={give} label={giveLabel} />
+      <span className="text-2xl">🔄</span>
+      <CardMini card={get} label={getLabel} />
     </div>
   );
 }

--- a/src/features/trade/trade-service.ts
+++ b/src/features/trade/trade-service.ts
@@ -3,6 +3,7 @@ import { and, eq, gte } from "drizzle-orm";
 import { db } from "@/db";
 import { collections } from "@/db/schema";
 import { addCardCopy, removeCardCopy } from "@/db/collection-writes";
+import { getCardCount } from "@/db/collection-reads";
 import { listCards, getCard } from "@/features/pool/service";
 import { grantCompletionRewards } from "@/features/rewards/service";
 import type { Card, Rarity } from "@/lib/types";
@@ -40,12 +41,7 @@ export async function listMatchesForRarity(
 }
 
 /** Read one collection entry's count for (child, card), 0 if absent. */
-async function ownedCount(childId: string, cardId: string): Promise<number> {
-  const row = await db.query.collections.findFirst({
-    where: and(eq(collections.childId, childId), eq(collections.cardId, cardId)),
-  });
-  return row?.count ?? 0;
-}
+const ownedCount = getCardCount;
 
 /**
  * Atomic two-sided swap (FR4). Re-validates server-side, then commits 4 writes

--- a/src/features/trade/trade-service.ts
+++ b/src/features/trade/trade-service.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { and, eq, gte, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { collections } from "@/db/schema";
+import { addCardCopy } from "@/db/collection-writes";
 import { listCards, getCard } from "@/features/pool/service";
 import { grantCompletionRewards } from "@/features/rewards/service";
 import type { Card, Rarity } from "@/lib/types";
@@ -81,26 +82,14 @@ export async function executeTrade(input: {
         .set({ count: sql`${collections.count} - 1` })
         .where(and(eq(collections.childId, aChildId), eq(collections.cardId, aCardId), gte(collections.count, 2))),
       // A receives bCard.
-      db
-        .insert(collections)
-        .values({ childId: aChildId, cardId: bCardId, count: 1 })
-        .onConflictDoUpdate({
-          target: [collections.childId, collections.cardId],
-          set: { count: sql`${collections.count} + 1` },
-        }),
+      addCardCopy(aChildId, bCardId),
       // B gives bCard.
       db
         .update(collections)
         .set({ count: sql`${collections.count} - 1` })
         .where(and(eq(collections.childId, bChildId), eq(collections.cardId, bCardId), gte(collections.count, 2))),
       // B receives aCard.
-      db
-        .insert(collections)
-        .values({ childId: bChildId, cardId: aCardId, count: 1 })
-        .onConflictDoUpdate({
-          target: [collections.childId, collections.cardId],
-          set: { count: sql`${collections.count} + 1` },
-        }),
+      addCardCopy(bChildId, aCardId),
     ]);
   } catch {
     return { ok: false, reason: "That trade is no longer valid — try again." };

--- a/src/features/trade/trade-service.ts
+++ b/src/features/trade/trade-service.ts
@@ -1,8 +1,8 @@
 import "server-only";
-import { and, eq, gte, sql } from "drizzle-orm";
+import { and, eq, gte } from "drizzle-orm";
 import { db } from "@/db";
 import { collections } from "@/db/schema";
-import { addCardCopy } from "@/db/collection-writes";
+import { addCardCopy, removeCardCopy } from "@/db/collection-writes";
 import { listCards, getCard } from "@/features/pool/service";
 import { grantCompletionRewards } from "@/features/rewards/service";
 import type { Card, Rarity } from "@/lib/types";
@@ -77,17 +77,11 @@ export async function executeTrade(input: {
   try {
     await db.batch([
       // A gives aCard. `count >= 2` guard + CHECK(count>=1) → non-dup rolls back.
-      db
-        .update(collections)
-        .set({ count: sql`${collections.count} - 1` })
-        .where(and(eq(collections.childId, aChildId), eq(collections.cardId, aCardId), gte(collections.count, 2))),
+      removeCardCopy(aChildId, aCardId),
       // A receives bCard.
       addCardCopy(aChildId, bCardId),
       // B gives bCard.
-      db
-        .update(collections)
-        .set({ count: sql`${collections.count} - 1` })
-        .where(and(eq(collections.childId, bChildId), eq(collections.cardId, bCardId), gte(collections.count, 2))),
+      removeCardCopy(bChildId, bCardId),
       // B receives aCard.
       addCardCopy(bChildId, aCardId),
     ]);

--- a/src/features/ui/AvatarBadge.tsx
+++ b/src/features/ui/AvatarBadge.tsx
@@ -1,0 +1,20 @@
+import { avatarEmoji } from "@/lib/avatars";
+
+/**
+ * Shared hero-avatar badge: a `hero-avatar` span rendering the emoji for an
+ * avatar key, hidden from assistive tech. Callers pass size/extra utility
+ * classes via `className` (e.g. `h-9 w-9 text-lg`).
+ */
+export function AvatarBadge({
+  avatar,
+  className,
+}: {
+  avatar: string;
+  className: string;
+}) {
+  return (
+    <span className={`hero-avatar ${className}`} aria-hidden>
+      {avatarEmoji(avatar)}
+    </span>
+  );
+}

--- a/src/features/ui/CenteredModal.tsx
+++ b/src/features/ui/CenteredModal.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+/**
+ * Shared centered-dialog shell: full-screen dimmed overlay with a centered
+ * `panel` card. Used by the one-off kid-facing modals (sacrifice hint,
+ * collection-reward celebration). Callers own the panel contents and, where
+ * needed, the surrounding portal.
+ */
+export function CenteredModal({
+  children,
+  testId,
+  labelledBy,
+}: {
+  children: ReactNode;
+  testId: string;
+  labelledBy?: string;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={labelledBy}
+      data-testid={testId}
+    >
+      <div className="panel flex max-w-sm flex-col items-center gap-4 p-6 text-center">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/features/ui/ErrorBanner.tsx
+++ b/src/features/ui/ErrorBanner.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+/**
+ * Kid-facing error paragraph. Renders nothing when `message` is falsy, so
+ * callers can drop the surrounding `error ? ... : null` ternary. Defaults to
+ * the panel-styled banner; pass `className` to override for inline variants.
+ */
+export function ErrorBanner({
+  testId,
+  message,
+  className = "panel px-5 py-3 text-center text-sm text-red-300",
+}: {
+  testId: string;
+  message: ReactNode;
+  className?: string;
+}) {
+  if (!message) return null;
+  return (
+    <p data-testid={testId} className={className}>
+      {message}
+    </p>
+  );
+}

--- a/src/features/ui/styles.ts
+++ b/src/features/ui/styles.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared Tailwind class strings for cross-feature form controls.
+ * Kept here so the input styling changes in one place.
+ */
+
+/** Standard dark rounded text input (border + focus ring). */
+export const TEXT_INPUT_CLASS =
+  "rounded-xl border border-white/15 bg-black/25 px-4 py-2.5 text-[color:var(--ink)] outline-none transition focus:border-[color:var(--brand-1)] focus:ring-2 focus:ring-[color:var(--brand-1)]/40";

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -17,4 +17,12 @@ export const env = {
   get blobToken(): string {
     return required("BLOB_READ_WRITE_TOKEN");
   },
+  /**
+   * HMAC secret for signed offers and the admin gate cookie. Falls back to ""
+   * (rather than throwing) so signature verification simply fails on a missing
+   * secret instead of crashing the request.
+   */
+  get authSecret(): string {
+    return process.env.AUTH_SECRET ?? "";
+  },
 };

--- a/src/lib/form.ts
+++ b/src/lib/form.ts
@@ -1,0 +1,4 @@
+/** Read a form field as a string, defaulting a missing value to "". */
+export function field(formData: FormData, name: string): string {
+  return String(formData.get(name) ?? "");
+}

--- a/src/lib/math.ts
+++ b/src/lib/math.ts
@@ -1,0 +1,4 @@
+/** Constrain `value` to the inclusive `[min, max]` range. */
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,9 @@
+/**
+ * True when the OS asks for reduced motion. SSR-safe: returns false when there
+ * is no window/matchMedia so first render is stable. One-shot snapshot — for a
+ * live-updating value use features/anim/useReducedMotion.
+ */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || !window.matchMedia) return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}

--- a/src/lib/rng.ts
+++ b/src/lib/rng.ts
@@ -1,0 +1,33 @@
+import type { Rng } from "./logic";
+
+/**
+ * Shared deterministic RNG helpers (injectable rng ⇒ property-testable). All
+ * three primitives clamp against `rng()===1` so an out-of-range index can never
+ * be produced, and every consumer stays uniform.
+ */
+
+/** Random integer in `[min, max]` inclusive. Clamps against `rng()===1`. */
+export function randInt(rng: Rng, min: number, max: number): number {
+  return min + Math.min(max - min, Math.floor(rng() * (max - min + 1)));
+}
+
+/** Return a shuffled copy of `arr` (Fisher–Yates); the input is not mutated. */
+export function shuffle<T>(arr: readonly T[], rng: Rng): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = randInt(rng, 0, i);
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+/** Return up to `n` distinct random items from `arr` (partial Fisher–Yates). */
+export function sample<T>(arr: readonly T[], n: number, rng: Rng): T[] {
+  const a = [...arr];
+  const k = Math.min(n, a.length);
+  for (let i = 0; i < k; i++) {
+    const j = randInt(rng, i, a.length - 1);
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a.slice(0, k);
+}

--- a/src/lib/signed-token.ts
+++ b/src/lib/signed-token.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared HMAC-signed token primitive (Security). PURE + isomorphic (Web Crypto):
+ * signs an arbitrary JSON payload as `base64url(json).base64url(hmac)` so the
+ * server can prove it issued the exact payload, and verifies signature +
+ * expiry without carrying any secret. Backs pull/offer.ts and quiz/quiz-offer.ts.
+ * `secret` + `nowMs` are injected (kept pure/testable).
+ */
+
+/** Every signed payload carries an epoch-ms expiry the verifier enforces. */
+export interface SignedPayload {
+  exp: number;
+}
+
+function b64urlEncode(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function b64urlDecode(s: string): Uint8Array {
+  const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
+  const bin = atob(s.replace(/-/g, "+").replace(/_/g, "/") + pad);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+async function hmac(payload: string, secret: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload));
+  return new Uint8Array(sig);
+}
+
+function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+/** Sign a payload → `base64url(json).base64url(hmac)`. */
+export async function signToken<T extends SignedPayload>(
+  payload: T,
+  secret: string,
+): Promise<string> {
+  const json = JSON.stringify(payload);
+  const encoded = b64urlEncode(new TextEncoder().encode(json));
+  const sig = await hmac(json, secret);
+  return `${encoded}.${b64urlEncode(sig)}`;
+}
+
+/**
+ * Return the payload iff the signature is valid, its shape passes `isValid`,
+ * AND it is not expired; else null. `isValid` guards the payload-specific fields
+ * (the shared exp > nowMs check is applied here afterwards).
+ */
+export async function verifyToken<T extends SignedPayload>(
+  token: string | undefined | null,
+  secret: string,
+  nowMs: number,
+  isValid: (payload: unknown) => payload is T,
+): Promise<T | null> {
+  if (!token || !secret) return null;
+  const dot = token.indexOf(".");
+  if (dot <= 0) return null;
+
+  let json: string;
+  let providedSig: Uint8Array;
+  try {
+    json = new TextDecoder().decode(b64urlDecode(token.slice(0, dot)));
+    providedSig = b64urlDecode(token.slice(dot + 1));
+  } catch {
+    return null;
+  }
+
+  const expected = await hmac(json, secret);
+  if (!timingSafeEqual(expected, providedSig)) return null;
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (!isValid(payload)) return null;
+  return payload.exp > nowMs ? payload : null;
+}

--- a/src/lib/signed-token.ts
+++ b/src/lib/signed-token.ts
@@ -6,42 +6,11 @@
  * `secret` + `nowMs` are injected (kept pure/testable).
  */
 
+import { b64urlDecode, b64urlEncode, hmac, timingSafeEqual } from "./webcrypto";
+
 /** Every signed payload carries an epoch-ms expiry the verifier enforces. */
 export interface SignedPayload {
   exp: number;
-}
-
-function b64urlEncode(bytes: Uint8Array): string {
-  let bin = "";
-  for (const b of bytes) bin += String.fromCharCode(b);
-  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-function b64urlDecode(s: string): Uint8Array {
-  const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
-  const bin = atob(s.replace(/-/g, "+").replace(/_/g, "/") + pad);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
-}
-
-async function hmac(payload: string, secret: string): Promise<Uint8Array> {
-  const key = await crypto.subtle.importKey(
-    "raw",
-    new TextEncoder().encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload));
-  return new Uint8Array(sig);
-}
-
-function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) return false;
-  let diff = 0;
-  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
-  return diff === 0;
 }
 
 /** Sign a payload → `base64url(json).base64url(hmac)`. */

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,41 @@
+/**
+ * SSR- and private-mode-safe Web Storage access. The browser storage globals
+ * may be absent during SSR / node tests, and property access itself can throw
+ * when storage is blocked; every read/write swallows failures so a missing or
+ * blocked store is a silent no-op (get returns null, set does nothing).
+ */
+
+type StorageKind = "localStorage" | "sessionStorage";
+
+function resolveStorage(kind: StorageKind): Storage | null {
+  try {
+    const g = globalThis as {
+      localStorage?: Storage;
+      sessionStorage?: Storage;
+      window?: { localStorage?: Storage; sessionStorage?: Storage };
+    };
+    return g[kind] ?? g.window?.[kind] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function storageGet(kind: StorageKind, key: string): string | null {
+  const store = resolveStorage(kind);
+  if (!store) return null;
+  try {
+    return store.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function storageSet(kind: StorageKind, key: string, value: string): void {
+  const store = resolveStorage(kind);
+  if (!store) return;
+  try {
+    store.setItem(key, value);
+  } catch {
+    /* storage blocked (private mode / quota) — silent, non-fatal */
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,6 +3,12 @@
 export const RARITIES = ["common", "rare", "epic", "legendary"] as const;
 export type Rarity = (typeof RARITIES)[number];
 
+/** Fresh zeroed count-per-rarity map. Returns a new object each call so callers
+ * that mutate the tally in place don't share module-level state. */
+export function zeroRarityCount(): Record<Rarity, number> {
+  return { common: 0, rare: 0, epic: 0, legendary: 0 };
+}
+
 /** Drop weights for the pull distribution (BR1). Must sum to 100. */
 export const RARITY_WEIGHTS: Record<Rarity, number> = {
   common: 60,

--- a/src/lib/webcrypto.ts
+++ b/src/lib/webcrypto.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared low-level Web Crypto primitives (Security). PURE + isomorphic: works in
+ * Node and the Edge/middleware runtime. Backs the HMAC-signed token modules
+ * (signed-token.ts for pull/quiz offers, admin/gate-token.ts for the admin gate).
+ */
+
+/** Encode bytes as unpadded base64url. */
+export function b64urlEncode(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** Decode an unpadded base64url string back to bytes. */
+export function b64urlDecode(s: string): Uint8Array {
+  const pad = s.length % 4 === 0 ? "" : "=".repeat(4 - (s.length % 4));
+  const bin = atob(s.replace(/-/g, "+").replace(/_/g, "/") + pad);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/** HMAC-SHA256 of `payload` under `secret`, as raw bytes. */
+export async function hmac(payload: string, secret: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload));
+  return new Uint8Array(sig);
+}
+
+/** Constant-time byte comparison (no early return on mismatch). */
+export function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}


### PR DESCRIPTION
## What Changed

- Extracted ~30 shared helpers, components, and modules across the app to collapse byte-identical or structurally-identical duplication: DB readers (`findChildRow`, `getCardCount`, `addCardCopy`/`removeCardCopy`, `child-mapper`), auth/crypto primitives (`webcrypto`, `signed-token`, `env.authSecret`, `requireActivePlayer`), and shared utilities (`rng`, `clamp`, `field`, `storage`, `prefersReducedMotion`, `zeroRarityCount`).
- Consolidated pull/quiz service logic — unified special-egg/rarity-pick pull paths over shared `offerTicketEgg`/`eggOutcome`/`makeTicketEggOutcome` helpers, deduplicated ticket-column mapping, balance-column types, token grant/refund primitives, and atomic-spend branches.
- Deduplicated UI into reusable pieces (`CardImage`, `RarityThumb`, `AvatarBadge`, `CenteredModal`, `ErrorBanner`, `Stepper`, `useOneShotBurst`, `raritySlotClass`, `TEXT_INPUT_CLASS`) and collapsed repeated sound-cue/fanfare/envelope patterns in the audio layer.

## Risk Assessment

✅ Low: A large but disciplined pure-refactoring branch whose extractions I verified preserve semantics across the balance, DB-write, and HMAC/security-critical paths, with no behavior changes introduced.

## Testing

Baseline `vitest run` passes (99/99), confirming the extraction introduces no regression. Since no existing test exercised the profile DB-read paths, I wrote a temporary integration-style test that mocks the DB/cookies and drives the three real call sites (getChild, getActiveChild, setActiveProfile) through the new shared `findChildRow` reader — all 6 assertions pass, showing each site now issues a single findFirst, maps rows via toChild, handles the not-found path, and setActiveProfile still validates existence before setting the httpOnly cookie. Behavior is preserved end-to-end; the evidence transcript is saved and the transient test removed. No UI surface is involved (backend DB-read helper extraction), so no visual artifact applies.

<details>
<summary>Evidence: Shared findChildRow reader drives all 3 call sites (verbose test transcript)</summary>

<code>✓ findChildRow(id) issues one findFirst and returns the row&#10;✓ service.getChild routes through the reader and maps to Child&#10;✓ service.getChild returns null when the reader finds nothing&#10;✓ active-profile.getActiveChild reads cookie then routes through the reader&#10;✓ active-profile.setActiveProfile validates existence via the reader, then sets the cookie&#10;✓ active-profile.setActiveProfile rejects an unknown child (reader returns undefined)&#10;Test Files 1 passed (1) / Tests 6 passed (6)</code>

```text

 RUN  v2.1.9 /Users/selwynyeow/.no-mistakes/worktrees/fec4ed99f6f0/01KXWAD2A9NDB0NEYD3QQ45AXA

 ✓ tests/child-reads.evidence.test.ts > findChildRow is the single shared by-id reader (gnhf-43) > findChildRow(id) issues one findFirst and returns the row
 ✓ tests/child-reads.evidence.test.ts > findChildRow is the single shared by-id reader (gnhf-43) > service.getChild routes through the reader and maps to Child
 ✓ tests/child-reads.evidence.test.ts > findChildRow is the single shared by-id reader (gnhf-43) > service.getChild returns null when the reader finds nothing
 ✓ tests/child-reads.evidence.test.ts > findChildRow is the single shared by-id reader (gnhf-43) > active-profile.getActiveChild reads cookie then routes through the reader
 ✓ tests/child-reads.evidence.test.ts > findChildRow is the single shared by-id reader (gnhf-43) > active-profile.setActiveProfile validates existence via the reader, then sets the cookie
 ✓ tests/child-reads.evidence.test.ts > findChildRow is the single shared by-id reader (gnhf-43) > active-profile.setActiveProfile rejects an unknown child (reader returns undefined)

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  12:39:19
   Duration  440ms (transform 40ms, setup 0ms, collect 20ms, tests 180ms, environment 0ms, prepare 38ms)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node_modules/.bin/vitest run` — full suite, 99/99 pass, no regression across the codebase</code>
- <code>Wrote a temporary evidence test `tests/child-reads.evidence.test.ts` mocking `@/db`, `next/headers`, and the auth guard, then drove the three real call sites: `findChildRow(&#39;child-1&#39;)`, `service.getChild` (row→Child map + null path), `active-profile.getActiveChild` (cookie→reader), and `active-profile.setActiveProfile` (existence check → cookie set, plus unknown-child rejection) — 6/6 pass</code>
- <code>Confirmed each call site issues exactly one `findFirst` per lookup and setActiveProfile writes the httpOnly `activeChildId` cookie only when the reader finds a row</code>
- <code>Removed the transient evidence test afterward; `git status` clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
