### PR TITLE
ci(backup): add a dead-man's switch so a backup that never runs is noticed

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -304,3 +304,62 @@ jobs:
 
       - name: Verify the backup restores exactly
         run: pnpm exec tsx scripts/backup/verify.ts prod-counts.tsv restored-counts.tsv
+
+      # The dead-man's switch, and the ONLY thing here that can report a backup
+      # which never ran. Everything else in this file reports on a run that
+      # happened; this repo's whole alerting posture is "a failed run is your
+      # alert", and a failed run is still a run. The gap that closes:
+      #
+      #   GitHub disables scheduled workflows in a PUBLIC repo after 60 days
+      #   with no repository activity — and a scheduled run is NOT activity, so
+      #   this workflow cannot keep itself alive. Two quiet months is ordinary
+      #   for a one-parent side project. Backups stop, no run fails, nothing is
+      #   emitted, and the first symptom is discovering there is no dump on the
+      #   day you need one. (Disabling appears to take `workflow_dispatch` with
+      #   it, so the manual "dump before doing something destructive" button
+      #   goes too — reported by others, not verified here.)
+      #
+      # Inverting the signal is what fixes it: the monitor expects a ping on a
+      # schedule and alerts on SILENCE, so it fires for every cause of "no
+      # backup" at once — dormancy, a disabled workflow, a rotated
+      # BACKUP_DATABASE_URL, a deleted repo, an account suspension. None of
+      # those can produce a failed run to notify on.
+      #
+      # LAST step, and deliberately NOT `if: always()`. A ping has to mean "a
+      # verified backup exists", not "the job got this far" — it is sent only
+      # after the restore-and-compare above has passed, so an unrestorable dump
+      # stays silent and trips the alarm exactly like a missing one.
+      #
+      # A failed ping does NOT fail the job. A monitoring outage must never turn
+      # a good backup red, and the failure direction is already safe: if the
+      # ping does not arrive, you are told. False alarm, never false calm.
+      #
+      # The URL is a SECRET because it is a capability, not an address —
+      # whoever holds it can silence the alarm by pinging on this job's behalf,
+      # which on a public repo would otherwise be anyone. It is the second
+      # secret in this workflow and, unlike BACKUP_DATABASE_URL, it reaches
+      # nothing: worst case is a muted alarm, never data.
+      #
+      # Absent secret = armed-but-not-configured, announced rather than assumed,
+      # so adding this step could not break tonight's run before the check
+      # exists. Setup: docs/RESTORE.md §5.
+      - name: Signal the dead-man's switch
+        env:
+          PING_URL: ${{ secrets.BACKUP_PING_URL }}
+        run: |
+          set -uo pipefail
+          if [ -z "${PING_URL:-}" ]; then
+            echo "::warning::BACKUP_PING_URL is not set — the dead-man's switch is NOT armed."
+            echo "A backup that stops running will go unnoticed. See docs/RESTORE.md §5."
+            exit 0
+          fi
+          # --retry covers a blip in the monitor, not in the backup. -o /dev/null
+          # keeps the response body out of a public log; GitHub masks the secret
+          # itself, but there is no reason to print either.
+          if curl -fsS -m 10 --retry 3 --retry-delay 2 -o /dev/null "$PING_URL"; then
+            echo "Dead-man's switch signalled: a verified backup exists."
+          else
+            echo "::warning::Ping failed. The backup itself is fine and verified —"
+            echo "expect an alert from the monitor, and treat it as a false alarm."
+          fi
+        shell: bash

--- a/Product-Definition/technical-environment.md
+++ b/Product-Definition/technical-environment.md
@@ -285,6 +285,13 @@ gitignored and untracked (verified); `.env.example` carries placeholders only an
 - **Server-only secrets**: `AUTH_SECRET`, `AUTH_GOOGLE_ID`, `AUTH_GOOGLE_SECRET`, `PARENT_EMAILS`,
   `ADMIN_PASSCODE`, `DATABASE_URL`, `BLOB_READ_WRITE_TOKEN`.
 - **Deliberately public** (`NEXT_PUBLIC_` prefix): the PostHog project token and host.
+- **GitHub Actions repository secrets** — a separate surface from the app's, and deliberately small
+  because the repository is public. Exactly two, both belonging to `backup.yml`:
+  `BACKUP_DATABASE_URL` (a **read-only** Neon role, `kc_backup_ro`, direct non-pooler endpoint) and
+  `BACKUP_PING_URL` (the dead-man's-switch ping — a *capability* rather than an address, since whoever
+  holds it can silence the alarm; it reaches no data, so the worst case is a muted alarm). **`ci.yml`
+  uses no secrets at all**, and that is a property worth keeping: a workflow that holds no secret
+  cannot leak one.
 
 **Standing constraint, verified every increment**: no secret may reach the client bundle. `ADMIN_PASSCODE`
 and `AUTH_SECRET` are server-only; the admin gate ships a *signed cookie*, never the passcode itself.

--- a/docs/RESTORE.md
+++ b/docs/RESTORE.md
@@ -162,13 +162,53 @@ exist in the target.
 ## 5. Keeping the backup alive
 
 - **The schedule stops after 60 days of repository inactivity.** GitHub disables scheduled workflows
