### PR TITLE
Raise fast-check `numRuns` in CI via `FC_NUM_RUNS`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,12 +120,32 @@ jobs:
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm typecheck
 
-      # 321 tests across 51 files, 22 of them property-based. This step has no
-      # `env:` block, and that is the point: the suite is verified to pass with
-      # every environment variable unset, so there is nothing here to configure
-      # wrong and nothing to leak.
+      # 321 tests across 51 files, 22 of them property-based, and 182 `fc.assert`
+      # call sites. The suite still passes with every environment variable unset
+      # — the one below only makes the search deeper, never makes it possible.
+      #
+      # 1000 is ten times fast-check's default, so this run explores ~182,000
+      # cases rather than ~18,200. Property-Based Testing is a *blocking*
+      # constraint (OQ-T-2), and mechanising a shallow search would close that
+      # question only nominally. The runner is where depth is free: nobody is
+      # waiting on it, and `pg-gate` sets the PR's wall-clock at ~2m30s either
+      # way, so `fast-gate` has roughly 90s of slack before this could cost
+      # anyone a second.
+      #
+      # Measured local cost, whole suite: unset 3.17s, 500 3.66s, 1000 4.19s,
+      # 2000 5.42s, 5000 8.66s, 10000 15.33s. All green — the properties held to
+      # 10,000 runs each, so raising this further is a one-line change with a
+      # known price. 1000 is chosen over 10000 because most arbitraries here are
+      # small and bounded (`fc.integer({min:0,max:60})`, arrays of at most 5), so
+      # the tail is mostly re-sampling, and the slack is better kept for `build`.
+      #
+      # Reproduce any CI-only failure locally with `FC_NUM_RUNS=1000 pnpm test`.
+      # A malformed value throws — see tests/setup.ts for why that matters more
+      # than it looks.
       - name: Unit and property-based tests
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
+        env:
+          FC_NUM_RUNS: 1000
         run: pnpm test
 
       # The only gate needing any environment at all, and a fake satisfies it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,12 @@
 # on `main`, which is a repository setting rather than anything committed here.
 # Until that is switched on, this workflow reports and nothing more.
 #
-# No secrets, deliberately. The repository is public, and every gate below is
-# verified to pass with the environment completely empty apart from the one
-# obviously-fake `.invalid` URL in the Build step — the only `env:` in this file.
-# (pg-gate needs no `env:` at all: its connection details are committed in
-# tests-pg/setup.ts and tests-pg/docker-compose.yml, and point at a throwaway
+# No secrets, deliberately. The repository is public, and every gate below still
+# passes with the environment completely empty. There are exactly two `env:`
+# blocks in this file and neither is a credential: an obviously-fake `.invalid`
+# URL that `next build` only parses, and FC_NUM_RUNS, which makes the property
+# search deeper but never makes it possible. (pg-gate has no `env:` at all — its
+# connection details are committed in tests-pg/, and point at a throwaway
 # container this workflow starts.) A workflow that holds no secret cannot leak
 # one, which beats being careful with it. In particular NOTHING here may reach
 # the production database.
@@ -120,12 +121,12 @@ jobs:
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm typecheck
 
-      # 321 tests across 51 files, 22 of them property-based, and 182 `fc.assert`
+      # 321 tests across 51 files, 22 of them property-based, and 100 `fc.assert`
       # call sites. The suite still passes with every environment variable unset
       # — the one below only makes the search deeper, never makes it possible.
       #
-      # 1000 is ten times fast-check's default, so this run explores ~182,000
-      # cases rather than ~18,200. Property-Based Testing is a *blocking*
+      # 1000 is ten times fast-check's default, so this run explores ~100,000
+      # cases rather than ~10,000. Property-Based Testing is a *blocking*
       # constraint (OQ-T-2), and mechanising a shallow search would close that
       # question only nominally. The runner is where depth is free: nobody is
       # waiting on it, and `pg-gate` sets the PR's wall-clock at ~2m30s either

