### PR TITLE
Bump the GitHub Actions off the deprecated Node 20 majors

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -64,21 +64,37 @@ jobs:
         ORDER BY 1, 2;
 
     steps:
-      - uses: actions/checkout@v4
+      # Majors are kept level with ci.yml, and moved with it in one commit (#31)
+      # — this preamble is duplicated across the two files on purpose, so two
+      # different answers to "which checkout?" would be the failure mode. The
+      # v4 line ran Node 20, which GitHub had already begun force-running on
+      # Node 24 while warning about it on every run.
+      - uses: actions/checkout@v7
 
       # Node version comes from `engines.node` in package.json rather than a
       # literal here, for the same reason pnpm's does below: one source of
       # truth. setup-node reads `volta.node`, then `devEngines.runtime`, then
-      # `engines.node` — we only set the last.
-      - uses: actions/setup-node@v4
+      # `engines.node` — we only set the last. Still true on v7.
+      #
+      # `package-manager-cache: false` because v5 added automatic caching for
+      # any package.json carrying `packageManager`, and for pnpm that shells out
+      # to a pnpm that this step has not installed yet. v6 narrowed the automatic
+      # case to npm, so the default is already off here — this states it rather
+      # than depending on it. It matters more in this file than in ci.yml: this
+      # job holds a production credential, and GitHub's own guidance is to turn
+      # automatic caching off in workflows with access to sensitive information.
+      - uses: actions/setup-node@v7
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       # No version here on purpose: the action reads `packageManager` from
       # package.json, so the pnpm running here is the exact one the developer
       # ran. Pinning it again would give the repo two answers to one question.
+      # Not the successor `pnpm/setup`, which requires pnpm v11 and this repo is
+      # on 10.32.1.
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - run: pnpm install --frozen-lockfile
 
@@ -139,8 +155,14 @@ jobs:
           ls -lh dump-*.sql.gz
         shell: bash
 
+      # Bumped with the rest (#31) even though it is not in ci.yml and so never
+      # appeared in the deprecation warning that started that ticket: v4 is the
+      # same Node 20 line, and this is the only step standing between a dump
+      # that exists and a dump anyone can retrieve. v7 changes nothing used
+      # here — it adds an `archive:` input for unzipped single-file uploads,
+      # which a `.sql.gz` does not want.
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: db-backup-${{ github.run_id }}
           path: dump-*.sql.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,9 @@ on:
 # an omission. backup.yml sets `cancel-in-progress: false`, which is right for a
 # backup — never abandon a half-finished dump — and probably wrong for a PR gate,
 # where a superseded push just burns a runner. Which way to go depends on how
-# long a run actually takes, so it is deferred until this has some runs behind
-# it. See "Not yet specified" on the map (#17).
+# long a run actually takes, so it was deferred until this had some runs behind
+# it. It now does (fast-gate ~57s, pg-gate ~2m30s), and the question is a live
+# ticket — #32 — rather than fog on the map.
 
 # Read-only. This workflow inspects the code; it never writes to the repo, posts
 # a comment, or publishes a package. Narrow it here rather than relying on the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,11 +99,12 @@ jobs:
       # something the developer never installed is the whole class of bug this
       # closes.
       #
-      # No dependency cache yet. Install is comfortably the largest cost in this
-      # job, so whether `actions/cache` earns its keep is a real question — but
-      # it is one to answer against a measured number, and caching next to
-      # `--frozen-lockfile` carries its own correctness risk. See "Not yet
-      # specified" on the map (#17).
+      # No dependency cache, and that question is CLOSED rather than deferred.
+      # The prediction when this file landed was that install would dominate the
+      # job; the first real run measured it at 4s of a 57s total, with `build`
+      # taking 30s. There is nothing there for `actions/cache` to win, and
+      # caching next to `--frozen-lockfile` carries its own correctness risk.
+      # Reopen it only against a new measurement, not against the intuition.
       - name: Install dependencies
         id: install
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ on:
 # backup — never abandon a half-finished dump — and probably wrong for a PR gate,
 # where a superseded push just burns a runner. Which way to go depends on how
 # long a run actually takes, so it was deferred until this had some runs behind
-# it. It now does (fast-gate ~57s, pg-gate ~2m30s), and the question is a live
+# it. It now does (fast-gate ~1m, pg-gate ~2m30s), and the question is a live
 # ticket — #32 — rather than fog on the map.
 
 # Read-only. This workflow inspects the code; it never writes to the repo, posts
