### PR TITLE
chore(auth): bump next-auth to 5.0.0-beta.32 for @auth/core 0.41.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@vercel/blob": "^0.27.0",
     "drizzle-orm": "^0.36.4",
     "next": "^15.1.3",
-    "next-auth": "^5.0.0-beta.25",
+    "next-auth": "5.0.0-beta.32",
     "posthog-js": "^1.181.0",
     "posthog-node": "^3.5.0",
     "react": "^19.0.0",
@@ -43,8 +43,8 @@
     "@types/react-dom": "^19.0.2",
     "drizzle-kit": "^0.28.1",
     "fast-check": "^3.23.1",
-    "tsx": "^4.19.2",
     "tailwindcss": "^4.0.0",
+    "tsx": "^4.19.2",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,14 +21,14 @@ importers:
         specifier: ^15.1.3
         version: 15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       next-auth:
-        specifier: ^5.0.0-beta.25
-        version: 5.0.0-beta.31(next@15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+        specifier: 5.0.0-beta.32
+        version: 5.0.0-beta.32(next@15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       posthog-js:
         specifier: ^1.181.0
         version: 1.406.2(preact-render-to-string@6.5.11(preact@10.24.3))
       posthog-node:
         specifier: ^3.5.0
-        version: 3.6.3(debug@4.4.3)
+        version: 3.6.3
       react:
         specifier: ^19.0.0
         version: 19.2.7
@@ -79,12 +79,12 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@auth/core@0.41.2':
-    resolution: {integrity: sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==}
+  '@auth/core@0.41.3':
+    resolution: {integrity: sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
-      nodemailer: ^7.0.7
+      nodemailer: ^7.0.7 || ^8.0.5
     peerDependenciesMeta:
       '@simplewebauthn/browser':
         optional: true
@@ -1607,13 +1607,13 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  next-auth@5.0.0-beta.31:
-    resolution: {integrity: sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==}
+  next-auth@5.0.0-beta.32:
+    resolution: {integrity: sha512-CGlChIEWZ6LltNVxrE5yiySMID+Idpmry47JYA5lLwgD8Sx02a8M65VL0TWVz9nbnOioS/tCW/rP/0+mE7Qp4Q==}
     peerDependencies:
       '@simplewebauthn/browser': ^9.0.1
       '@simplewebauthn/server': ^9.0.2
       next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
-      nodemailer: ^7.0.7
+      nodemailer: ^7.0.7 || ^8.0.5
       react: ^18.2.0 || ^19.0.0
     peerDependenciesMeta:
       '@simplewebauthn/browser':
@@ -1932,7 +1932,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@auth/core@0.41.2':
+  '@auth/core@0.41.3':
     dependencies:
       '@panva/hkdf': 1.2.1
       jose: 6.2.3
@@ -2633,9 +2633,9 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.18.1(debug@4.4.3):
+  axios@1.18.1:
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0
       form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
@@ -2857,9 +2857,7 @@ snapshots:
 
   fflate@0.4.9: {}
 
-  follow-redirects@1.16.0(debug@4.4.3):
-    optionalDependencies:
-      debug: 4.4.3
+  follow-redirects@1.16.0: {}
 
   form-data@4.0.6:
     dependencies:
@@ -2992,9 +2990,9 @@ snapshots:
 
   nanoid@3.3.15: {}
 
-  next-auth@5.0.0-beta.31(next@15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
+  next-auth@5.0.0-beta.32(next@15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@auth/core': 0.41.2
+      '@auth/core': 0.41.3
       next: 15.5.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
 
@@ -3085,9 +3083,9 @@ snapshots:
     transitivePeerDependencies:
       - preact-render-to-string
 
-  posthog-node@3.6.3(debug@4.4.3):
+  posthog-node@3.6.3:
     dependencies:
-      axios: 1.18.1(debug@4.4.3)
+      axios: 1.18.1
       rusha: 0.8.14
     transitivePeerDependencies:
       - debug

--- a/tests/auth-policy.pbt.test.ts
+++ b/tests/auth-policy.pbt.test.ts
@@ -47,4 +47,52 @@ describe("isParentEmail (U2-SEC-3)", () => {
     expect(isParentEmail("", ["a@x.com"])).toBe(false);
     expect(isParentEmail("a@x.com", [])).toBe(false);
   });
+
+  // --- Do NOT Unicode-normalize this comparison. Pinned, with the reasoning,
+  // because the change looks like a security improvement and is the opposite.
+  //
+  // Auth.js shipped a HIGH advisory (GHSA-7rqj-j65f-68wh) for a homoglyph `@`
+  // bypass, fixed by NFKC-normalizing addresses BEFORE validating them. Reading
+  // that and reaching for `.normalize("NFKC")` here is the obvious move and it
+  // would open the hole rather than close it — the two code shapes are mirror
+  // images:
+  //
+  //   Auth.js validated an address, THEN normalized it, and used the normalized
+  //   value downstream. Normalizing later meant the thing checked was not the
+  //   thing used.
+  //
+  //   This function does an EXACT MATCH against a fixed allowlist. Every
+  //   normalization applied to untrusted input maps MORE distinct strings onto
+  //   the allowlisted value, so it can only ever WIDEN what is accepted.
+  //
+  // `toLowerCase` already widens deliberately and is bounded: ASCII case is not
+  // meaningful in the addresses Google issues. NFKC is not bounded — it folds
+  // fullwidth forms, ligatures and compatibility characters onto ASCII, so it
+  // would map a lookalike address onto the parent's.
+  it("does NOT fold Unicode lookalikes onto an allowlisted address", () => {
+    const allow = parseAllowlist("parent@example.com");
+
+    // U+FF20 FULLWIDTH COMMERCIAL AT — NFKC-normalizes to a plain "@".
+    expect("parent＠example.com".normalize("NFKC")).toBe("parent@example.com");
+    expect(isParentEmail("parent＠example.com", allow)).toBe(false);
+
+    // U+1D18 LATIN LETTER SMALL CAPITAL P — no NFKC mapping, rejected anyway.
+    expect(isParentEmail("ᴘarent@example.com", allow)).toBe(false);
+
+    // The real address still matches, so this is not just "everything fails".
+    expect(isParentEmail("parent@example.com", allow)).toBe(true);
+  });
+
+  it("property: only an exact (case/whitespace-insensitive) match is accepted", () => {
+    // The general statement behind the case above: any input that is not the
+    // allowlisted address after trim+lowercase is denied, whatever else it is.
+    fc.assert(
+      fc.property(fc.emailAddress(), fc.string({ maxLength: 12 }), (email, noise) => {
+        const allow = parseAllowlist(email);
+        const candidate = `${email}${noise}`;
+        const expected = candidate.trim().toLowerCase() === email.trim().toLowerCase();
+        expect(isParentEmail(candidate, allow)).toBe(expected);
+      }),
+    );
+  });
 });


### PR DESCRIPTION
`5.0.0-beta.31` / `@auth/core@0.41.2` sits inside the affected range of three advisories published 2026-07-20, two **HIGH**, all fixed in `beta.32` / `0.41.3`:

| Advisory | Severity | Reachable here? |
|---|---|---|
| [GHSA-7rqj-j65f-68wh](https://github.com/nextauthjs/next-auth/security/advisories/GHSA-7rqj-j65f-68wh) — homoglyph `@` bypass in the email normalizer | **HIGH** | No — Google only, no Email provider |
| [GHSA-xmf8-cvqr-rfgj](https://github.com/nextauthjs/next-auth/security/advisories/GHSA-xmf8-cvqr-rfgj) — `getToken()` throws on a malformed `Bearer` header | **HIGH** | No — never called; `middleware.ts` wraps `auth()` |
| [GHSA-x445-f3h2-j279](https://github.com/nextauthjs/next-auth/security/advisories/GHSA-x445-f3h2-j279) — OAuth check cookies not bound to their provider | medium | No — **only because one provider is configured** |

Reachability was checked against `src/auth/config.ts`, `middleware.ts` and `src/features/auth/`, not assumed. The third is a **configuration-dependent** safety and goes live silently the day a second provider is added — which is why this is a bump rather than a shrug.

Patch-level within the beta line: peer deps unchanged and already satisfied, security fixes only, no API change. `typecheck`, **331 tests** and `build` all green locally.

**Pinned exactly rather than restoring the caret**, kept on purpose. `^5.0.0-beta.25` matched every `5.0.0-beta.*` — verified with `semver.satisfies` — so the declared range said the app's only security boundary may float across prereleases. It is also how the installed version had reached beta.31 while `package.json` still said beta.25. The lockfile plus `--frozen-lockfile` meant it never actually drifted in CI or a Vercel build; the exact pin makes the intent match the behaviour.

## ⚠️ The NFKC hardening is NOT here, because my recommendation was backwards

I proposed adding `.normalize("NFKC")` to `isParentEmail`. **It would have opened the hole it claimed to close**, and I caught it by testing the direction of the change instead of assuming it.

The two code shapes are mirror images, not the same bug:

- **Auth.js** validated an address, *then* normalized it, and used the normalized value downstream — so the thing checked was not the thing used. NFKC closes that.
- **`isParentEmail`** does an **exact match** against a fixed allowlist. Every normalization applied to untrusted input maps *more* distinct strings onto the allowlisted value, so NFKC can only **widen** what is accepted.

```
"parent＠example.com"            (U+FF20 FULLWIDTH COMMERCIAL AT)
  .normalize("NFKC")  →  "parent@example.com"    ← would MATCH the allowlist
  today (lowercase only)  →  no match            ← denied, fail-closed
```

The current implementation is **correct as written**. `toLowerCase` widens deliberately and is bounded — ASCII case is not meaningful in the addresses Google issues. NFKC is not bounded.

**So the deliverable is the opposite of what was asked for: a test that stops the change being made.** `tests/auth-policy.pbt.test.ts` now pins the lookalike as denied, carries the full reasoning inline, and adds a property that only an exact case/whitespace-insensitive match is ever accepted. Proven by mutation — adding `.normalize("NFKC")` turns it red.

The research doc is retracted in place on `research/next-auth-v5-status` rather than quietly edited.