### PR TITLE
docs(definition): apply Increment 25 write-backs

### DIFF
--- a/Product-Definition/features/difficulty-refresh/open-questions.md
+++ b/Product-Definition/features/difficulty-refresh/open-questions.md
@@ -11,7 +11,8 @@
 | Pre-declared during the interviews | 10 (7 business, 3 technical) |
 | Resolved inside the approval loops | **10** |
 | Raised at the join | **3** (J1–J3) |
-| **Open going into AI-DLC** | **3** |
+| **Open going into AI-DLC** | ~~3~~ → **0** |
+| **Closed at Requirements, 2026-08-08** | **3** (J1=a, J2=a, J3=recommended) + 2 new findings |
 
 ---
 
@@ -36,7 +37,7 @@ Recorded for traceability. None of these need AI-DLC's attention.
 
 ## Contradictions and gaps found at the join
 
-### ❗ J1 — **OPEN**: the seen-tracking design cannot be implemented as specified
+### ✅ J1 — **CLOSED (a)** 2026-08-08: the seen-tracking design cannot be implemented as specified
 
 **The technical document says** seen-rows are written on **submit**, not when the offer is minted
 (OQ-DR-T1), so an abandoned quiz burns nothing.
@@ -72,7 +73,7 @@ Three ways out, and the choice has a security dimension:
 server-authoritative record of what was served. Note it slightly enlarges every offer token (5 short
 ids), which is inert — the token is already carrying 5 answer strings.
 
-### ❗ J2 — **OPEN**: ticket-free replay undercuts the anti-memorisation fix at today's bank size
+### ✅ J2 — **CLOSED (a), accepted** 2026-08-08: ticket-free replay undercuts the anti-memorisation fix at today's bank size
 
 Two approved decisions collide, and the arithmetic matters.
 
@@ -114,7 +115,7 @@ Options:
 authoring follow-up slips. The claim in D6 should be **restated more precisely**: seen-tracking
 delivers most of its value at today's bank size *for the once-a-day path*, not under heavy replay.
 
-### ⚠️ J3 — **OPEN (confirm)**: the vision's scope list and the technical delivery plan disagree
+### ✅ J3 — **CLOSED** 2026-08-08: the vision's scope list and the technical delivery plan disagree
 
 `vision-document.md` lists **11 items IN the MVP**, including item 10: *"Grow six grammar banks to
 40–50 each — ~150–200 authored questions. The largest single piece of work."*
@@ -174,3 +175,39 @@ Recorded so they are not re-derived as problems later.
 2. **J3** — cheap to settle and it defines "done" for the increment.
 3. **J2** — no action needed to start; record the arithmetic and revisit if the authoring follow-up
    slips.