@@ -128,10 +128,11 @@ jobs:
       #
       # No dependency cache, and that question is CLOSED rather than deferred.
       # The prediction when this file landed was that install would dominate the
-      # job; the first real run measured it at 4s of a 57s total, with `build`
-      # taking 30s. There is nothing there for `actions/cache` to win, and
-      # caching next to `--frozen-lockfile` carries its own correctness risk.
-      # Reopen it only against a new measurement, not against the intuition.
+      # job. It does not: install is 4s, and has stayed 4s across every run since
+      # — of a 57s job then and a ~69s job now, where `build` is 30s and the
+      # property search is ~20s. There is nothing there for `actions/cache` to
+      # win, and caching next to `--frozen-lockfile` carries its own correctness
+      # risk. Reopen it against a new measurement, not against the intuition.
       - name: Install dependencies
         id: install
         run: pnpm install --frozen-lockfile
@@ -224,7 +225,7 @@ jobs:
       - uses: actions/checkout@v7
 
       # Same three setup steps as fast-gate, and deliberately not factored out:
-      # a composite action or a reusable workflow would trade ten duplicated
+      # a composite action or a reusable workflow would trade nine duplicated
       # lines for a second file to keep in sync, and these are the lines whose
       # whole purpose is to have one obvious answer. See fast-gate above for why
       # neither step carries a version literal, why `package-manager-cache` is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,29 +70,55 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      # Action majors are the LATEST, not the oldest that works, and that is the
+      # posture rather than an accident of when this was written. GitHub retires
+      # the Node runtime under an action on its own schedule: everything here was
+      # on the v4 line running Node 20, which GitHub had already begun
+      # force-running on Node 24 with a deprecation warning on every run. A
+      # required check is the worst place to discover that a forced runtime has
+      # stopped being forced, because the check that would fail is the one
+      # blocking the fix. Bumped in #31; re-check when a warning next appears.
+      - uses: actions/checkout@v7
 
       # Both toolchain versions come from package.json — `engines.node` here and
       # `packageManager` for pnpm below — rather than literals in this file, so a
       # developer bumping either one does not have to remember this file exists.
+      # `node-version-file: package.json` still resolves `engines.node` on v7:
+      # the action checks `volta.node`, then `devEngines.runtime`, then
+      # `engines.node`, and this repo sets only the last.
       #
       # Carry one caveat: `engines.node` is advisory. With no `.npmrc` setting
       # `engine-strict`, pnpm warns and exits 0 on a mismatch. It pins what CI
       # *installs*; it stops nothing.
-      - uses: actions/setup-node@v4
+      #
+      # `package-manager-cache: false` is the one input this bump ADDED, and it
+      # is deliberate rather than cargo-culted. setup-node v5 started caching
+      # automatically whenever package.json has a `packageManager` field — which
+      # this repo has — and for pnpm that means shelling out to pnpm to locate
+      # the store, from a step that runs BEFORE pnpm is installed. v6 narrowed
+      # the automatic case to npm only, so on v7 the default is already off
+      # here; this says so out loud instead of resting on a third party's
+      # default staying narrow. It is also just true: caching was measured and
+      # rejected (see the install step below).
+      - uses: actions/setup-node@v7
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       # No `version:` on purpose — the action reads `packageManager`, so the pnpm
       # running here is the exact one the developer ran. Pinning it again would
       # give the repo two answers to one question.
       #
+      # Still `pnpm/action-setup` and not its successor `pnpm/setup`: that one
+      # requires pnpm v11 or newer, and `packageManager` here is pnpm 10.32.1.
+      # It becomes the right answer if and when this repo moves to pnpm 11.
+      #
       # Note the order: setup-node runs BEFORE this, which is only safe because
-      # setup-node has no `cache:` key. `cache: pnpm` shells out to pnpm to
-      # locate the store, so adding it means pnpm has to be installed first.
-      # Whoever acts on the caching note below must swap these two steps.
+      # setup-node caches nothing — no `cache:` key, and `package-manager-cache`
+      # explicitly off above. Any form of pnpm-store caching shells out to pnpm
+      # to locate the store, so turning one on means swapping these two steps.
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       # `--frozen-lockfile` turns a lockfile that disagrees with package.json
       # into a failure rather than a silent re-resolution — CI installing
