### PR TITLE
docs(definition): correct the false "repo must stay private" security claim

### DIFF
--- a/Product-Definition/features/collection-safety/technical-environment.md
+++ b/Product-Definition/features/collection-safety/technical-environment.md
@@ -77,7 +77,7 @@ Ways an agent could plausibly break this feature *while writing reasonable-looki
 
 | Service | Constraints / Notes |
 |---------|---------------------|
-| **GitHub Actions** | Free tier. Private repo `nywleswoey/kids-collection` `[from: gh repo view]` → 2,000 minutes/month included; a nightly dump costs roughly 45 min/month. **Well inside free — but it is a shared budget**, so future CI (parent OQ-T-2) draws from the same pool |
+| **GitHub Actions** | Free tier. ~~Private repo → 2,000 minutes/month included~~ **CORRECTED 2026-08-12: the repo is PUBLIC, and public repos get unlimited standard-runner minutes.** A nightly dump costs roughly 45 min/month and CI (parent OQ-T-2, now shipped) roughly 3.5 min per PR — neither draws on a budget. ⚠️ The original "shared budget" note was not merely over-cautious: **going private silently converts this to a metered 2,000 min/month allowance**, and would also disable branch-protection rulesets on GitHub Free. Both were observed during the ~9 hours the repo spent private on 2026-08-10 |
 | **GitHub Actions artifacts** | Free tier, default 90-day retention. The sole backup destination. Gzipped dump of 300 cards + 3 children is expected well under 1 MB |
 | **Neon PITR** | Already included on the current plan. **Verified retention: 6 hours.** No configuration change or cost |
 
@@ -150,8 +150,37 @@ This is a deliberate expansion, recorded rather than assumed:
   to hold write credentials, and this is the cheapest available reduction in blast radius.
 - The secret must never be echoed. `pg_dump` failures can print connection strings — redact or suppress
   verbose output.
