### PR TITLE
docs(ci): quote the gate runtimes with their sample size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,21 @@ on:
 # This block was deliberately absent when the file landed, because choosing
 # either way needed runtimes nobody had yet; settled in #32 once they existed.
 #
-# The PR half is settled by those runtimes: over the last runs on `main`,
-# fast-gate took 69–103s and pg-gate 134–143s. A run against a commit nobody
-# will merge spends a couple of minutes of a free runner deciding something no
-# one will read, and the newest push is the only one whose verdict can matter.
-# Cheap to abandon, worth nothing to finish.
+# The PR half is settled by those runtimes. Across all 16 successful runs of the
+# CURRENT configuration (everything since #35 raised FC_NUM_RUNS), fast-gate is
+# 54-103s, mean 71, and pg-gate 103-166s, mean 142. A run against a commit
+# nobody will merge spends a couple of minutes of a free runner deciding
+# something no one will read, and the newest push is the only one whose verdict
+# can matter. Cheap to abandon, worth nothing to finish.
+#
+# Note the spread, which is wider than it looks like it should be: the same
+# unchanged tree varies by ~2x on fast-gate and ~60% on pg-gate, entirely from
+# runner variation. These figures were FIRST written here as 69-103s and
+# 134-143s, from two runs, and the very next PR fell outside BOTH ranges. So
+# they now carry their sample size on purpose — a range quoted from two
+# observations is a guess wearing a measurement's clothes, and this file is the
+# wrong place for that. Anything reasoning about CI cost should use the mean and
+# expect the tail, not treat the maximum as a ceiling.
 #
 # `main` is the reverse: every commit there must keep its own recorded verdict.
 # A cancelled run leaves a commit in history that CI never judged — the "nobody
@@ -172,8 +182,9 @@ jobs:
       # No dependency cache, and that question is CLOSED rather than deferred.
       # The prediction when this file landed was that install would dominate the
       # job. It does not: install is 4s, and has stayed 4s across every run since
-      # — of a 57s job then and a ~69s job now, where `build` is 30s and the
-      # property search is ~20s. There is nothing there for `actions/cache` to
+      # — of a 57s job then and a 54-103s one now (mean 71), where `build` is 30s
+      # and the property search is ~20s. There is nothing there for
+      # `actions/cache` to
       # win, and caching next to `--frozen-lockfile` carries its own correctness
       # risk. Reopen it against a new measurement, not against the intuition.
       - name: Install dependencies
@@ -200,10 +211,18 @@ jobs:
       # 1000 is ten times fast-check's default, so this run explores ~100,000
       # cases rather than ~10,000. Property-Based Testing is a *blocking*
       # constraint (OQ-T-2), and mechanising a shallow search would close that
-      # question only nominally. The runner is where depth is free: nobody is
-      # waiting on it, and `pg-gate` sets the PR's wall-clock at ~2m30s either
-      # way, so `fast-gate` has roughly 90s of slack before this could cost
-      # anyone a second.
+      # question only nominally. The runner is where depth is nearly free: nobody
+      # is waiting on it, and `pg-gate` usually sets the PR's wall-clock either
+      # way, so this mostly costs nothing.
+      #
+      # "Nearly" and "usually" are doing real work in that sentence, and they
+      # replace a flat claim of ~90s of slack. The two jobs' ranges OVERLAP:
+      # fast-gate is 54-103s and pg-gate 103-166s, so on an unlucky pairing —
+      # slow fast-gate, fast pg-gate — this job becomes the critical path rather
+      # than hiding behind it. The slack is ~70s at the means and 0s at the
+      # extremes. Still the right trade for a blocking constraint, but if this
+      # value is ever raised again, that is the headroom being spent, not a
+      # comfortable 90s.
       #
       # Measured local cost, whole suite: unset 3.17s, 500 3.66s, 1000 4.19s,
       # 2000 5.42s, 5000 8.66s, 10000 15.33s. All green — the properties held to

--- a/Product-Definition/technical-environment.md
+++ b/Product-Definition/technical-environment.md
@@ -398,8 +398,10 @@ developer). No security scanning. No lint (see below).
 **branch protection on `main` makes them binding**.
 
 - **The workflow**: two jobs on `pull_request` and on `push: main`. **`fast-gate`** runs `typecheck`,
-  `pnpm test` and `build` (69–103s); **`pg-gate`** runs `pnpm pg:up` and `pnpm test:pg` against the Docker
-  containers (134–143s, and therefore the PR's critical path). Two jobs rather than one because `pg-gate`
+  `pnpm test` and `build` (**54–103s, mean 71**); **`pg-gate`** runs `pnpm pg:up` and `pnpm test:pg`
+  against the Docker containers (**103–166s, mean 142**, and therefore the PR's critical path) — both
+  measured over all 16 successful runs of the current configuration, and both varying that widely on an
+  unchanged tree purely from runner variation, so use the mean and expect the tail. Two jobs rather than one because `pg-gate`
   is CI's only dependency on something outside the repo (`local-neon-http-proxy`, a mutable tag in a
   third party's namespace); isolated, that outage names itself instead of reading as broken code.
   **Zero secrets** — every gate passes with the environment empty. The one value `build` needs is a


### PR DESCRIPTION
The `69–103s` / `134–143s` figures I wrote in #41 came from **two runs**, and the very next PR fell outside **both** — `fast-gate` 54s, `pg-gate` 151s.

Recomputed over **all 16 successful runs of the current configuration** (everything since #35 raised `FC_NUM_RUNS`, so the numbers describe what runs today):

| Job | Range | Mean | n |
|---|---|---|---|
| `fast-gate` | **54–103s** | 71 | 16 |
| `pg-gate` | **103–166s** | 142 | 16 |

Both now carry `n` and the mean. A range quoted from two observations is a guess wearing a measurement's clothes, and these figures get reasoned against — #32's whole PR-half argument rests on them.

The spread is wider than it looks like it should be: the same unchanged tree varies ~2x on `fast-gate` and ~60% on `pg-gate`, entirely from runner variation. Worth stating so the maximum isn't read as a ceiling.

## One claim weakened rather than renumbered

The `FC_NUM_RUNS` comment said `pg-gate` sets the PR's wall-clock *"either way, so `fast-gate` has roughly 90s of slack before this could cost anyone a second."*

**The two ranges overlap at 103s.** On a slow-`fast-gate`/fast-`pg-gate` pairing, `fast-gate` becomes the critical path rather than hiding behind it. Slack is **~70s at the means and 0s at the extremes**. Still the right trade for a blocking constraint — but that is the headroom any future raise of `FC_NUM_RUNS` is spending, and the old comment would have let someone spend it thinking it was free.

Same correction applied to `technical-environment.md` → *CI/CD Gates*, and to the cache comment's `~69s job now`.