@@ -194,19 +220,28 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Same three setup steps as fast-gate, and deliberately not factored out:
-      # a composite action or a reusable workflow would trade eight duplicated
+      # a composite action or a reusable workflow would trade ten duplicated
       # lines for a second file to keep in sync, and these are the lines whose
       # whole purpose is to have one obvious answer. See fast-gate above for why
-      # neither step carries a version literal.
-      - uses: actions/setup-node@v4
+      # neither step carries a version literal, why `package-manager-cache` is
+      # off, and why the action majors are the latest ones.
+      #
+      # The duplication has a bound, and it is checked rather than assumed: this
+      # preamble appears in exactly three places (both jobs here and backup.yml),
+      # it changed in all three in one commit (#31), and a mismatch between them
+      # is visible in a single `grep -rn 'uses:' .github/workflows`. That is a
+      # cheaper guarantee than a fourth file that can silently drift from what
+      # every job actually runs.
+      - uses: actions/setup-node@v7
         with:
           node-version-file: package.json
+          package-manager-cache: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Closes #31. Part of #17.

## What moved

| action | was | now | why v-latest |
|---|---|---|---|
| `actions/checkout` | v4 | **v7** | v5 moved to Node 24 |
| `actions/setup-node` | v4 | **v7** | v5 moved to Node 24 |
| `pnpm/action-setup` | v4 | **v6** | v5 moved to Node 24 |
| `actions/upload-artifact` | v4 | **v7** | v6 moved to Node 24 (`backup.yml` only) |

Every v4 line runs on Node 20. GitHub is already force-running them on Node 24
and warning on every run:

```
##[warning]Node.js 20 is deprecated. The following actions target Node.js 20 but
are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4,
pnpm/action-setup@v4.
```

This is housekeeping right up until it isn't. `fast-gate` and `pg-gate` are the
two required checks in the ruleset from #24, so when the forcing stops, the break
lands in the one position where a broken check blocks its own fix.

`upload-artifact` was **not** in that warning — it only appears in `backup.yml`,
which has not run since — but it is the same Node 20 line, and it is the single
step standing between a dump existing and a dump being retrievable. Same class,
same commit.

Both workflows move together in one commit: they duplicate the same
checkout/setup-node/pnpm preamble, and leaving them on different majors is the
two-answers-to-one-question drift #20 just finished removing from the toolchain.

## Two behaviour changes across the jump, checked rather than assumed

**setup-node v5 added automatic caching**, triggered by a `packageManager` field
in `package.json` — which this repo has. For pnpm that means shelling out to pnpm
to locate the store, from a step that runs *before* pnpm is installed. v6 then
narrowed the automatic case to **npm only**, so on v7 it is already off here.
The explicit `package-manager-cache: false` states that rather than resting on a
third party's default staying narrow, and it agrees with the measured answer:
caching buys nothing against a 4s install.

**`node-version-file: package.json` still resolves `engines.node`** on v7 — the
action checks `volta.node`, then `devEngines.runtime`, then `engines.node`, and
only the last is set here. No code change needed, just the number.

## Not moved

`pnpm/action-setup` now advertises a successor, `pnpm/setup`, which installs pnpm
as a standalone binary and can replace `actions/setup-node` outright. It requires
**pnpm v11+**, and `packageManager` here is `pnpm@10.32.1`. Recorded in a comment
so it is a known door rather than a rediscovery.

## Two stale comments, fixed in their own commits

Both are pointers into the map that stopped being true, which is the quiet kind
of rot this workflow exists to avoid:

- The dependency-cache note deferred the question to the map's *Not yet specified*
  and rested on "install is comfortably the largest cost in this job". #21's first
  real run measured install at **4s of 57s**, with `build` at 30s. The question is
  closed, not deferred.
- The concurrency note also pointed at the map's fog. That patch graduated into
  **#32** once there were runtimes to decide against.

## Verification

- `fast-gate` and `pg-gate` on this PR exercise the bumped `checkout`,
  `setup-node` and `pnpm/action-setup` directly.
- **Job ids are untouched**, so the `fast-gate` / `pg-gate` strings the ruleset
  requires still resolve — a rename here would leave both required checks waiting
  forever.
- `backup.yml` is scheduled and will not prove itself on this PR. It gets a
  `workflow_dispatch` run against this branch, reported in a comment below before
  merge.