### PR TITLE
ci: cancel superseded PR runs, never cancel a run on `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,13 +37,42 @@ on:
   push:
     branches: [main]
 
-# There is no `concurrency:` block here yet, and that is a decision rather than
-# an omission. backup.yml sets `cancel-in-progress: false`, which is right for a
-# backup — never abandon a half-finished dump — and probably wrong for a PR gate,
-# where a superseded push just burns a runner. Which way to go depends on how
-# long a run actually takes, so it was deferred until this had some runs behind
-# it. It now does (fast-gate ~1m, pg-gate ~2m30s), and the question is a live
-# ticket — #32 — rather than fog on the map.
+# A superseded run is abandoned on a PR and never on `main`. Those are opposite
+# answers to one question, which is why both keys below are expressions rather
+# than the flat literals backup.yml can afford (`group: backup`, never cancel).
+#
+# The PR half is settled by the runtimes this block waited on: fast-gate ~69s,
+# pg-gate ~2m30s. A run against a commit nobody will merge spends a couple of
+# minutes of a free runner deciding something no one will read, and the newest
+# push is the only one whose verdict can matter. Cheap to cancel, worth nothing
+# to finish.
+#
+# `main` is the reverse: every commit there must keep its own recorded verdict.
+# A cancelled run leaves a commit in history that CI never judged — the "nobody
+# actually checked" hole this whole file exists to close.
+#
+# So for a push the group is keyed on the COMMIT, and that is deliberate rather
+# than the obvious `github.ref`. `cancel-in-progress` governs only the RUNNING
+# member of a group; a *pending* one is a separate rule — "any existing pending
+# job or workflow in the same concurrency group will be canceled and the new
+# queued job or workflow will take its place" — and it applies whatever the flag
+# says. A branch-keyed group puts every main push in one group, so three merges
+# inside one pg-gate would cancel the middle commit's run while it queued, by
+# exactly the mechanism this block was added to prevent. Keyed per commit the
+# group has one possible member, so nothing on `main` ever queues and nothing is
+# ever cancelled. (`queue: max` would also fix it, but it cannot be combined with
+# `cancel-in-progress: true`, and the PR half needs true.)
+#
+# Cancelling is safe against branch protection only because it can never touch a
+# SHA a rule is still looking at: the push that triggers the new run is the same
+# push that stopped the old commit being the PR head, and the rule evaluates the
+# head. This is worth stating because a cancelled required check does NOT merely
+# fail to report — `cancelled` is not among the successful/skipped/neutral
+# conclusions protection accepts, so it blocks. That is the cost the `main` half
+# is keyed to avoid, not a risk it was talked out of.
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Read-only. This workflow inspects the code; it never writes to the repo, posts
 # a comment, or publishes a package. Narrow it here rather than relying on the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,14 @@ on:
 # A superseded run is abandoned on a PR and never on `main`. Those are opposite
 # answers to one question, which is why both keys below are expressions rather
 # than the flat literals backup.yml can afford (`group: backup`, never cancel).
+# This block was deliberately absent when the file landed, because choosing
+# either way needed runtimes nobody had yet; settled in #32 once they existed.
 #
-# The PR half is settled by the runtimes this block waited on: fast-gate ~69s,
-# pg-gate ~2m30s. A run against a commit nobody will merge spends a couple of
-# minutes of a free runner deciding something no one will read, and the newest
-# push is the only one whose verdict can matter. Cheap to cancel, worth nothing
-# to finish.
+# The PR half is settled by those runtimes: over the last runs on `main`,
+# fast-gate took 69–103s and pg-gate 134–143s. A run against a commit nobody
+# will merge spends a couple of minutes of a free runner deciding something no
+# one will read, and the newest push is the only one whose verdict can matter.
+# Cheap to abandon, worth nothing to finish.
 #
 # `main` is the reverse: every commit there must keep its own recorded verdict.
 # A cancelled run leaves a commit in history that CI never judged — the "nobody
@@ -53,23 +55,35 @@ on:
 #
 # So for a push the group is keyed on the COMMIT, and that is deliberate rather
 # than the obvious `github.ref`. `cancel-in-progress` governs only the RUNNING
-# member of a group; a *pending* one is a separate rule — "any existing pending
-# job or workflow in the same concurrency group will be canceled and the new
-# queued job or workflow will take its place" — and it applies whatever the flag
-# says. A branch-keyed group puts every main push in one group, so three merges
-# inside one pg-gate would cancel the middle commit's run while it queued, by
-# exactly the mechanism this block was added to prevent. Keyed per commit the
-# group has one possible member, so nothing on `main` ever queues and nothing is
-# ever cancelled. (`queue: max` would also fix it, but it cannot be combined with
+# member of a group; a *pending* one is a separate rule — "By default, any
+# existing pending job or workflow in the same concurrency group will be
+# canceled and the new queued job or workflow will take its place" — and that
+# default holds whatever the flag says. A branch-keyed group would put every
+# push to `main` in one group, so three merges inside one pg-gate would cancel
+# the middle commit's run while it queued, by exactly the mechanism this block
+# was added to prevent. Keyed per commit the group has one possible member, so
+# nothing on `main` ever queues and nothing is ever cancelled. (`queue: max`
+# raises that default to 100 waiting runs, but it is rejected outright next to
 # `cancel-in-progress: true`, and the PR half needs true.)
 #
-# Cancelling is safe against branch protection only because it can never touch a
-# SHA a rule is still looking at: the push that triggers the new run is the same
-# push that stopped the old commit being the PR head, and the rule evaluates the
-# head. This is worth stating because a cancelled required check does NOT merely
-# fail to report — `cancelled` is not among the successful/skipped/neutral
-# conclusions protection accepts, so it blocks. That is the cost the `main` half
-# is keyed to avoid, not a risk it was talked out of.
+# What a cancellation costs is worth stating exactly, because `cancelled` is NOT
+# among the successful/skipped/neutral conclusions branch protection accepts: a
+# cancelled required check BLOCKS, it does not merely fail to report. In the
+# ordinary case that is harmless — a `synchronize` push is itself what triggers
+# the replacement run, so the run being cancelled belongs to the commit that
+# just stopped being the PR head, and the rule only ever evaluates the head.
+# Two cases escape that reasoning and are worth knowing rather than discovering:
+#
+#   `reopened` is a default `pull_request` activity type and does NOT move the
+#   head, so closing and reopening mid-run cancels a run on the SHA still being
+#   evaluated. It self-heals: the replacement reports the same two contexts
+#   against the same SHA.
+#
+#   Re-running an OLDER run rejoins this group and cancels the current head's
+#   run, then reports its own conclusions against the older SHA. That one does
+#   not self-heal — the head is left holding two cancelled checks and the PR is
+#   unmergeable until it is pushed to or re-run. Loud and recoverable, but it is
+#   the reason to re-run the newest run rather than an older one.
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/Product-Definition/technical-environment.md
+++ b/Product-Definition/technical-environment.md
@@ -398,12 +398,22 @@ developer). No security scanning. No lint (see below).
 **branch protection on `main` makes them binding**.
 
 - **The workflow**: two jobs on `pull_request` and on `push: main`. **`fast-gate`** runs `typecheck`,
-  `pnpm test` and `build` (~66s); **`pg-gate`** runs `pnpm pg:up` and `pnpm test:pg` against the Docker
-  containers (~2m24s, and therefore the PR's critical path). Two jobs rather than one because `pg-gate`
+  `pnpm test` and `build` (69–103s); **`pg-gate`** runs `pnpm pg:up` and `pnpm test:pg` against the Docker
+  containers (134–143s, and therefore the PR's critical path). Two jobs rather than one because `pg-gate`
   is CI's only dependency on something outside the repo (`local-neon-http-proxy`, a mutable tag in a
   third party's namespace); isolated, that outage names itself instead of reading as broken code.
   **Zero secrets** — every gate passes with the environment empty. The one value `build` needs is a
   committed dummy `DATABASE_URL` pointing at an RFC 2606 `.invalid` host, which `neon()` only parses.
+- **Superseded PR runs are cancelled; runs on `main` never are.** The `concurrency:` group is keyed on
+  the pull request for a PR and on the **commit** for a push, with `cancel-in-progress` true only for
+  `pull_request`. A run against a commit nobody will merge is minutes spent deciding something no one
+  will read; a cancelled run on `main`, by contrast, would leave a commit in history that CI never
+  judged — the exact hole this section exists to close. The push key is the commit rather than the
+  branch on purpose: a *pending* run is cancelled when a third joins its group regardless of
+  `cancel-in-progress`, so a branch-keyed group would drop the middle commit's verdict when two merges
+  land inside one `pg-gate`. ⚠️ **Re-run the newest run, not an older one**: an older re-run rejoins the
+  PR's group, cancels the head's run, and reports against the stale SHA — leaving the head with two
+  cancelled (and therefore blocking) checks until it is pushed to or re-run.
 - **The block is branch protection, not a Vercel change.** Repository ruleset `main protection`
   (active, targeting `~DEFAULT_BRANCH` so a rename cannot leave it protecting nothing) requires a pull
   request and both status checks `fast-gate` and `pg-gate`, restricts deletions, blocks force-pushes and
@@ -444,7 +454,7 @@ developer). No security scanning. No lint (see below).
 **Why `test:pg` runs on *every* PR** — overriding the earlier rule of "when the persistence layer
 changes". A path-filtered job that is **skipped** never reports a conclusion, so as a *required* check it
 leaves the PR pending forever; the usual workaround, a same-named always-green companion job, is exactly
-the "something was checked" lie this document is trying to stop. The blanket rule costs ~2m24s per PR and
+the "something was checked" lie this document is trying to stop. The blanket rule costs ~2m20s per PR and
 removes the question entirely. The containers are the same `pnpm pg:up` a developer runs, on Postgres 17
 matching production's major (see *Test Types*).
 


### PR DESCRIPTION
Closes #32. Last ticket on the map (#17).

`ci.yml` shipped without a `concurrency:` block deliberately — choosing one needed observed runtimes. Those exist now, and they settle the PR half outright: over recent runs on `main`, `fast-gate` took 69–103s and `pg-gate` 134–143s, so a run against a commit nobody will merge is a couple of minutes of a free runner deciding something no one will read.

```yaml
concurrency:
  group: ci-${{ github.event.pull_request.number || github.sha }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

**`main` wants the opposite answer**, hence two expressions rather than the flat literals `backup.yml` can afford. Every commit on `main` must keep its own recorded verdict; a cancelled run leaves a commit in history CI never judged, which is the hole this whole effort exists to close.

**The push key is the commit, not `github.ref`, and that is the non-obvious part.** `cancel-in-progress` governs only the *running* member of a group. A *pending* member is a separate rule — ["By default, any existing pending job or workflow in the same concurrency group will be canceled and the new queued job or workflow will take its place"](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency) — which holds whatever the flag says. A branch-keyed group would put every push to `main` in one group, so two merges inside one `pg-gate` would drop the middle commit's verdict by exactly the mechanism this block was added to prevent. Keyed per commit, the group has one possible member: nothing on `main` ever queues, so nothing is ever cancelled. (`queue: max` raises the pending limit to 100 but is [rejected next to `cancel-in-progress: true`](https://github.blog/changelog/2026-05-07-github-actions-concurrency-groups-now-allow-larger-queues/), and the PR half needs true.)

**Review caught the safety argument being over-strong**, and both axes found it independently. `cancelled` is not among the successful/skipped/neutral conclusions branch protection accepts, so a cancelled required check *blocks*. That is harmless for a `synchronize` push — the push that triggers the replacement is the push that stopped the old commit being the head. Two cases escape it, now written into the file rather than left to be discovered:

- **`reopened`** is a default activity type and does not move the head, so a close/reopen mid-run cancels a run on the SHA still being evaluated. Self-heals.
- **Re-running an older run** rejoins the group, cancels the head's run, and reports against the stale SHA. Does *not* self-heal — the head sits blocked until pushed to or re-run.

Written back to `technical-environment.md` → *CI/CD Gates*, which describes this workflow and would otherwise be the one place the policy is unrecorded; its `~66s`/`~2m24s` figures predate #31 and #35 and are corrected in the same edit.

## Verification

The PR's own runs are the experiment — a second push while the first run is in flight, then a check that the head is mergeable rather than stranded. Results appended here before merge.