--- a/tests-pg/setup.ts
+++ b/tests-pg/setup.ts
@@ -1,5 +1,4 @@
 import { neonConfig } from "@neondatabase/serverless";
-import fc from "fast-check";
 
 /**
  * Point the neon-http driver at the local proxy (docker: postgres + neon HTTP
@@ -13,6 +12,14 @@ neonConfig.poolQueryViaFetch = true;
 process.env.DATABASE_URL = "postgres://postgres:postgres@localhost:5499/main";
 process.env.AUTH_SECRET ??= "test-secret-key";
 
-// Each property run truncates + reseeds a real DB over HTTP — keep the count
-// modest so the round-trips stay quick.
-fc.configureGlobal({ numRuns: 10 });
+// No `fc.configureGlobal` here, deliberately: this suite runs NO properties.
+// Every `it.runIf(properties)` in the shared contracts is switched off by the
+// `{ properties: false }` each tests-pg entry point passes, which is the whole
+// of the "47 passed | 3 skipped" — so nothing in this run reaches `fc.assert`
+// and a numRuns set here would configure nothing. It previously did, and read
+// as though the pg suite were fuzzing at a low count.
+//
+// If properties are ever switched on for the pg adapters, set a LOW count here
+// rather than inheriting: each run truncates and reseeds a real database over
+// HTTP, so the round-trips, not the search, are the cost. Depth for the suite
+// that actually fuzzes lives in tests/setup.ts, via FC_NUM_RUNS.

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -21,14 +21,16 @@ import fc from "fast-check";
 const configured = process.env.FC_NUM_RUNS;
 
 if (configured !== undefined && configured !== "") {
-  const numRuns = Number(configured);
-
-  if (!Number.isInteger(numRuns) || numRuns < 1) {
+  // Decimal digits only, so the check means what the message says. `Number()`
+  // alone would quietly accept `1e3`, `0x10`, `0b101`, `+100`, `" 100 "` and
+  // `100.0` — all "valid" to Number.isInteger, none of them something anyone
+  // meant to write in a workflow file.
+  if (!/^[0-9]+$/.test(configured) || Number(configured) < 1) {
     throw new Error(
-      `FC_NUM_RUNS must be a positive integer; got ${JSON.stringify(configured)}. ` +
-        `Leave it unset for fast-check's default of 100.`,
+      `FC_NUM_RUNS must be a positive integer in plain decimal digits; ` +
+        `got ${JSON.stringify(configured)}. Leave it unset for fast-check's default of 100.`,
     );
   }
 
-  fc.configureGlobal({ numRuns });
+  fc.configureGlobal({ numRuns: Number(configured) });
 }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,34 @@
+import fc from "fast-check";
+
+/**
+ * Property-search depth for `pnpm test`, controlled by FC_NUM_RUNS.
+ *
+ * Unset — the local default — leaves fast-check on its own default of 100 cases
+ * per property, which keeps the inner loop at a few seconds. CI sets it higher
+ * (see .github/workflows/ci.yml): nobody is waiting on a runner, and a blocking
+ * constraint deserves the deeper search where the deeper search is free.
+ *
+ * There is deliberately no `process.env.CI` branch. CI=true is set by every CI
+ * system and by some local tooling, so a CI-sniffing default would silently
+ * change what a developer's run means. An explicit variable, set in one visible
+ * place, also means `FC_NUM_RUNS=1000 pnpm test` reproduces a CI failure exactly.
+ *
+ * A malformed value THROWS rather than falling back. `numRuns: NaN` makes
+ * fast-check run each property zero times and report a pass — a suite that
+ * claims 321 green while checking nothing, which is the precise failure this
+ * repo's CI work exists to prevent. Better to fail the run loudly.
+ */
+const configured = process.env.FC_NUM_RUNS;
+
+if (configured !== undefined && configured !== "") {
+  const numRuns = Number(configured);
+
+  if (!Number.isInteger(numRuns) || numRuns < 1) {
+    throw new Error(
+      `FC_NUM_RUNS must be a positive integer; got ${JSON.stringify(configured)}. ` +
+        `Leave it unset for fast-check's default of 100.`,
+    );
+  }
+
+  fc.configureGlobal({ numRuns });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,5 +10,8 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts"],
+    // Property-search depth only; see tests/setup.ts. Nothing here needs a
+    // database — that is vitest.pg.config.ts's job.
+    setupFiles: ["./tests/setup.ts"],
   },
 });