-  in dormant repositories and emails the repository owner. If this project goes quiet for two months,
-  re-enable the workflow from the Actions tab. Nothing else re-arms it.
+  in dormant **public** repositories and emails the repository owner. A scheduled run does **not**
+  count as activity — only something that modifies the repo (a push, a release, a merged PR) — so this
+  workflow cannot keep itself alive. Re-enable it from the Actions tab; nothing else re-arms it.
+  Disabling also appears to take `workflow_dispatch` with it, so the manual trigger below would be
+  gone too.
 - **Every run verifies itself.** The workflow restores its own dump into a throwaway Postgres and
   asserts every table is present with exactly the production row count. A failed run means the
   backup is not trustworthy — investigate it rather than waiting for the next night.
-- **A failed run is your alert.** GitHub notifies on workflow failure by default. There is no other
-  alerting, by design.
+- **A failed run is your alert — but a run that never happens cannot fail.** That gap is what the
+  dead-man's switch below closes. Apart from it, GitHub's default workflow-failure notification is
+  the only alerting, by design.
+
+### 5.1 The dead-man's switch
+
+The last step of `backup.yml` pings a monitoring service **only after** the restore-and-compare has
+passed. The monitor expects that ping on a schedule and **alerts on silence**, which inverts the
+signal: instead of reporting failures it can see, it reports the absence of success. One alarm covers
+every way a backup can stop — the 60-day dormancy above, a disabled workflow, a rotated
+`BACKUP_DATABASE_URL`, a deleted repo, a suspended account — none of which can produce a failed run
+to notify on.
+
+**False alarm, never false calm.** A monitoring outage rings the bell for a backup that was fine; no
+combination of failures rings it for a backup that was not.
+
+**Setup — this is not armed until you do it.** Until `BACKUP_PING_URL` exists, every run prints a
+warning saying so, and the backup still works exactly as before.
+
+1. Create a free account at a cron-monitoring service — [healthchecks.io](https://healthchecks.io) is
+   the obvious pick (free tier, open source, self-hostable if you ever want to move it).
+2. Add a check:
+   - **Name**: `kids-collection nightly backup`
+   - **Schedule**: `0 18 * * *` (matching `backup.yml`), timezone UTC
+   - **Grace period**: `2 hours` — a run takes minutes, so anything beyond that is a real problem.
+3. Copy the check's **ping URL**.
+4. Add it as a repository secret named **`BACKUP_PING_URL`**:
+   `gh secret set BACKUP_PING_URL --repo nywleswoey/kids-collection`
+5. Set the alert destination to an address you actually read. An alarm nobody sees is the thing this
+   was built to stop.
+6. **Prove it before trusting it**, both directions:
+   - Actions → **backup** → **Run workflow**. The check should go green within a minute.
+   - Then leave it alone past the grace period, or hit the service's "test alert" button, and
+     confirm the alert actually lands. A dead-man's switch that has never been observed to fire is a
+     claim, not a mechanism — the same standard the restore drill in §3.2 is held to.
+
+⚠️ **The ping URL is a secret because it is a capability, not an address.** Anyone holding it can
+silence the alarm by pinging on the workflow's behalf, which on a public repo would otherwise be
+anyone. Unlike `BACKUP_DATABASE_URL` it reaches no data — the worst case is a muted alarm.
 - **Take a dump before doing anything destructive.** Actions → backup → **Run workflow**. That is
   what the manual trigger is for.
 - **The backup credential is read-only** (`kc_backup_ro`, direct non-pooler endpoint, stored as the


### PR DESCRIPTION
Every alert this repo has reports on a run that **happened**. The stated posture is *"a failed run is your alert"* — and a failed run is still a run. **Nothing reports a backup that silently stopped.**

That isn't hypothetical. GitHub disables scheduled workflows in a **public** repo after 60 days with no repository activity, and **a scheduled run does not count as activity** — so `backup.yml` cannot keep itself alive. Two quiet months is ordinary for a one-parent side project. Backups stop, no run fails, nothing is emitted, and the first symptom is discovering there is no dump on the day you need one. Disabling also appears to take `workflow_dispatch` with it, so the manual "dump before doing something destructive" trigger would be gone at the same moment you'd reach for it.

**Inverting the signal fixes the class, not just the cause.** The monitor expects a ping on a schedule and **alerts on silence**. One alarm now covers dormancy, a disabled workflow, a rotated `BACKUP_DATABASE_URL`, a deleted repo, a suspended account — none of which can produce a failed run to notify on.

## Three decisions worth stating

- **Last step, and deliberately not `if: always()`.** A ping must mean *"a verified backup exists"*, not *"the job got this far"* — it is sent only after the restore-and-compare passes. An unrestorable dump stays silent and trips the alarm exactly like a missing one.
- **A failed ping does not fail the job.** A monitoring outage must never turn a good backup red, and the failure direction is already safe: **false alarm, never false calm.**
- **The URL is a secret because it is a capability, not an address.** Whoever holds it can silence the alarm by pinging on the workflow's behalf, which on a public repo would otherwise be anyone. Unlike `BACKUP_DATABASE_URL` it reaches no data — worst case is a muted alarm.

## ⚠️ Not armed until you finish setup

Until `BACKUP_PING_URL` exists the step announces itself with a warning and exits 0, so merging this cannot break tonight's run before the check is created. The backup behaves exactly as before.

Runbook in `docs/RESTORE.md` §5.1 — create the check (schedule `0 18 * * *` UTC, 2 h grace), `gh secret set BACKUP_PING_URL`, point alerts at an address you actually read, then **prove it in both directions**: confirm a manual run turns the check green, *and* confirm the alert actually lands. A dead-man's switch that has never been observed to fire is a claim, not a mechanism — the same standard §3.2's restore drill is held to.

Also records the second Actions secret in `technical-environment.md`, alongside the note that `ci.yml` still uses **none**.

Addresses item 2 of #45.