### PR TITLE
perf: tighten Next.js image optimization config to cut transform costs

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,20 @@ const nextConfig: NextConfig = {
       // Seed-time image source (U3) — Pollinations.ai
       { protocol: "https", hostname: "image.pollinations.ai" },
     ],
+    // Card art in Blob is immutable, so cache each optimized variant for a
+    // year — avoids repeat transformations and cache writes on every request.
+    minimumCacheTTL: 31536000,
+    // Emit one format instead of the default avif+webp pair; halves the number
+    // of transformations per image.
+    formats: ["image/webp"],
+    // Every <Image> uses the default quality (75); allowlisting it keeps the
+    // transformation set from fanning out across arbitrary qualities.
+    qualities: [75],
+    // Cards are square thumbnails rendered at dim 110/200/256/512 (1x/2x).
+    // Trim the size allowlists to those widths so we don't cache-write the
+    // large default device sizes that these images never request.
+    imageSizes: [128, 256, 512],
+    deviceSizes: [640, 1080],
   },
   async rewrites() {
     return [


### PR DESCRIPTION
## Intent

Reduce Vercel Image Optimization costs for the kids-collection app. Card art is served from Vercel Blob and is immutable (images never change), and CardImage only ever renders square thumbnails at a small fixed set of sizes (dim 110/200/256/512, at 1x/2x DPR) with the default quality of 75. Following Vercel's 'Managing Image Optimization Costs' guidance, tighten next.config.ts images config: set minimumCacheTTL to 31536000 (1 year) so each optimized variant is reused rather than re-transformed/re-cached; emit only webp (formats:['image/webp']) instead of the default avif+webp pair to halve transformations per image; allowlist qualities:[75] since every <Image> uses the default quality; and trim imageSizes:[128,256,512] and deviceSizes:[640,1080] to match the actual thumbnail widths so the large default device sizes are never cache-written. This is a config-only change in next.config.ts; no component code changed. Verified locally: optimizer serves webp on Accept:image/webp, allowlists enforced (w=512&q=75 -> 200; q=40 and w=1920 -> 400).

## What Changed

- Configure the `images` block in `next.config.ts` for immutable Blob-served card art: set `minimumCacheTTL` to 31536000 (1 year) so each optimized variant is reused instead of re-transformed on every request.
- Emit only `image/webp` (dropping the default avif+webp pair) and allowlist `qualities: [75]` to match the single default quality every `<Image>` uses, halving and bounding transformations per image.
- Trim `imageSizes` to `[128, 256, 512]` and `deviceSizes` to `[640, 1080]` so the large default device sizes are never cache-written, matching the actual square-thumbnail widths (verified: `w=512&q=75` → 200, `q=40`/`w=1920` → 400; webp served on `Accept: image/webp`).

## Risk Assessment

✅ Low: Well-bounded, config-only change to next.config.ts whose trimmed size/quality/format allowlists fully cover every actual next/image call site with no broken variants, matching all required intent criteria.

## Testing

`Installed deps and ran the real Next.js image optimizer against a generated local test image, then exercised the exact acceptance matrix from the intent: allowlisted variants (w=128/256/512/1080, q=75) return HTTP 200 with content-type image/webp; webp is served even when the client also accepts avif (avif never emitted, matching formats:['image/webp']); disallowed quality q=40 and disallowed widths w=1920 and w=750 (former default deviceSizes now trimmed out) return HTTP 400. This reproduces the author's stated local verification (w=512&q=75->200, q=40->400, w=1920->400) end-to-end at the HTTP surface an end user's browser hits. The 1-year minimumCacheTTL is a CDN/server-side cache directive not surfaced in the dev browser Cache-Control header, so it was verified as present in next.config.ts rather than via a runtime header. Transient artifacts (test PNG, .next) removed; no source changes. Result: all criteria satisfied.`

<details>
<summary>Evidence: Image optimizer verification transcript</summary>

`Allowlisted (w=128/256/512/1080, q=75) -> HTTP 200 image/webp; avif+webp Accept -> webp; q=40 -> HTTP 400; w=1920 & w=750 -> HTTP 400`

```text
Next.js Image Optimizer verification — kids-collection (next.config.ts hardening)
Source image: /public/testcard.png (600x600), server: next dev (Next 15.5)
Config: formats=[image/webp], qualities=[75], imageSizes=[128,256,512], deviceSizes=[640,1080], minimumCacheTTL=31536000

--- Allowlisted variants: expect HTTP 200, content-type image/webp ---
w=512   q=75   Accept=image/avif,image/webp,*/*      -> HTTP 200  content-type=image/webp
w=1080  q=75   Accept=image/webp,*/*                 -> HTTP 200  content-type=image/webp
w=256   q=75   Accept=image/webp,*/*                 -> HTTP 200  content-type=image/webp
w=128   q=75   Accept=image/webp,*/*                 -> HTTP 200  content-type=image/webp

--- Quality NOT in allowlist qualities=[75]: expect HTTP 400 ---
w=512   q=40   Accept=image/webp,*/*                 -> HTTP 400  content-type=

--- Width NOT in trimmed allowlists (old default device size): expect HTTP 400 ---
w=1920  q=75   Accept=image/webp,*/*                 -> HTTP 400  content-type=
w=750   q=75   Accept=image/webp,*/*                 -> HTTP 400  content-type=

--- avif never emitted: client sends Accept avif+webp, optimizer returns webp ---
w=512   q=75   Accept=image/avif,image/webp,*/*      -> HTTP 200  content-type=image/webp
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm dev image optimizer HTTP checks`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
