### PR TITLE
Pin the toolchain in package.json; remove the hanging `lint` script

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -70,12 +70,11 @@ jobs:
         with:
           node-version: 24
 
+      # No version here on purpose: the action reads `packageManager` from
+      # package.json, so the pnpm running here is the exact one the developer
+      # ran. Pinning it again would give the repo two answers to one question.
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          # Required: package.json has no `packageManager` field, and the action
-          # refuses to guess. Matches the pnpm major used locally (10.x).
-          version: 10
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -66,9 +66,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Node version comes from `engines.node` in package.json rather than a
+      # literal here, for the same reason pnpm's does below: one source of
+      # truth. setup-node reads `volta.node`, then `devEngines.runtime`, then
+      # `engines.node` — we only set the last.
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version-file: package.json
 
       # No version here on purpose: the action reads `packageManager` from
       # package.json, so the pnpm running here is the exact one the developer

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@10.32.1",
+  "engines": {
+    "node": "24"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
Resolves #20. Part of #17 — the toolchain-hygiene change both CI workflows depend on.

Four small commits, each self-contained:

| | |
|---|---|
| `562c23e` | add `packageManager: "pnpm@10.32.1"` + `engines.node: "24"` |
| `c1c2e88` | remove the broken `lint` script |
| `19940c7` | drop `backup.yml`'s now-redundant pnpm pin |
| `2267578` | read Node from `engines.node` too (found in review — see below) |

## Why

**One source of truth for the toolchain.** `package.json` had neither field, which is why `backup.yml`
carried a `version: 10` pin and a comment apologising for it — an arbitrary 10.x, picked because
`pnpm/action-setup` refuses to guess, not because 10.x was verified. Both workflow declarations now read
from `package.json`, so CI installs the *exact* toolchain the developer runs. That is the point of a gate:
a gate testing a configuration nobody uses isn't testing anything.

**The `lint` script was a trap.** `next lint` is deprecated, and this repo has no ESLint config and no
ESLint dependency — so it never linted anything. What it actually does is drop into next's interactive
setup prompt. Verified both failure modes:

- with a TTY it **hangs** — `script -q /dev/null pnpm lint` had to be killed at 20s
- without one it **exits 1** with a half-drawn prompt in the log — `pnpm lint < /dev/null`

Wired into CI the first looks like a stuck runner and the second like a real lint failure. Neither is.
ESLint adoption is deliberately out of scope for the map, but leaving a booby-trapped script behind is
exactly the hazard that scope ruling must not create.

## The review caught this branch breaking its own rule

`19940c7`'s message argues that re-pinning pnpm "would give the repo two answers to one question" — while
`562c23e` had just created that second answer for **Node**: `engines.node: "24"` alongside a hardcoded
`node-version: 24`. Both review axes flagged it independently.

`2267578` fixes it with `node-version-file: package.json`. Verified against setup-node's own
[advanced-usage docs](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md): it reads
`volta.node`, then `devEngines.runtime`, then `engines.node` — only the last is set here. Behaviour is
unchanged, `24` resolved to the latest 24.x before and still does.

## Verification

- `pnpm install --frozen-lockfile` → clean, resolves **pnpm v10.32.1** exactly, **no engine warning**, **lockfile untouched**
- `pnpm typecheck` → clean
- `pnpm test` → **321 passed / 51 files**
- `pnpm lint` → `Command "lint" not found`
- `backup.yml` parses; step shape confirmed as `{"uses"=>"actions/setup-node@v4", "with"=>{"node-version-file"=>"package.json"}}`
- all four commits signature-verified (`git log --format='%G?'` → `G`)

`backup.yml` is the only existing workflow and it is unrun until tonight's schedule — the two changed steps
are `setup-node` and `action-setup`, both verified against the actions' own documentation rather than recall.

## Noted, not fixed — out of scope for this ticket

- **`@types/node: "^22.10.2"` vs `engines.node: "24"`.** Typechecking against a major the repo no longer
  targets. Real, but bumping it risks new type errors and belongs in its own change.
- **`packageManager` carries no integrity hash.** Corepack accepts `pnpm@10.32.1+sha512.<hash>`. Low impact
  here since `action-setup` installs pnpm directly rather than via corepack.