### PR DESCRIPTION
Closes #25. Part of #17.

### This ticket was pointing at the wrong file

#25 was charted as "raise `fc.configureGlobal({ numRuns: 10 })` in `tests-pg/setup.ts`". Working #22 established that **that line was dead code**: all three property tests in the pg suite are `it.runIf(properties)`, switched off by `{ properties: false }` at each entry point, so nothing in `pnpm test:pg` ever reaches `fc.assert`. It read as though the pg suite were fuzzing at a low count. It was fuzzing at no count.

The suite that actually fuzzes — `pnpm test`, 22 `*.pbt.test.ts` files, **100 `fc.assert` call sites** — had no override at all and ran at fast-check's default of 100.

So the raise lands on `fast-gate`, not `pg-gate`, and this no longer depends on #22's containers.

### Mechanism

`tests/setup.ts`, new, wired as the default config's `setupFiles`, reading **`FC_NUM_RUNS`**:

- **unset locally** → fast-check's default of 100, inner loop stays ~3s
- **`1000` in CI** → ~100,000 cases per run instead of ~10,000

No `process.env.CI` branch, deliberately: `CI=true` is set by every CI system and some local tooling, so a CI-sniffing default would silently change what a developer's run means. An explicit variable also means `FC_NUM_RUNS=1000 pnpm test` reproduces a CI-only failure exactly.

### Measured cost (whole suite, local)

| `FC_NUM_RUNS` | duration |
|---|---|
| unset (100) | 3.17s |
| 500 | 3.66s |
| 1000 | **4.19s** |
| 2000 | 5.42s |
| 5000 | 8.66s |
| 10000 | 15.33s |

**All green at every value.** The properties held to 10,000 runs each — ~1M executions — so no actual failure was surfaced, and raising further later is a one-line change at a known price.

1000 over 10000 because most arbitraries here are small and bounded (`fc.integer({min:0,max:60})`, arrays of at most 5), so the tail is mostly re-sampling. And `pg-gate` sets the PR's wall-clock at ~2m30s regardless, so `fast-gate` (53s) has ~90s of slack — this costs nobody a second either way.

### A malformed value throws, and that matters more than it looks

`fc.configureGlobal({ numRuns: NaN })` calls the predicate **zero times** and `fc.assert` **does not throw** — verified against a property that always returns `false`, which "passed". A typo like `FC_NUM_RUNS=1oo` would have produced a fully green 321-test suite that checked nothing. That is precisely the dishonest harness this map exists to prevent, so the guard fails the run loudly instead.

### Review caught (fixed in `befb342`)

- **The case-count arithmetic was wrong by ~1.8×.** I counted 182 `fc.assert` sites; the real number is **100**. The count had globbed `tests/*.pbt.test.ts` and `tests/**/*.pbt.test.ts` together, counting all 22 files twice. Both axes flagged it independently.
- **The file header still claimed the Build step held "the only `env:` in this file"** — untrue the moment `FC_NUM_RUNS` was added.
- **The guard was looser than its own message.** `Number.isInteger` accepted `1e3`, `0x10`, `0b101`, `+100`, `" 100 "`, `100.0`. Now plain decimal digits only.

### Also

Removes the dead `numRuns: 10` from `tests-pg/setup.ts` (and its now-unused `fc` import), keeping a comment recording the condition under which a low count there would be right again — the round-trips, not the search, are that suite's cost. Verified `pnpm test:pg` still reports `47 passed | 3 skipped`.

### Left to record

Local numbers only so far; `pnpm test` was **8s** on `fast-gate` before this. The runner figure from this PR gets recorded on #25 before it closes, the way #21 and #22 recorded theirs.