### PR TITLE
docs(state): mark the state files frozen instead of leaving them silently wrong

### DIFF
--- a/Product-Definition/state/business-state.md
+++ b/Product-Definition/state/business-state.md
@@ -1,4 +1,15 @@
 # Business State
+
+> ### ❄️ FROZEN SNAPSHOT — not a live index. Do not trust the counts below.
+>
+> This records the state of the definition session **as approved on 2026-08-03**, and is deliberately
+> not maintained. **The live source is `Product-Definition/open-questions.md`.**
+>
+> As of 2026-08-12 the *"Business: 3 open"* line below is wrong: **1** is open (OQ-B-3). OQ-B-2 closed
+> 2026-08-07 and OQ-B-1 — the highest-stakes item in the whole set — closed 2026-08-11.
+>
+> See the fuller note in `technical-state.md` for why this box exists rather than a corrected number.
+
 - Status: complete
 
 ## Role Progress

--- a/Product-Definition/state/session-index.md
+++ b/Product-Definition/state/session-index.md
@@ -1,4 +1,11 @@
 # Discovery Session Index
+
+> ### ❄️ FROZEN SNAPSHOT — not a live index.
+>
+> Records the discovery session **as it stood on 2026-08-03** and is deliberately not maintained. The
+> *"Last Updated"* stamp below refers to that session, not to this directory. See
+> `technical-state.md` for why these files are frozen rather than corrected.
+
 - Created / Last Updated: 2026-08-03T02:51:17Z
 - Project Type: Feature on existing
 - Depth: full

--- a/Product-Definition/state/technical-state.md
+++ b/Product-Definition/state/technical-state.md
@@ -1,4 +1,20 @@
 # Technical State
+
+> ### ❄️ FROZEN SNAPSHOT — not a live index. Do not trust the counts below.
+>
+> This records the state of the definition session **as approved on 2026-08-03**, and is deliberately
+> not maintained. It is kept because the history is worth having, not because it is current.
+>
+> **The live sources are `Product-Definition/open-questions.md` and the documents themselves.** As of
+> 2026-08-12 the open-question counts here are wrong in both roles — Business is **1** open, not 3
+> (OQ-B-1 closed 2026-08-11, OQ-B-2 closed 2026-08-07), and Technical is **1**, not 2 (OQ-T-2 closed
+> 2026-08-09).
+>
+> This banner exists because *"deliberately frozen"* and *"nobody noticed it went stale"* are
+> indistinguishable to a reader, and this project has already been bitten once by a document stating
+> something with confidence long after it stopped being true. If a future effort decides `state/`
+> should be live after all, that is a fine decision — make it explicitly and delete this box.
+
 - Status: complete
 
 ## Role Progress


### PR DESCRIPTION
`state/technical-state.md` says *"Business: 3 open (OQ-B-1..3)"* and `state/business-state.md` says *"Business: 3 open"*. **One is open.** OQ-B-2 closed 2026-08-07, OQ-T-2 closed 2026-08-09, and OQ-B-1 — the highest-stakes item in the set — closed 2026-08-11.

**The numbers are not corrected, deliberately.** #38 set the precedent that `state/` is a frozen record of the definition session rather than a live index, on the grounds that OQ-B-2's closure was never written back there either and treating it as live would adopt a burden this repo already declined. That precedent is kept.

What changes is that the freezing is now **legible**. "Deliberately frozen" and "nobody noticed it went stale" look identical to a reader — and this project has just been bitten by exactly that: a line in the collection-safety technical environment asserted the repo was private long after it stopped being true, and it was believed because it was stated confidently (#46).

So each of the three files opens with a banner that names the snapshot date, points at the live source, and states outright which counts below are wrong. A future effort that decides `state/` should be live is welcome to make that call — the banner says so, and says to delete it when they do.

Addresses item 4 of #12.