+
+
+---
+
+## Resolution — closed at Requirements Analysis, 2026-08-08
+
+Increment 25 shipped (PR #15). All three join questions are closed, and the join itself missed two
+things that only appeared when the code was read.
+
+| ID | Resolution |
+|---|---|
+| **J1** | **(a)** — `questionIds` joins the signed offer payload. Confirmed against the code first: `QuizOfferPayload` was `{childId, topic, answers, exp}` and submit was `(offer, picks)`, so the server genuinely could not name what it served. Guard treats the field as optional so a quiz begun before the deploy still submits |
+| **J2** | **(a)** — accepted, with the arithmetic recorded. **Sharpened**: `conjunctions` and `prepositions` hold **14** questions, not ~16, so they give **two** clean attempts before repeats, not three. Confirmed by observation against a real database, not by argument |
+| **J3** | Increment 25 = vision items 1–9 and 11. Item 10 (~150–200 authored questions) is in scope for the **feature**, delivered in a second PR |
+
+### Two contradictions the join did not catch
+
+**Finding A — the daily-three gate was specified in the wrong place.** Both documents put enforcement on
+the route, reasoning correctly that hiding topics in the picker is not enforcement because the URL is
+navigable — then stopped one step short. `startQuizAction` is a Server Action: a directly invocable POST
+taking the topic id from the client, so a page redirect is bypassed exactly as a picker is. The gate now
+sits in `buildQuiz`. **This strengthens D5/T5-i rather than implementing it.**
+
+**Finding B — D1's schema could not perform D1's own reset.** `(child_id, question_id, seen_at)` does not
+say which topic a question belongs to, so the approved per-topic exhaustion reset was not expressible;
+the `vt-`/`pp-` prefixes are a naming habit, not data. A `topic` column was added. It also dissolves a
+hazard nobody had noticed: a global key silently requires grammar ids to be unique across **all six**
+banks — true today only by convention, tested nowhere, and precisely what the ~200-question authoring
+follow-up would have broken, silently merging two children's seen-sets. **This corrects D1.**
+
+### And one the design got wrong, caught by a property test
+
+`D5`'s recipe — *"'exclude yesterday's' comes free — call the same function with `sgtDayKey - 1`"* — does
+not terminate: day D needs D−1, needs D−2, with no anchor. The first implementation hid the recursion one
+level down and failed on the property test's first run, repeating a grammar topic across a cycle
+boundary. Non-repetition is now structural. The outcome D5 wanted is preserved in full; its recipe is not.

--- a/Product-Definition/features/difficulty-refresh/technical-environment.md
+++ b/Product-Definition/features/difficulty-refresh/technical-environment.md
@@ -58,10 +58,17 @@ tests · Vercel · $0/month runtime cost.
 ### D1 — Seen-question tracking: a new table, reached through `QuizStore` (T1)
 
 ```
-quiz_seen_questions (child_id, question_id, seen_at)
-  UNIQUE (child_id, question_id)
+quiz_seen_questions (child_id, topic, question_id, seen_at)
+  PRIMARY KEY (child_id, topic, question_id)
   FK child_id → children(id) ON DELETE CASCADE     -- matches quiz_completions
 ```
+
+> ⚠️ **CORRECTED at Requirements, 2026-08-08 (Finding B).** As first written this table had no `topic`
+> column — and could not perform the per-topic reset specified two bullets below, because a row did not
+> say which topic its question belonged to. The `vt-`/`pp-` prefixes are a naming habit, not data.
+> Adding `topic` also removes a hazard: a `(child, question)` key silently requires grammar ids to be
+> unique across **all six** banks, which holds today only by convention and is tested nowhere — exactly
+> what the ~200-question authoring follow-up would have broken, silently merging two seen-sets.
 
 - **A new method on the existing `QuizStore`**, not a new port. Same aggregate, same lifecycle.
 - **Full seam treatment**: pg adapter + in-memory fake + an extension to
@@ -121,6 +128,15 @@ pure SGT-day reasoning. A function of `(childId, sgtDayKey)`.
   property that makes item 4 actually remove free choice.
 - **The route rejects, it does not merely omit** (T5-i): `/play/learn/[topicId]` refuses a topic outside
   today's three. Hiding the other seven in the picker is not enforcement — the URL is navigable.
+  > ⚠️ **CORRECTED at Requirements, 2026-08-08 (Finding A).** Right reasoning, one step short. The gate
+  > belongs in **`buildQuiz`**: `startQuizAction` is a Server Action — a directly invocable POST taking
+  > the topic id from the client — so a page redirect is bypassed exactly as a picker is by typing a URL.
+  > The route redirect is retained for UX; the service is the boundary.
+- **"Exclude yesterday's" is NOT free.** *"Call the same function with `sgtDayKey - 1`"* does not
+  terminate — day D needs D−1, needs D−2, with no anchor. Non-repetition is delivered structurally
+  instead: consecutive days take disjoint slices of one per-cycle permutation, and a cycle's last day is
+  never adjusted so its predecessor is reconstructible in O(1). Corrected at Construction after a
+  property test caught a grammar topic repeating across a cycle boundary.
 
 **Feasibility, checked during the interview:** the "≥1 maths" guarantee cannot be starved. There are
 **4 maths topics** and at most **3** are excluded as yesterday's, so at least one is always eligible —

--- a/Product-Definition/technical-environment.md
+++ b/Product-Definition/technical-environment.md
@@ -61,8 +61,8 @@ Scope: source code only. Config files (`.mjs`, `.json`) and generated output are
 | Next.js 15 (App Router) | Whole app — routing, Server Components, Server Actions, middleware | Maintain |
 | React 19 | UI layer; Server Components default | Maintain |
 | Tailwind CSS 4 | All styling; shared classes in `globals.css` | Maintain |
-| Drizzle ORM 0.36 + drizzle-kit 0.28 | All DB access; migrations 0000–0006 applied to prod | Maintain |
-| Neon Postgres 16 (`@neondatabase/serverless`) | Primary datastore — 6 tables | Maintain |
+| Drizzle ORM 0.36 + drizzle-kit 0.28 | All DB access; migrations 0000–0007 applied to prod | Maintain |
+| Neon Postgres (`@neondatabase/serverless`) | Primary datastore — **7 tables**. ⚠️ prod is **PG 17**, not 16; `test:pg` still runs PG16 | Maintain |
 | Auth.js / NextAuth 5.0.0-beta.25 | Parent Google OAuth | Maintain — **see OQ-T-3** |
 | Vercel Blob 0.27 | 300 card images | Maintain |
 | Zod 3 | Profile input + seed-file schema | Maintain |
@@ -144,7 +144,7 @@ The ways an AI agent most plausibly breaks this codebase *while writing perfectl
 | Service | Constraints / Notes |
 |---------|---------------------|
 | Vercel (hosting, Functions, Edge middleware) | Free tier. Production deploys only from the approved flow; no new paid add-ons. |
-| Neon Postgres | Free tier. Migrations 0000–0006 applied to prod — new migrations must preserve `collections`, `children` and `cards` data. |
+| Neon Postgres | Free tier. Migrations 0000–0007 applied to prod — new migrations must preserve `collections`, `children` and `cards` data. |
 | Vercel Blob | Free tier. Stores the 300 card images. Written by the seeding pipeline, never at runtime. |
 | Google OAuth (identity only) | Parent sign-in with an email allowlist. Identity provider only — not hosting or storage. |
 | PostHog | Analytics + error capture. **Session replay is restricted**: enabled only inside the child play area, `maskAllInputs: true`, `recordCrossOriginIframes: false`, off by default so parent/admin pages (including the passcode screen) are never recorded. **Any change to this scoping is a kid-safety decision, not a config tweak.** |
@@ -184,7 +184,7 @@ unauthenticated-by-default surface that has to re-implement the checks Server Ac
 **Relational / SQL only.**
 
 Postgres holds everything: `themes`, `cards`, `children`, `collections`, `quizCompletions`,
-`collectionRewards`. The guarantees protecting the children's data are relational features — CHECK
+`collectionRewards`, `quizSeenQuestions`. The guarantees protecting the children's data are relational features — CHECK
 constraints (`count >= 1`, non-negative ticket columns) and transactional batches for atomic trades.
 
 Explicitly **not** used: document store, key-value store, search index (300 cards need none), in-memory
@@ -314,7 +314,7 @@ contradictions**; this is a strict technical superset.
   `easter_egg_tickets_non_negative`, `epic_tickets_non_negative`, `lucky_tickets_non_negative`.
 - **`themes.sort_order`** — backfilled by migration 0006 to the exact order the children already saw.
   A contract, not a convenience.
-- **Migrations 0000–0006** — already applied to prod. Never edited in place; only added to.
+- **Migrations 0000–0007** — already applied to prod. Never edited in place; only added to.
 
 **Atomicity contracts** (proven by the dual-adapter contract suite)
 - `spendOne` returns null on guard failure — no double-spend.

--- a/Product-Definition/vision-document.md
+++ b/Product-Definition/vision-document.md
@@ -105,7 +105,9 @@ Grounded in the repository as of 2026-08-03 — 14 feature modules under `src/fe
 - **Sound** — SFX and BGM, rarity fanfares, dedicated easter-egg cue.
 - **Easter eggs** — ~1% pick-1-of-N epic+ offers, HMAC-signed and expiring so a claim can't be swapped.
 - **Quizzes / Learn** — educational questions with per-question feedback (correct/incorrect, the right
-  answer, and a "why"); award granted server-side via signed offer.
+  answer, and a "why"); award granted server-side via signed offer. **Ten topics** (4 maths, 6 grammar)
+  since Inc 25, of which **three are drawn per child per day** — free choice was removed deliberately.
+  Grammar questions a child has already answered are remembered and deprioritised.
 - **Trading** — atomic two-sided duplicate swap between two children; friend-first board that badges only
   what the other party lacks.
 - **Sacrifice** — burn 4+ copies (keep 1) for a rarity-pick ticket, same tier or one up, 50/50.
@@ -249,7 +251,14 @@ Next.js App Router + TypeScript + Tailwind application on Vercel, with Neon Post
   a trade must never half-apply.
 - **Server-authoritative awards via HMAC-signed offers.** Easter-egg picks and quiz awards are pinned in
   a signed, expiring offer so a claim cannot be swapped for an un-offered card. Client-side answer keys
-  exist for feedback only. Award decisions must never move to the client.
+  exist for feedback only. Award decisions must never move to the client. **Since Inc 25 the quiz offer
+  also pins the question ids served**, so which questions a child has seen is likewise server-stated —
+  a client cannot suppress it. Anything the server must trust about what it served belongs in the
+  signed payload, not in the submission.
+- **A client-supplied topic id is not a permission.** The daily three are enforced in `buildQuiz`, not
+  in the page. A Server Action is a directly invocable POST, so a route redirect is a courtesy and the
+  service is the boundary — the same reasoning that makes child profile selection not a security
+  boundary.
 - **`themes.sort_order` is a contract, not a convenience.** Backfilled in migration 0006 to the exact
   order the children already saw. Reordering silently reshuffles their world.
 - **The auth and safety boundary.** Parent Google OAuth + email allowlist is the only real boundary.


### PR DESCRIPTION
## Increment 25 write-backs

Migration `0007` is applied to production and #15 is deployed, so the definition should describe what is actually running rather than what was planned.

Docs only — no code, no tests, no schema.

### Parent definition

- **Quizzes / Learn**: ten topics (4 maths, 6 grammar), **three drawn per child per day**, grammar questions a child has already answered are remembered and deprioritised.
- **Two new entries under "What Must NOT Change"**, both learned the hard way in this increment:
  - The signed-offer invariant now covers **question ids as well as answer keys**. The general rule: anything the server must trust about *what it served* belongs in the signed payload, not in the submission. Increment 25 existed for three weeks as a design that could not be built because this wasn't true.
  - **A client-supplied topic id is not a permission.** The daily three are enforced in `buildQuiz`, not the page — a Server Action is a directly invocable POST, so a route redirect is a courtesy. Same shape as the existing rule that child profile selection is not a security boundary.
- 6 tables → **7**; migrations `0000–0006` → **`0000–0007`**.
- Records that **production Neon is PG17 while `test:pg` runs PG16**. Known since Increment 23 but it lived only in `aidlc-state.md`, where nobody writing a migration would look.

### Feature definition

- **J1, J2, J3 closed.** J2 is *sharpened*, not just accepted: `conjunctions` and `prepositions` hold **14** questions, not ~16, so they give **two** clean attempts before repeats rather than three. Confirmed by observation against a real database, not by argument.
- **D1 corrected** — the schema had no `topic` column and therefore could not perform the per-topic reset it specified two bullets further down.
- **D5 corrected twice** — the gate belongs in the service rather than the route, and *"'exclude yesterday's' comes free"* does not terminate.

Corrections are marked as corrections rather than quietly edited away, so the reasoning that turned out to be wrong stays visible next to what replaced it. A definition that only ever shows its final answers teaches nothing about how it got them.

### Still open after this

- Vision item 10 — growing the six grammar banks to 40–50 (~150–200 authored questions). Bound by **OQ-DR-T3**: ids may be added to, never renumbered, reused or removed.
- **OQ-T-2** — still no test CI, now carrying six more obligations.
- A tap-through of a fractions quiz as a signed-in child, the first day the topic comes up.
