### PR TITLE
test(collections): close OQ-CS-3 with the general delete-path property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
         if: ${{ !cancelled() && steps.install.outcome == 'success' }}
         run: pnpm typecheck
 
-      # 321 tests across 51 files, 22 of them property-based, and 100 `fc.assert`
+      # 329 tests across 52 files, 23 of them property-based, and 104 `fc.assert`
       # call sites. The suite still passes with every environment variable unset
       # — the one below only makes the search deeper, never makes it possible.
       #

--- a/Product-Definition/features/collection-safety/open-questions.md
+++ b/Product-Definition/features/collection-safety/open-questions.md
@@ -45,7 +45,49 @@ Scope note: this file covers the **Collection Safety** feature. The parent
 
 ## Technical (Technical Environment) open questions
 
-### OQ-CS-3: The general delete-path property test is deferred, while PBT is a blocking constraint
+### OQ-CS-3: The general delete-path property test is deferred, while PBT is a blocking constraint — ✅ **CLOSED 2026-08-12**
+
+> **Answer: the general statement now ships, as four properties plus the concrete cases the properties
+> structurally cannot reach.** The deferral reasoning was re-examined rather than inherited, as this entry
+> asked, and it holds up: a narrow test was better than none. What it could not do was *say* the general
+> thing, and it turns out saying it needs two homes, not one.
+>
+> **`tests/delete-path.pbt.test.ts`** (in-memory fake, `FC_NUM_RUNS: 1000` in CI) states scope over a
+> generated world of 4 children × 4 cards — always LARGER than any operation touches, so a bystander
+> exists to be harmed:
+>
+> - a sacrifice changes only the `(child, card)` it names, and never below the one copy the child keeps;
+> - a trade changes only the four pairs it names;
+> - a trade never reduces a bystander's *total* holdings (the form that catches a balanced-but-wrong move);
+> - **no service path ever removes a `(child, card)` row at all** — the strong form, and true today.
+>
+> **`tests-pg/delete-path.pg.test.ts`** states what a fake cannot: every row that vanishes in production
+> vanishes through a **cascade**. BR14 (deleting a child takes their rows and nobody else's) was
+> *documented but untested* until now, and the `seed --sync` pruners had no pg coverage at all.
+>
+> *Recorded so it is not rediscovered*, four findings from building it:
+>
+> - **The pruners are not guarded the way `resetPool()` is.** `deleteThemesNotIn` / `deleteCardsNotIn`
+>   cascade into `collections` with no owned-rows check; their only protection is the CLI's
+>   `--allow-prune` plus a typed confirmation. **An empty keep-list deletes every theme, every card and
+>   every collection row** — `pruneNotIn` reads "keep nothing" as "no filter". Pinned as behaviour with a
+>   loud comment rather than changed: a prune that could not remove a dropped card would not be a prune.
+>   This is the sharpest remaining edge in the delete story.
+> - **Three of the four properties were vacuous when first written** and passed anyway. The four test
+>   cards had four different rarities, so `validateTrade` rejected every generated trade before it reached
+>   the store — green properties exercising nothing, which is this project's signature failure mode
+>   wearing a new costume. Each property now counts its own writes and asserts the count is non-zero.
+> - **Neither test location subsumes the other, and that was found by mutating, not by reasoning.** The
+>   store's row-DELETE branch is unreachable from any service (sacrifice keeps a copy; a swap needs a
+>   duplicate), so a mutation dropping `child_id` from that DELETE was missed by the properties entirely
+>   and caught only by the new concrete bystander cases in the shared store contract — which also run
+>   against real Postgres, where the properties deliberately do not.
+> - **Every assertion here was proven to bite.** Five mutations, each reverted: `removeCard` losing its
+>   `child_id` predicate, `swapCards` decrementing every holder, `sacrifice` allowed to burn a last copy,
+>   `pgProfileStore.remove` losing its id predicate, and `deleteCardsNotIn` losing its theme scope. Each
+>   went red, and the property failures shrank to 10–14-step counterexamples.
+>
+> Suite: **52 files / 329 tests** unit (was 51/321) and **7 files / 57 passed** pg (was 6/47).
 - **Source section**: Business Q5 (scope) vs parent Technical Environment (Testing)
 - **Question**: When does the property-based test *"no service path can delete a `collections` row it
   doesn't own"* ship, and is slice 1 acceptable without it?
