### PR TITLE
Make `pg:up` fail when a migration fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:pg": "vitest run --config vitest.pg.config.ts",
-    "pg:up": "docker compose -f tests-pg/docker-compose.yml -p kc-pgtest up -d && until pg_isready -h localhost -p 5499 -U postgres -q; do sleep 0.5; done && for f in $(ls src/db/migrations/*.sql | sort); do PGPASSWORD=postgres psql -q -h localhost -p 5499 -U postgres -d main -v ON_ERROR_STOP=1 -f \"$f\"; done",
+    "pg:up": "docker compose -f tests-pg/docker-compose.yml -p kc-pgtest up -d && until pg_isready -h localhost -p 5499 -U postgres -q; do sleep 0.5; done && for f in src/db/migrations/*.sql; do PGPASSWORD=postgres psql -q -h localhost -p 5499 -U postgres -d main -v ON_ERROR_STOP=1 -f \"$f\" || exit 1; done",
     "pg:down": "docker compose -f tests-pg/docker-compose.yml -p kc-pgtest down -v",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",


### PR DESCRIPTION
Closes #28. Blocks #22.

## What was wrong

`pg:up` applies migrations in a `for` loop. `-v ON_ERROR_STOP=1` was already doing its job — each `psql`
exits non-zero on a bad migration — but POSIX gives a `for` loop the exit status of its **last** command. So
with 8 migrations, a failure in `0003` followed by a success in `0007` left `pg:up` **exiting 0 on a
half-migrated database**.

The same clause meant an empty glob passed silently too.

## Proof

Old and new loop bodies run under `sh` against a real container, with a deliberately broken migration wedged
in at `0003a`:

| case | old | new |
|---|---|---|
| broken migration mid-sequence | **exit 0** ← the bug | exit 1 |
| empty glob | **exit 0** | exit 1 |

Clean run unchanged: `pg:up` exits 0, all 8 migrations applied, `pnpm test:pg` still 47 passed / 3 skipped.

## Why it lands before the `test:pg` gate, not after

Today this misleads one developer at a keyboard, who will probably notice when tests fail strangely. Once
#22 lands it misleads a **required check**: a broken migration would produce a green `test:pg` against a
partially built schema. That is exactly the "something checked" lie the CI effort exists to stop — a harness
is not evidence unless the harness is honest.

## On dropping `$(ls ... | sort)`

POSIX pathname expansion is already sorted, and these names are `NNNN_ascii`, so ordering is stable in any
locale. The round-trip through `ls` bought nothing and cost two things: it word-split the filenames (the
`"$f"` quoting came too late to help), and it is what made the no-match case pass silently.

`pg:up` is the only script in `package.json` with a loop, so nothing else shares this shape.

## Noted, deliberately not fixed here

`until pg_isready ...; do sleep 0.5; done` has no timeout. It is a hang, not a false-pass, so it is out of
this ticket's scope — but on a runner it is a 6-hour job and a required check that never reports. The gate
job in #22 wants `timeout-minutes`.