### PR TITLE
docs(definition): close OQ-B-1 and record where the risk moved

### DIFF
--- a/Product-Definition/open-questions.md
+++ b/Product-Definition/open-questions.md
@@ -7,7 +7,52 @@ Last generated: 2026-08-03T11:16:45Z
 
 ## Business (Vision) open questions
 
-### OQ-B-1: No known backup or restore path for the children's collections
+### OQ-B-1: No known backup or restore path for the children's collections — ✅ **CLOSED 2026-08-11**
+
+> **Answer: both exist now, and the "cheapest adequate insurance" turned out to be both, not either.**
+> Neon **point-in-time restore** covers the first **6 hours** — verified from the Neon dashboard on the
+> free plan, not assumed — and a **nightly `pg_dump`** covers **90 days** beyond it. Neither alone is
+> adequate: PITR is too narrow to survive a mistake noticed the next morning, and a nightly dump has no
+> second-level precision. `.github/workflows/backup.yml` runs at 18:00 UTC (02:00 SGT) and on
+> `workflow_dispatch`, against a **read-only** credential (`kc_backup_ro`, direct non-pooler endpoint,
+> stored as `BACKUP_DATABASE_URL`).
+>
+> **Every run verifies itself rather than asserting success**: it restores its own dump into a throwaway
+> Postgres 17 and asserts every table is present with exactly the production row count. A green run is a
+> dump that *provably restored* at the time it was taken. `docs/RESTORE.md` is the runbook, written
+> around how long ago the damage happened, because that is what determines the move.
+>
+> **The dump is GPG-encrypted to a public key committed at `.github/backup-pubkey.asc`**, so the runner
+> can write a backup it cannot read. This was not foresight — it closed a real leak: the artifacts were
+> uploaded in plaintext with 90-day retention, and an Actions artifact is downloadable by anyone with
+> read access, which on a public repo is every logged-in GitHub user. Roughly a week of the children's
+> collection data was retrievable by anyone. Found and fixed 2026-08-10/11 (#40).
+>
+> **The threat model this covers is operator error**, which is what the QB2 boundary is actually about,
+> and it is now defended *twice*: `resetPool()` refuses to run while any child owns a card, `pnpm seed
+> --sync` aborts rather than prune without `--allow-prune`, and any destructive seed operation against
+> production requires the exact collection-row count typed at an interactive terminal.
+>
+> *Recorded so it is not rediscovered*, three gaps that are accepted rather than overlooked:
+>
+> - **The 6–24 hour band has no point-in-time capability.** Recovery there means last night's dump and
+>   losing that day's pulls. Accepted trade-off for $0/month and zero upkeep.
+> - **Card images are not covered** — they live in Vercel Blob, no `pg_dump` includes them, and they are
+>   reproducible from `seed/cards.json`. A restored database points at Blob URLs that are still live.
+> - **Losing the private key destroys every dump inside the 90-day window, silently** — the artifacts stay
+>   intact and useless, and only PITR's 6 hours needs no key. This is now the sharpest single risk in the
+>   design, sharper than the concentration risk in OQ-CS-4 (code and backups in one GitHub account),
+>   because it fails without warning. No CI check can catch it; the answer is the **yearly restore drill**
+>   in `RESTORE.md` §3.2. Custody was tested rather than claimed — the 1Password copy was imported into a
+>   throwaway keyring and used to decrypt a real artifact.
+> - **The 90-day depth accrues from here; it does not exist yet.** As of closing, exactly **one** artifact
+>   is stored (`db-backup-31440936165`, 2026-08-10T23:05Z). Every plaintext predecessor was destroyed when
+>   the leak was found — deleted from GitHub, and the rescued local copies deleted afterwards too — so
+>   nothing before 2026-08-10 survives, and no dump exists that does not need the private key. The
+>   *mechanism* is proven and the *inventory* is one night deep, reaching its full 90 days in November.
+>
+> Full detail: `docs/RESTORE.md` and the heavily-commented `.github/workflows/backup.yml`.
+
 - **Source section**: Risks / What Must NOT Change
 - **Question**: Does any backup or point-in-time restore exist for the Neon Postgres database today? If
   not, what is the cheapest adequate insurance — Neon PITR on the current plan, or a scheduled `pg_dump`?
@@ -151,20 +196,23 @@ pull request whose properties fail cannot be merged. The row above now reads *Al
 ## Summary
 
 Raised during definition: 5  (Business: 3, Technical: 2)
-**Still open: 3**  (OQ-B-1, OQ-B-3, OQ-T-3) — OQ-B-2 closed 2026-08-07, OQ-T-2 closed 2026-08-09.
+**Still open: 2**  (OQ-B-3, OQ-T-3) — OQ-B-2 closed 2026-08-07, OQ-T-2 closed 2026-08-09,
+OQ-B-1 closed 2026-08-11.
 Cross-role contradictions: 0
 
 AI-DLC should load this file during Requirements Analysis and resolve each entry
 before proceeding to User Stories or Application Design.
 
 **Priority order** if they can't all be addressed at once:
-1. **OQ-B-1** (backup/restore) — the only item where the downside is irreversible data loss.
-2. **OQ-B-3** (AI-reconstructed prose) — cheap to confirm, and everything downstream inherits it.
-3. **OQ-T-3** (next-auth beta) — no action until auth-adjacent work is planned.
+1. **OQ-B-3** (AI-reconstructed prose) — cheap to confirm, and everything downstream inherits it.
+2. **OQ-T-3** (next-auth beta) — no action until auth-adjacent work is planned.
 
-~~**OQ-T-2** (CI automation) — makes a declared blocking constraint actually blocking.~~ **Done
-2026-08-09.** ~~**OQ-B-2** (cost vs. pool growth) — needs a number, not a decision.~~ **Answered
-2026-08-07.**
+~~**OQ-B-1** (backup/restore) — the only item where the downside is irreversible data loss.~~ **Closed
+2026-08-11.** Note the *shape* of the risk moved rather than vanishing: it is no longer "no backup
+exists" but "the private key must not be lost", which fails silently and is why the yearly restore
+drill is the mitigation. ~~**OQ-T-2** (CI automation) — makes a declared blocking constraint actually
+blocking.~~ **Done 2026-08-09.** ~~**OQ-B-2** (cost vs. pool growth) — needs a number, not a
+decision.~~ **Answered 2026-08-07.**
 
 ---
 

--- a/Product-Definition/vision-document.md
+++ b/Product-Definition/vision-document.md
@@ -195,26 +195,29 @@ load or uptime that will never be needed.
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| No known backup / restore path for children's collections | **High** | Not found in the repo. Collections are irreplaceable — a bad migration or dropped Neon branch loses every pull the kids have made. Confirm whether Neon PITR covers the current plan; otherwise schedule a periodic `pg_dump`. Tracked as **OQ-B-1**. |
+| ~~No known backup / restore path for children's collections~~ **Losing the backup encryption key** | **High** | **OQ-B-1 closed 2026-08-11 — the risk did not vanish, it moved.** Both layers exist: Neon PITR (**6 hours**, verified) and a self-verifying nightly `pg_dump` (**90 days**), runbook at `docs/RESTORE.md`. The dump is GPG-encrypted to a committed public key, so what is now irreplaceable is the **private** key — lose it and every dump in the window becomes silently unrecoverable, with only PITR's 6 hours needing no key. Mitigation is the **yearly restore drill** (`RESTORE.md` §3.2); no automated check can catch this. |
 | Single Google account is a single point of failure | Medium | The parent is the only authenticated user; losing that account makes all three binders inaccessible. No documented recovery path exists. |
 | Pollinations.ai is a free third party with no SLA or account | Medium | Only re-seeding depends on it — the 300 live cards are already in Blob, so the children are unaffected if it disappears. Cloudflare Workers AI / Flux is the parked fallback. |
 | Age-4 pre-reader cannot access the educational text | Medium | **Accepted trade-off.** The parent's judgement is that pictures alone suffice at this age; read-aloud is explicitly declined. Recorded as a known, deliberate limitation rather than an open action. |
-| Free-tier limits as the pool grows | Low–Medium | Raised in significance by the decision that the pool keeps growing. 300 cards today; the $0/month metric is the tripwire. Tracked as **OQ-B-2**. |
+| Free-tier limits as the pool grows | Low | **Downgraded — OQ-B-2 closed 2026-08-07 with a number.** Blob sits at 28.29 MB of a 1 GB tier and a theme costs ≈1.4 MB, leaving room for roughly **400–700 more themes**. The binding constraints are the parent's authoring time and the children's appetite, not the free tier. |
 | Increment 22 visual check still outstanding | Low | Checklist in `build-and-test` §4 — never run on a signed-in child profile. |
 
 ### Open Questions
 
 Full detail in `open-questions.md`.
 
-- **OQ-B-1 — No known backup or restore path for the children's collections.** Does any backup or
-  point-in-time restore exist for the Neon database today? Cannot be answered from the repo; note the
-  evidence is an assertion of absence. Resolve before any migration touching `collections`, `children`,
-  or `cards`.
-- **OQ-B-2 — Does the $0/month cost target survive an ever-growing card pool?** The success metric fixes
-  cost flat while the pool is intended to keep growing. Both hold at 300 cards; the crossover pool size
-  is unknown.
+**One remains open.**
+
 - **OQ-B-3 — Problem statement and vision statement are AI-reconstructed, not user-authored.** Nothing in
   the source material constrains them, making them the two sections most likely to be quietly wrong.
+
+Closed, kept here so they are not re-raised:
+
+- ~~**OQ-B-1** — No known backup or restore path.~~ **Closed 2026-08-11.** Neon PITR (6h, verified) plus a
+  self-verifying, GPG-encrypted nightly `pg_dump` (90d). See the Known Risks table above for where the
+  risk moved.
+- ~~**OQ-B-2** — Does $0/month survive an ever-growing card pool?~~ **Closed 2026-08-07.** Yes; ~400–700
+  themes of headroom, and storage was never the binding constraint.
 
 **Settled during definition — not open**: read-aloud (declined), pool growth (decided: keeps growing),
 parent visibility into per-child pulls (not wanted), `SACRIFICE_MIN` retune (withdrawn), children's

--- a/docs/RESTORE.md
+++ b/docs/RESTORE.md
@@ -14,6 +14,16 @@ the right move depends almost entirely on how long ago the damage happened.
 | **1–90 days** | An older nightly dump | up to a day of pulls, from that day |
 | **> 90 days** | **Nothing exists** | everything |
 
+> **⚠️ The 1–90 day row is a property of the schedule, not of what is stored today.** The dump history was
+> reset to zero on 2026-08-10 when the plaintext artifacts were destroyed (§6), so the archive is only as
+> deep as the nights since then and reaches its full 90 days in November 2026. **Check what actually
+> exists before relying on this table** — Actions → **backup**, or:
+>
+> ```sh
+> gh api repos/nywleswoey/kids-collection/actions/artifacts \
+>   --jq '.artifacts[] | select(.expired|not) | "\(.name) \(.created_at)"'
+> ```
+
 **The 6–24 hour band has no point-in-time capability.** Recovery there means restoring last night's
 dump and accepting that the day's pulls are gone. That is a known property of the design, not a
 surprise — it was the accepted trade-off for a $0/month, zero-upkeep backup.
@@ -186,11 +196,20 @@ too, and it fails silently — the artifacts stay right where they are, perfectl
 useless. There is no partial recovery from it and no warning that it has happened until a restore.
 Key custody is now as load-bearing as the dumps themselves; see the box in §3.2.
 
-**Six pre-encryption dumps (2026-08-06 → 2026-08-10) were downloaded to
-`~/Downloads/kids-collection-backups/` and deleted from GitHub** when the repository's artifacts were
-found to be publicly readable. They are *unencrypted*, they are the only copies of those days, and
-they need no key — which makes them both the fallback if key custody fails and a small pile of
-plaintext production data sitting in a Downloads folder. Decide where they should live.
+**The pre-encryption dumps (2026-08-06 → 2026-08-10) no longer exist anywhere.** They were deleted from
+GitHub when the repository's artifacts were found to be publicly readable, downloaded to
+`~/Downloads/kids-collection-backups/` first, and **that local copy was subsequently deleted too
+(confirmed 2026-08-11)**. Those days are unrecoverable. That was the correct call — they were plaintext
+production data about children sitting unencrypted in a Downloads folder — but it is worth stating
+plainly rather than leaving a runbook pointing at a path that is not there.
+
+Two consequences follow. **The archive restarts from 2026-08-10**, which is what the warning in §1 is
+about. And **there is no longer any dump that does not need the private key**: the key-custody box in
+§3.2 was previously softened by those plaintext copies, and it no longer is. Below the 6-hour PITR
+window, the key is the single thing standing between a mistake and total loss.
+
+*(An inconsistency now impossible to settle, recorded so it is not re-litigated: this file said six
+dumps and the wayfinder map said seven. Nothing survives to count.)*
 
 ---
 


### PR DESCRIPTION
`open-questions.md` still called OQ-B-1 *"the highest-stakes item in this file"* and the summary still read **Still open: 3**. It has been answered since Increment 23.

**Both layers exist, and "cheapest adequate insurance" turned out to be both rather than either.** Neon PITR covers the first **6 hours** (verified from the dashboard on the free plan, not assumed); a nightly `pg_dump` covers **90 days** beyond it. Neither alone is adequate — PITR is too narrow to survive a mistake noticed next morning, and a nightly dump has no second-level precision. Every run restores its own dump into a throwaway Postgres 17 and asserts per-table row counts, so a green run is a dump that *provably restored* at the time it was taken.

**The risk did not vanish, it moved — and the closure leads with that.** The dump is GPG-encrypted to a committed public key, so what is now irreplaceable is the **private** key: lose it and every dump inside the window becomes silently unrecoverable, artifacts intact and useless, with only PITR's 6 hours needing no key. No automated check can catch this. The mitigation is the yearly restore drill in `RESTORE.md` §3.2.

Swept `vision-document.md` in the same pass, where **OQ-B-1 was still described as "Not found in the repo"** and **OQ-B-2 was still listed as open** despite closing 2026-08-07 — nobody swept this file when #27 swept `technical-environment.md`.

## Two corrections to `RESTORE.md`, both adverse, both found by checking rather than reading

- **§6 pointed at a path that does not exist.** It said the pre-encryption dumps live at `~/Downloads/kids-collection-backups/` and are *"the only copies of those days"*. The directory is not there; the owner confirmed deleting it. Those days (2026-08-06 → 08-10) are unrecoverable, and — the consequence worth naming — **no dump remains that does not require the private key**, which previously softened the custody warning.
- **§1's recovery table promised depth that does not exist.** GitHub holds exactly **one** artifact (`db-backup-31440936165`, 2026-08-10T23:05Z). The archive restarted on 2026-08-10 and reaches its full 90 days in November 2026. §1 now warns about this and gives the one-liner to check what is actually stored.

A runbook that names a path with nothing behind it is the same failure mode as a check that cannot fail — it reads as coverage.

## Deliberately left frozen

`Product-Definition/state/*.md` and the per-feature snapshots under `features/collection-safety/`, on #27's precedent: OQ-B-2's closure was never written back to `state/business-state.md` either, and treating `state/` as live would adopt a burden this repo already declined.

Closes nothing on the tracker — OQ-B-1 lives in the definition documents, not in an issue.