@@ -92,13 +134,18 @@ mistake for scope creep later and remove.
 
 ## Summary
 
-Total open questions: 3  (Business: 2, Technical: 1)
-Cross-role contradictions: 0 · Gaps: 1 (OQ-CS-3) · Near-misses: 1 (alerting, in the user's favour)
+Total open questions: 2  (Business: 1, Technical: 1) — OQ-CS-3 closed 2026-08-12.
+Cross-role contradictions: 0 · Gaps: **0** (OQ-CS-3 closed) · Near-misses: 1 (alerting, in the user's favour)
 
 **Priority order**:
-1. **OQ-CS-3** (general delete-path PBT) — the only item where a *blocking* parent constraint is not met.
-2. **OQ-CS-2** (soft-delete) — V3's blast radius is unchanged until it ships; small increment.
-3. **OQ-CS-4** (single vendor) — deliberately scoped out; no action, keep visible.
+1. **OQ-CS-2** (soft-delete) — V3's blast radius is unchanged until it ships; small increment.
+2. **OQ-CS-4** (single vendor) — deliberately scoped out; no action, keep visible.
+
+~~**OQ-CS-3** (general delete-path PBT) — the only item where a *blocking* parent constraint is not met.~~
+**Closed 2026-08-12.** The blocking PBT constraint is now met for the delete path specifically, not just
+mechanised in general by parent OQ-T-2. One thing it surfaced is worth carrying into any future work on
+the seed pipeline: the `seed --sync` pruners have **no structural guard**, and an empty keep-list deletes
+every collection row.
 
 ---
 

--- a/Product-Definition/technical-environment.md
+++ b/Product-Definition/technical-environment.md
@@ -66,7 +66,7 @@ Scope: source code only. Config files (`.mjs`, `.json`) and generated output are
 | Auth.js / NextAuth 5.0.0-beta.25 | Parent Google OAuth | Maintain — **see OQ-T-3** |
 | Vercel Blob 0.27 | 300 card images | Maintain |
 | Zod 3 | Profile input + seed-file schema | Maintain |
-| Vitest 2 + fast-check 3 | 51 unit/PBT files (22 property-based) + 5 contract specs | Maintain |
+| Vitest 2 + fast-check 3 | 52 unit/PBT files (23 property-based) + 5 contract specs | Maintain |
 | PostHog (`posthog-js` / `posthog-node`) | Analytics, error capture, scoped session replay | Maintain |
 | Pollinations.ai | Seed-time image generation only | Maintain — Workers AI / Flux is the parked alternative |
 
@@ -339,11 +339,11 @@ contradictions**; this is a strict technical superset.
 
 ### Test Types
 
-- **Unit** — 51 files under `tests/` (321 tests), run by `pnpm test` (Vitest, node env, no database
-  needed). 22 of the 51 are property-based; see below.
+- **Unit** — 52 files under `tests/` (329 tests), run by `pnpm test` (Vitest, node env, no database
+  needed). 23 of the 52 are property-based; see below.
 - **Integration** — `pnpm test:pg` runs the store adapters against a real Postgres 17 in Docker via a
-  local Neon HTTP proxy (`tests-pg/`, 6 suites — the 5 store adapters plus the pool writer — serial
-  execution, 30s timeout; 47 tests pass and 3 skip). The container
+  local Neon HTTP proxy (`tests-pg/`, 7 suites — the 5 store adapters, the pool writer, and the
+  delete-path cascades — serial execution, 30s timeout; 57 tests pass and 3 skip). The container
   **major** deliberately matches production Neon, so a contract the suite proves is a contract prod
   honours; the tag floats within the major, since Neon moves prod's minor unannounced and a pinned minor
   would match only on the day it was pinned. The `psql` doing the migrations may be older, which nothing
@@ -371,11 +371,20 @@ no provider is installed. This is a deliberate position, not an oversight. The b
 
 > **Every invariant that protects the children's data must be covered by a property-based test or a
 > contract test** — ticket arithmetic, duplicate accounting, trade atomicity, offer signing, sacrifice
-> eligibility, rarity weighting, quiz caps.
+> eligibility, rarity weighting, quiz caps, **and the delete path**.
 
 A line-coverage percentage can be satisfied without ever asserting that an invariant holds across the
-input space; the 22 existing PBT files already meet the stronger bar — and, since 2026-08-09, a required
+input space; the 23 existing PBT files already meet the stronger bar — and, since 2026-08-09, a required
 check runs them on every pull request rather than trusting that someone did.
+
+The delete path was the one named gap in that list until 2026-08-12 (OQ-CS-3): `resetPool()` had a narrow
+guard and a narrow test, while the general statement — *no service path touches a `collections` row
+outside its named scope* — was deferred. It now ships as four properties in
+`tests/delete-path.pbt.test.ts` plus the cascade cases in `tests-pg/delete-path.pg.test.ts`, because the
+two catch classes the other structurally cannot: the store's row-DELETE branch is unreachable from any
+service, and a fake has no cascades to get wrong. ⚠️ **The `seed --sync` pruners remain structurally
+unguarded** — an empty keep-list deletes every collection row, and only the CLI's `--allow-prune` plus a
+typed confirmation stands in the way. That is pinned as behaviour, not fixed.
 
 ### Tooling
 

--- a/tests-pg/delete-path.pg.test.ts
+++ b/tests-pg/delete-path.pg.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { neon } from "@neondatabase/serverless";
+import { pgProfileStore } from "@/db/stores/profile-store.pg";
+import {
+  countCollections,
+  deleteCardsNotIn,
+  deleteThemesNotIn,
+} from "@/features/pool/writer";
+import { resetAll, seedChildren, seedCollections } from "./db";
+
+/**
+ * OQ-CS-3, the half a fake cannot state. Every row that disappears from
+ * `collections` in production disappears through a CASCADE — `collections`
+ * references both `children` and `cards` with ON DELETE CASCADE — and an
+ * in-memory store has no cascades to get wrong. The service-layer scoping
+ * property lives in tests/delete-path.pbt.test.ts and runs at depth; this file
+ * is about the deletes that no service ever asks for.
+ *
+ * Two paths reach them, and they are NOT equally guarded:
+ *
+ *   `resetPool()`  — refuses outright while any collection row exists (Inc23
+ *                    FR1), and is pinned in pool-writer.pg.test.ts.
+ *   the PRUNERS    — `deleteThemesNotIn` / `deleteCardsNotIn`, the `seed --sync`
+ *                    delta path. These have NO structural guard. Their only
+ *                    protection is at the CLI (`--allow-prune` plus a typed
+ *                    confirmation), which is a different layer and a different
+ *                    failure mode. Nothing here proposes adding one — a prune
+ *                    that could not remove a dropped card would not be a prune —
+ *                    but the blast radius should be written down rather than
+ *                    discovered, which is what these tests do.
+ */
+const sql = neon(process.env.DATABASE_URL!);
+
+/** Two themes so the pruners' scoping has something to be wrong about. */
+async function seedTwoThemes(): Promise<void> {
+  await resetAll();
+  await sql`INSERT INTO themes (id, name) VALUES ('t1', 'Animals'), ('t2', 'Vehicles')`;
+  await sql`INSERT INTO cards (id, theme_id, name, rarity, image_url, edu_text) VALUES
+    ('a1', 't1', 'Ant',   'common'::rarity, '', ''),
+    ('a2', 't1', 'Bear',  'common'::rarity, '', ''),
+    ('v1', 't2', 'Car',   'common'::rarity, '', ''),
+    ('v2', 't2', 'Digger','common'::rarity, '', '')`;
+  await seedChildren({ kid1: {}, kid2: {} });
+  await seedCollections({ kid1: { a1: 2, a2: 1, v1: 3 }, kid2: { a1: 1, v2: 4 } });
+}
+
+const rowsFor = async (cardId: string): Promise<number> => {
+  const [{ n }] = await sql`SELECT count(*)::int AS n FROM collections WHERE card_id = ${cardId}`;
+  return n;
+};
+
+const rowsOwnedBy = async (childId: string): Promise<number> => {
+  const [{ n }] = await sql`SELECT count(*)::int AS n FROM collections WHERE child_id = ${childId}`;
+  return n;
+};
+
+describe("BR14: deleting a child takes their collection rows and nobody else's", () => {
+  beforeEach(seedTwoThemes);
+
+  it("cascades to exactly the removed child's rows", async () => {
+    expect(await countCollections()).toBe(5);
+
+    await pgProfileStore.remove("kid1");
+
+    // kid1's three rows are gone; kid2's two are untouched.
+    expect(await rowsOwnedBy("kid1")).toBe(0);
+    expect(await rowsOwnedBy("kid2")).toBe(2);
+    expect(await countCollections()).toBe(2);
+
+    // And the cascade stops at collections — it must not take the pool with it.
+    const [{ n: cards }] = await sql`SELECT count(*)::int AS n FROM cards`;
+    expect(cards).toBe(4);
+  });
+
+  it("leaves a shared card's other owner alone", async () => {
+    // Both children hold a1. Removing one must not remove the card, nor the
+    // other child's copy of it — the case a per-child delete gets wrong when it
+    // reaches for the card instead of the row.
+    await pgProfileStore.remove("kid1");
+    expect(await rowsFor("a1")).toBe(1);
+    expect(await sql`SELECT count(*)::int AS n FROM cards WHERE id = 'a1'`.then((r) => r[0].n)).toBe(1);
+  });
+});
+
+describe("the seed --sync pruners: scope, and the blast radius when scope is empty", () => {
+  beforeEach(seedTwoThemes);
+
+  it("deleteCardsNotIn keeps the collection rows of cards it keeps", async () => {
+    // Drop 'Bear' from theme t1, keep 'Ant'. kid1 loses their a2 row and nothing
+    // else; the OTHER theme's cards are outside the scope entirely.
+    const deleted = await deleteCardsNotIn("t1", ["Ant"]);
+    expect(deleted).toBe(1);
+
+    expect(await rowsFor("a2")).toBe(0); // pruned card's rows cascade away
+    expect(await rowsFor("a1")).toBe(2); // kept card, BOTH owners intact
+    expect(await rowsFor("v1")).toBe(1); // other theme untouched
+    expect(await rowsFor("v2")).toBe(1);
+    expect(await countCollections()).toBe(4);
+  });
+
+  it("deleteCardsNotIn is scoped to its theme — a name shared with another theme survives", async () => {
+    // 'Car' exists only in t2. Pruning t1 down to nothing must not reach it.
+    await deleteCardsNotIn("t1", []);
+    expect(await rowsFor("v1")).toBe(1);
+    expect(await rowsFor("v2")).toBe(1);
+    expect(await rowsOwnedBy("kid1")).toBe(1); // only v1 left
+  });
+
+  it("deleteThemesNotIn removes one theme's cards and their rows, not the other's", async () => {
+    const deleted = await deleteThemesNotIn(["Animals"]);
+    expect(deleted).toBe(1);
+
+    expect(await rowsFor("a1")).toBe(2);
+    expect(await rowsFor("v1")).toBe(0);
+    expect(await rowsFor("v2")).toBe(0);
+  });
+
+  it("⚠️ an EMPTY keep-list deletes every theme and every collection row, unguarded", async () => {
+    // Pinned as behaviour, deliberately, because it is the sharpest edge in this
+    // file. `pruneNotIn` treats an empty keep-list as "no filter", so the delete
+    // runs unrestricted — and unlike resetPool() there is no owned-rows check to
+    // stop it. A seed file that failed to parse into any themes would take every
+    // child's entire collection with it, and the only thing standing in the way
+    // is the CLI's --allow-prune plus a typed confirmation.
+    //
+    // If this ever becomes reachable without that confirmation, THIS is the test
+    // that should have been read first.
+    expect(await countCollections()).toBe(5);
+
+    const deleted = await deleteThemesNotIn([]);
+
+    expect(deleted).toBe(2);
+    expect(await countCollections()).toBe(0);
+    const [{ n: cards }] = await sql`SELECT count(*)::int AS n FROM cards`;
+    expect(cards).toBe(0);
+    // The children themselves survive — they own nothing, which is the whole
+    // difference between "the pool was reset" and "the binders were emptied".
+    const [{ n: kids }] = await sql`SELECT count(*)::int AS n FROM children`;
+    expect(kids).toBe(2);
+  });
+});

--- a/tests/contracts/collection-store-contract.ts
+++ b/tests/contracts/collection-store-contract.ts
@@ -108,6 +108,46 @@ export function runCollectionStoreContract(
       expect(await store.ownedCardIds("kid")).toEqual(new Set());
     });
 
+    // --- OQ-CS-3: scope. Every case above names only the children it acts on,
+    // so none of them could catch a WHERE clause that forgot `child_id` — the
+    // adapter would agree with itself while quietly emptying somebody else's
+    // binder. These put a BYSTANDER in the store holding the very same cards.
+    // The property-based version of this lives in tests/delete-path.pbt.test.ts
+    // and runs at depth; these are the concrete form, so the claim is also made
+    // against real Postgres (the pg run sets properties:false).
+
+    it("removeCard touches only the named child, not a bystander holding the same card", async () => {
+      const store = await makeStore({ kid: { a: 3 }, other: { a: 3 } });
+      expect(await store.removeCard("kid", "a")).toEqual({ count: 2 });
+      expect(await store.cardCount("other", "a")).toBe(3);
+    });
+
+    it("removeCard deleting a row to 0 does not delete another child's row for that card", async () => {
+      // The delete-the-row branch is the one that issues a DELETE rather than an
+      // UPDATE, so it is the branch where a missing child_id predicate is fatal.
+      const store = await makeStore({ kid: { a: 3 }, other: { a: 2 } });
+      expect(await store.removeCard("kid", "a", 3, 3)).toEqual({ count: 0 });
+      expect(await store.cardCount("kid", "a")).toBe(0);
+      expect(await store.cardCount("other", "a")).toBe(2);
+      expect(await store.ownedCardIds("other")).toEqual(new Set(["a"]));
+    });
+
+    it("swapCards touches only the two named children", async () => {
+      const store = await makeStore({ A: { x: 2 }, B: { y: 2 }, C: { x: 2, y: 2 } });
+      expect(await store.swapCards({ aChildId: "A", aCardId: "x", bChildId: "B", bCardId: "y" })).toBe(true);
+      expect(await store.cardCount("C", "x")).toBe(2);
+      expect(await store.cardCount("C", "y")).toBe(2);
+    });
+
+    it("a REFUSED swap leaves a bystander untouched too", async () => {
+      // The rollback path writes as well (it has to undo the first give), so it
+      // gets its own bystander case rather than trusting the success path's.
+      const store = await makeStore({ A: { x: 2 }, B: { y: 1 }, C: { x: 3, y: 3 } });
+      expect(await store.swapCards({ aChildId: "A", aCardId: "x", bChildId: "B", bCardId: "y" })).toBe(false);
+      expect(await store.cardCount("C", "x")).toBe(3);
+      expect(await store.cardCount("C", "y")).toBe(3);
+    });
+
     it("swapCards swaps two duplicates cleanly", async () => {
       const store = await makeStore({ A: { x: 2 }, B: { y: 2 } });
       expect(await store.swapCards({ aChildId: "A", aCardId: "x", bChildId: "B", bCardId: "y" })).toBe(true);

--- a/tests/delete-path.pbt.test.ts
+++ b/tests/delete-path.pbt.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import { makeTradeService } from "@/features/trade/trade-service";
+import { makePullService } from "@/features/pull/pull-service";
+import { SACRIFICE_COST } from "@/features/pull/sacrifice";
+import { inMemoryCollectionStore, type CollectionSeed } from "@/db/stores/collection-store.fake";
+import { inMemoryChildStore } from "@/db/stores/child-store.fake";
+import type { CollectionStore } from "@/db/stores/collection-store";
+import type { Catalog } from "@/features/pool/catalog";
+import type { RewardGranter } from "@/features/rewards/reward-granter";
+import type { Card, Rarity } from "@/lib/types";
+
+/**
+ * OQ-CS-3 — "no service path can delete a `collections` row it doesn't own."
+ *
+ * The definition documents carried this as a GAP for the whole of Increment 23:
+ * Property-Based Testing is a *blocking* constraint, `resetPool()` got a narrow
+ * guard and a narrow test (T7 choice d), and the general statement was deferred
+ * with the note that "that reasoning should be re-examined, not inherited."
+ * This file is the re-examination.
+ *
+ * WHAT "OWN" MEANS HERE, because the word is doing all the work. A service call
+ * names its participants — sacrifice names one (child, card); a trade names two
+ * children and two cards. Every OTHER (child, card) pair is a bystander, and the
+ * property is that bystanders are untouched. Not "nothing is ever deleted": the
+ * invariant is about SCOPE.
+ *
+ * WHAT THIS FILE CANNOT REACH, stated so nobody reads it as wider than it is.
+ * The store's row-DELETE branch (`removeCard` reaching exactly 0) is
+ * unreachable from any service: sacrifice passes `minHeld = SACRIFICE_COST + 1`
+ * so it always keeps a copy, and a swap requires `held >= 2` on both givers. A
+ * mutation that dropped the `child_id` predicate from that DELETE was NOT caught
+ * here — it was caught by the concrete bystander cases in the shared store
+ * contract, which call the store directly and run against real Postgres too.
+ * Each catches a class the other structurally cannot; neither subsumes the other.
+ * That asymmetry is the reason both exist, and it was found by mutating rather
+ * than by reasoning.
+ *
+ * Runs against the in-memory fake, which is where the depth is: CI sets
+ * FC_NUM_RUNS=1000.
+ */
+
+/** One rarity for every card ON PURPOSE — see the reachability guards below. */
+const TRADE_RARITY: Rarity = "rare";
+
+function card(id: string, rarity: Rarity = TRADE_RARITY): Card {
+  return { id, themeId: "t1", name: id, rarity, imageUrl: "", eduText: "", sourceUrl: "" };
+}
+
+function fakeCatalog(cards: Card[]): Catalog {
+  const byId = new Map(cards.map((c) => [c.id, c]));
+  return {
+    async listCards() {
+      return cards;
+    },
+    async getCard(id) {
+      return byId.get(id) ?? null;
+    },
+    async listThemes() {
+      return [];
+    },
+  };
+}
+
+/** Rewards are best-effort in both services; a no-op keeps the property on the seam. */
+const noRewards: RewardGranter = {
+  async grantCompletionRewards() {
+    return [];
+  },
+};
+
+/**
+ * The whole world as a flat `child/card -> count` map. Flat on purpose: the
+ * assertion is a set-difference over KEYS, so a copy that moved between children
+ * shows up as two changed keys rather than hiding inside a nested compare.
+ */
+type Snapshot = Map<string, number>;
+const key = (childId: string, cardId: string) => `${childId}/${cardId}`;
+
+async function snapshot(
+  store: CollectionStore,
+  childIds: readonly string[],
+  cardIds: readonly string[],
+): Promise<Snapshot> {
+  const out: Snapshot = new Map();
+  for (const childId of childIds) {
+    const counts = await store.ownedCounts(childId, [...cardIds]);
+    for (const cardId of cardIds) out.set(key(childId, cardId), counts[cardId] ?? 0);
+  }
+  return out;
+}
+
+/** Keys whose count differs between two snapshots of the same world. */
+function changedKeys(before: Snapshot, after: Snapshot): string[] {
+  const changed: string[] = [];
+  for (const [k, v] of before) {
+    if (after.get(k) !== v) changed.push(k);
+  }
+  return changed.sort();
+}
+
+// --- Generators --------------------------------------------------------------
+
+const CHILD_IDS = ["kid1", "kid2", "kid3", "kid4"] as const;
+const CARD_IDS = ["c1", "c2", "c3", "c4"] as const;
+const ALL_CARDS = CARD_IDS.map((id) => card(id));
+
+/**
+ * A populated world: every child holds a (possibly zero) count of every card.
+ * Counts reach SACRIFICE_COST + 2 so a sacrifice is sometimes affordable and
+ * sometimes refused — both branches have to keep bystanders safe, and a
+ * generator that only produced refusals would prove nothing about the path that
+ * actually writes.
+ */
+const worldArb: fc.Arbitrary<CollectionSeed> = fc
+  .tuple(
+    ...CHILD_IDS.map(() =>
+      fc.tuple(...CARD_IDS.map(() => fc.integer({ min: 0, max: SACRIFICE_COST + 2 }))),
+    ),
+  )
+  .map((rows) => {
+    const seed: CollectionSeed = {};
+    rows.forEach((counts, ci) => {
+      const cards: Record<string, number> = {};
+      counts.forEach((n, di) => {
+        if (n > 0) cards[CARD_IDS[di]] = n;
+      });
+      seed[CHILD_IDS[ci]] = cards;
+    });
+    return seed;
+  });
+
+const childArb = fc.constantFrom(...CHILD_IDS);
+const cardArb = fc.constantFrom(...CARD_IDS);
+
+function makeTrade(collections: CollectionStore) {
+  return makeTradeService({
+    collections,
+    catalog: fakeCatalog(ALL_CARDS),
+    rewards: noRewards,
+    profiles: { async listChildren() { return []; } },
+  });
+}
+
+function makePull(collections: CollectionStore) {
+  return makePullService({
+    children: inMemoryChildStore(
+      Object.fromEntries(CHILD_IDS.map((id) => [id, { easterEggTickets: 0, pullTokens: 0 }])),
+    ),
+    collections,
+    catalog: fakeCatalog(ALL_CARDS),
+    rewards: noRewards,
+  });
+}
+
+describe("OQ-CS-3: no service path touches a collections row outside its named scope", () => {
+  it("property: sacrifice changes only the (child, card) it names", async () => {
+    // REACHABILITY GUARD. An earlier draft of this file gave the four cards four
+    // different rarities, which made `validateTrade` reject every generated trade
+    // — three green properties that exercised nothing. Counting the writes and
+    // asserting the count is non-zero is what turns "it passed" into "it ran".
+    let burned = 0;
+
+    await fc.assert(
+      fc.asyncProperty(worldArb, childArb, cardArb, async (world, childId, cardId) => {
+        const collections = inMemoryCollectionStore(world);
+        const pull = makePull(collections);
+
+        const before = await snapshot(collections, CHILD_IDS, CARD_IDS);
+        // A refusal is a legitimate outcome, not a failure — the invariant holds
+        // on BOTH branches, so the throw is absorbed and the same assertions run.
+        const ok = await pull
+          .sacrifice(childId, cardId)
+          .then(() => true)
+          .catch(() => false);
+        const after = await snapshot(collections, CHILD_IDS, CARD_IDS);
+        if (ok) burned++;
+
+        for (const k of changedKeys(before, after)) {
+          expect(k).toBe(key(childId, cardId));
+        }
+
+        // Down by exactly the cost, never below the one copy the child keeps.
+        const b = before.get(key(childId, cardId))!;
+        const a = after.get(key(childId, cardId))!;
+        expect(a === b || a === b - SACRIFICE_COST).toBe(true);
+        if (a !== b) expect(a).toBeGreaterThanOrEqual(1);
+      }),
+    );
+
+    expect(burned).toBeGreaterThan(0);
+  });
+
+  it("property: a trade changes only the four (child, card) pairs it names", async () => {
+    let applied = 0;
+
+    await fc.assert(
+      fc.asyncProperty(
+        worldArb,
+        childArb,
+        cardArb,
+        childArb,
+        cardArb,
+        async (world, aChildId, aCardId, bChildId, bCardId) => {
+          const collections = inMemoryCollectionStore(world);
+          const before = await snapshot(collections, CHILD_IDS, CARD_IDS);
+          const res = await makeTrade(collections).executeTrade({
+            aChildId,
+            aCardId,
+            bChildId,
+            bCardId,
+          });
+          const after = await snapshot(collections, CHILD_IDS, CARD_IDS);
+          if (res.ok) applied++;
+
+          const named = new Set([
+            key(aChildId, aCardId),
+            key(aChildId, bCardId),
+            key(bChildId, aCardId),
+            key(bChildId, bCardId),
+          ]);
+          for (const k of changedKeys(before, after)) {
+            expect(named.has(k)).toBe(true);
+          }
+        },
+      ),
+    );
+
+    expect(applied).toBeGreaterThan(0);
+  });
+
+  it("property: a trade never reduces a bystander child's total holdings", async () => {
+    // Stated over TOTALS as well as per-card keys on purpose. A bug that moved a
+    // copy between two of a bystander's OWN cards leaves every per-card key
+    // changed-but-balanced; a bug that deleted one does not.
+    let applied = 0;
+
+    await fc.assert(
+      fc.asyncProperty(
+        worldArb,
+        childArb,
+        cardArb,
+        childArb,
+        cardArb,
+        async (world, aChildId, aCardId, bChildId, bCardId) => {
+          const collections = inMemoryCollectionStore(world);
+          const total = async (childId: string) =>
+            (await collections.entries(childId)).reduce((n, e) => n + e.count, 0);
+
+          const bystanders = CHILD_IDS.filter((id) => id !== aChildId && id !== bChildId);
+          const before = new Map<string, number>();
+          for (const id of bystanders) before.set(id, await total(id));
+
+          const res = await makeTrade(collections).executeTrade({
+            aChildId,
+            aCardId,
+            bChildId,
+            bCardId,
+          });
+          if (res.ok) applied++;
+
+          for (const id of bystanders) {
+            expect(await total(id)).toBe(before.get(id));
+          }
+        },
+      ),
+    );
+
+    expect(applied).toBeGreaterThan(0);
+  });
+
+  it("property: no service path ever removes a (child, card) row", async () => {
+    // The strong form, and true today: sacrifice keeps a copy and a swap needs a
+    // duplicate, so a row can APPEAR (the receiving side of a trade) but never
+    // disappear. Every row that vanishes in production does so through a CASCADE
+    // — child deleted, or card/theme pruned — which is pinned in tests-pg where
+    // a cascade can actually be observed. If a future service ever needs to burn
+    // a last copy, this property is the one that should be argued with first.
+    let acted = 0;
+
+    await fc.assert(
+      fc.asyncProperty(
+        worldArb,
+        childArb,
+        cardArb,
+        childArb,
+        cardArb,
+        async (world, aChildId, aCardId, bChildId, bCardId) => {
+          const collections = inMemoryCollectionStore(world);
+          const heldKeys = async () => {
+            const out = new Set<string>();
+            for (const id of CHILD_IDS) {
+              for (const e of await collections.entries(id)) out.add(key(id, e.cardId));
+            }
+            return out;
+          };
+
+          const before = await heldKeys();
+          const trade = await makeTrade(collections).executeTrade({
+            aChildId,
+            aCardId,
+            bChildId,
+            bCardId,
+          });
+          const sac = await makePull(collections)
+            .sacrifice(aChildId, aCardId)
+            .then(() => true)
+            .catch(() => false);
+          if (trade.ok || sac) acted++;
+
+          const after = await heldKeys();
+          for (const k of before) expect(after.has(k)).toBe(true);
+        },
+      ),
+    );
+
+    expect(acted).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
OQ-CS-3 was the last named gap where a **blocking** constraint went unmet. PBT is blocking; `resetPool()` got a narrow guard and a narrow test (T7 choice d); the general statement was deferred with the note that *"that reasoning should be re-examined, not inherited."*

This is the re-examination, and **the deferral holds up** — a narrow test was better than none. What it couldn't do was *say* the general thing, and saying it turns out to need two homes.

## `tests/delete-path.pbt.test.ts` — scope, at depth

Generates a world of 4 children × 4 cards, always **larger** than any operation touches, so a bystander exists to be harmed. Four properties:

- a sacrifice changes only the `(child, card)` it names, never below the one copy the child keeps;
- a trade changes only its four named pairs;
- a trade never reduces a bystander's **total** holdings (catches a balanced-but-wrong move);
- **no service path ever removes a row at all** — the strong form, true today.

## `tests-pg/delete-path.pg.test.ts` — the cascades

Every row that vanishes in production vanishes through a cascade, and a fake has none to get wrong. **BR14 was documented but untested**; the `seed --sync` pruners had no pg coverage at all.

## Four things worth carrying

**1. The pruners have no structural guard.** Unlike `resetPool()`, `deleteThemesNotIn`/`deleteCardsNotIn` cascade into `collections` with no owned-rows check — only the CLI's `--allow-prune` and a typed confirmation. **An empty keep-list deletes every theme, card and collection row**, because `pruneNotIn` reads "keep nothing" as "no filter". Pinned as behaviour with a loud comment rather than changed: a prune that couldn't remove a dropped card wouldn't be a prune. This is the sharpest remaining edge in the delete story.

**2. Three of the four properties were vacuous as first written, and passed.** The four test cards had four different rarities, so `validateTrade` rejected every generated trade before it reached the store — green properties exercising nothing, which is this project's signature failure mode in a new costume. Each property now **counts its own writes and asserts the count is non-zero**.

**3. Neither location subsumes the other — found by mutating, not by reasoning.** The store's row-DELETE branch is unreachable from any service (sacrifice keeps a copy; a swap needs a duplicate), so a mutation dropping `child_id` from that DELETE was missed by the properties entirely and caught only by the new concrete bystander cases in the shared contract, which also run against **real Postgres** where the properties deliberately don't.

**4. Every assertion was proven to bite.** Five mutations, each reverted:

| Mutation | Caught by |
|---|---|
| `removeCard` loses its `child_id` predicate | contract bystander case (not the properties — see 3) |
| `swapCards` decrements every holder | 2 properties, shrunk to 12- and 14-step counterexamples |
| `sacrifice` may burn a last copy | 2 properties, shrunk to 14 and 10 steps |
| `pgProfileStore.remove` loses its id predicate | both BR14 cascade tests |
| `deleteCardsNotIn` loses its theme scope | both pruner scope tests |

## Counts

**52 files / 329 tests** unit (was 51/321), **7 suites / 57 passed** pg (was 6/47), 23 PBT files, 104 `fc.assert` sites. Refreshed in `technical-environment.md` and `ci.yml`, where they had gone stale again since #38.