-- Artifacts contain a **full copy of the production database**. Repository visibility is what protects
-  them; the repo must stay private, and that is now a security property, not merely a preference.
+- Artifacts contain a **full copy of the production database**.
+  ~~Repository visibility is what protects them; the repo must stay private, and that is now a security
+  property, not merely a preference.~~
+  > ### ⚠️ CORRECTED 2026-08-12 — this is false now, and the exposure it describes actually happened
+  >
+  > **The repository is public** (`gh repo view` → `PUBLIC`, 2026-08-12). An Actions artifact is
+  > downloadable by anyone with **read** access, which on a public repo is every logged-in GitHub user.
+  > Roughly a week of the children's collection data was retrievable by anyone until 2026-08-10.
+  >
+  > *When it stopped being private is not established.* The interview record for this feature cites
+  > `gh repo view` reporting **private** on 2026-08-05, so this line may well have been true the day it
+  > was written. That does not soften it — it sharpens it. **A security property that depends on a
+  > setting nobody watches is not a security property**, and this one silently stopped holding without a
+  > single document noticing.
+  >
+  > It is also why the leak went unnoticed: the line states a protection confidently enough that a reader
+  > checking "are the artifacts safe?" would stop here and be satisfied. The `$0/month` and "public repo"
+  > constraints were carried faithfully elsewhere in the parent documents — they were simply never read
+  > as statements about where the *backups* end up.
+  >
+  > **What actually protects them now is encryption, not visibility** (#40). The dump is GPG-encrypted to
+  > a public key committed at `.github/backup-pubkey.asc` before upload, so the runner can write a backup
+  > it cannot read. No decryption key exists in CI, and nothing whose compromise retroactively exposes
+  > past dumps.
+  >
+  > **Making the repo private is not the fix and must not be treated as one.** It was tried first and
+  > reverted: rulesets are unavailable on private repos on GitHub Free, so it disabled the branch
+  > protection enforcing the CI gates — fixing an exposure by removing an enforcement mechanism.
+  >
+  > The residual risk moved rather than vanishing: **lose the private key and every dump in the 90-day
+  > window is silently unrecoverable.** See `docs/RESTORE.md` §3.2 and #45.
 
 ### Unchanged
 

--- a/Product-Definition/vision-document.md
+++ b/Product-Definition/vision-document.md
@@ -278,3 +278,26 @@ Next.js App Router + TypeScript + Tailwind application on Vercel, with Neon Post
   `SACRIFICE_MIN = 4` in `src/features/pull/sacrifice.ts`, consumed by both the card detail page and the
   galaxy filter, with a property-based test asserting the equivalence. The values are correct as-is; the
   invariant is that they are never hardcoded anywhere else.
+- **A pool reset must never delete `collections`.** `cards.theme_id` and `collections.card_id` are both
+  `ON DELETE CASCADE`, so deleting the pool destroys every child's cards regardless of what the function
+  names. `resetPool()` therefore refuses outright while any collection row exists, and has **no override
+  parameter** — re-adding one re-arms the exact defect it exists to remove. A caller that genuinely wants
+  both operations calls both. *(Increment 23 FR1. The neighbouring `seed --sync` pruners are NOT guarded
+  this way — see #12.)*
+- **A destructive seed operation must detect production and require a fresh typed confirmation.** Never
+  an environment variable, a config file or a flag — those are all satisfiable by a script, which is the
+  failure this exists to prevent. It prints its blast radius per child, by name, requires the exact
+  collection-row count typed at an interactive terminal, and always aborts when there is no TTY.
+- **The backup is a full dump, with no `-t`/`-n` allowlist, ever.** A table allowlist silently stops
+  covering whatever is added next, and the tables most worth losing are the ones nobody remembered to
+  list.
+- **The restore drill runs on every backup run.** A dump that has not been restored is a claim, not a
+  backup: each run restores its own output into a throwaway Postgres and asserts every table is present
+  with exactly the production row count. A green run means a dump that *provably restored* at the time it
+  was taken. **And since #40 the artifact is GPG-encrypted before upload** — the repository is public, so
+  visibility protects nothing; encryption is what makes the destination safe.
+- **No service path may touch a `collections` row outside its named scope.** A sacrifice names one
+  `(child, card)`; a trade names two children and two cards; every other pair is a bystander and must be
+  untouched. Enforced since 2026-08-12 by properties in `tests/delete-path.pbt.test.ts` and cascade cases
+  in `tests-pg/delete-path.pg.test.ts` (OQ-CS-3), which also pin BR14: deleting a child takes their rows
+  and nobody else's.


### PR DESCRIPTION
`features/collection-safety/technical-environment.md` stated:

> Artifacts contain a **full copy of the production database**. Repository visibility is what protects them; the repo must stay private, and that is now a security property, not merely a preference.

**The repo is public** (`gh repo view` → `PUBLIC`). An Actions artifact is downloadable by anyone with read access, which on a public repo is every logged-in GitHub user — and roughly a week of the children's collection data was retrievable by anyone until 2026-08-10.

The line describes a protection that does not exist, and it is plausibly *why* that went unnoticed for months: it answers "are the artifacts safe?" confidently enough that a reader stops there. The `$0/month` and "public repo" constraints were carried faithfully elsewhere — they were simply never read as statements about where the *backups* end up.

**When the repo stopped being private is not established, and the correction says so rather than guessing.** The feature's own interview record cites `gh repo view` reporting *private* on 2026-08-05, so the line may have been true the day it was written. That sharpens it rather than softening it: **a security property that depends on a setting nobody watches is not a security property**, and this one stopped holding without a single document noticing.

What protects the artifacts now is **encryption, not visibility** (#40) — the dump is GPG-encrypted to a committed public key before upload, so the runner can write a backup it cannot read. The correction also records that **going private is not the fix**: it was tried first and reverted, because rulesets are unavailable on private repos on GitHub Free, so it disabled the branch protection enforcing the CI gates.

Same file, Actions row: *"Private repo → 2,000 minutes/month"* → unlimited standard-runner minutes, with the observed consequence that going private silently converts it back to a metered allowance.

## Also: the "What Must NOT Change" additions Increment 23 owed the parent

Four from #12 item 3, plus a fifth from #44:

- a pool reset must never delete `collections` — both FKs cascade, so `resetPool()` refuses while any row exists and has **no override parameter**;
- a destructive seed operation must detect production and require a **fresh typed confirmation**, never an env var, config file or flag — all satisfiable by a script, which is the failure this prevents;
- the backup is a **full dump, no `-t`/`-n` allowlist, ever** — an allowlist silently stops covering whatever is added next;
- the **restore drill runs on every backup run** — a dump that has not been restored is a claim, not a backup;
- **no service path may touch a `collections` row outside its named scope** (OQ-CS-3).

Interview histories left frozen on #38's precedent, including the one recording the original "private" observation — that is a record of what was seen at the time, not a live claim.

Closes item 3 of #12.