### PR TITLE
feat(admin): add passkey management and platform enrolment

### DIFF
--- a/Product-Definition/features/parent-gate-auth/open-questions.md
+++ b/Product-Definition/features/parent-gate-auth/open-questions.md
@@ -132,3 +132,55 @@ convert it from an untested assumption into a verified one. Cheap; nothing to bu
 4. **OQ-PG-5** — recorded for the future reader; no action.
 AI-DLC should load this file during Requirements Analysis and resolve each entry before proceeding to
 User Stories or Application Design.
+
+---
+
+## OQ-PG-4 — RESOLVED 2026-08-13, negatively
+
+Tested on production per `docs/PASSKEY-CUTOVER.md` §1.1: with 1Password already unlocked, the passkey
+assertion completed on a **single button click, with no biometric or password prompt**.
+
+**This is not a code defect and not a spec violation.** `requireUserVerification: true` is set on both
+ceremonies, and `verifyAuthenticationResponse` rejects any assertion whose UV flag is false — so
+1Password asserted UV=true. It treats an unlocked vault as the user having already been verified. That
+is a legitimate but weaker reading than this discovery assumed. WebAuthn has no way to demand a *fresh*
+verification; the authenticator alone decides what counts.
+
+### What survives
+- **Q1(c), the decisive argument, still holds.** Nothing is typed, so nothing is observable. A child
+  watching learns nothing reusable.
+- No standing shared secret once `ADMIN_PASSCODE` is removed.
+- Ergonomics are as promised (Q1a).
+
+### What does not
+- **The residual risk changes shape, and lands inside threat model Q2(a).** An unattended device with an
+  unlocked vault admits anyone with one click. Under the passcode this required having *seen* the
+  passcode. Observation-permanent becomes physical-access-transient.
+- The 20s sliding window is doing much less work than intended: it re-prompts, but the prompt costs a
+  click.
+
+### Consequence for the cutover
+Deploy 1 is unaffected and correct as shipped. What this bears on is **deploy 2** — whether removing
+`ADMIN_PASSCODE` is still the right end state, which is OQ-PG-2 restated with better information.
+See `docs/PASSKEY-CUTOVER.md` §6.3.
+
+### Decision taken 2026-08-13 (user)
+
+**Enrol a platform passkey on each device, then remove the 1Password credential, then deploy 2.**
+
+Rejected: shortening 1Password's auto-lock (shrinks the window without closing it); keeping the passcode
+as a second factor (would reopen OQ-PG-2 and retain a secret the children may have seen); accepting the
+one-click behaviour as-is.
+
+**Consequence — the deferred management UI is no longer deferrable.** Enrolling a platform passkey is not
+sufficient on its own: while the 1Password credential remains enrolled it stays offerable at the unlock
+prompt, so anyone at an unlocked device can simply choose it. Retiring the weaker credential requires a
+list and a remove action, which OQ-PG-1 had scoped out of the first slice on the grounds that 1Password's
+sync made multi-credential *management* unnecessary. That reasoning no longer holds — the sync is exactly
+what has to be given up. The multi-credential **schema**, retained despite Amendment 1, is what makes this
+a UI addition rather than a migration.
+
+**Also reopened in effect: the per-device enrolment cost that Amendment 1 removed.** Platform passkeys do
+not sync across ecosystems, so the mixed-ecosystem cost returns — one enrolment per device. Amendment 1's
+conclusion was correct for the situation as understood at the time; the OQ-PG-4 result changed the
+situation, not the reasoning.

--- a/app/admin/enrol/page.tsx
+++ b/app/admin/enrol/page.tsx
@@ -22,7 +22,7 @@ export default async function AdminEnrolPage() {
       className="flex min-h-screen flex-col items-center justify-center p-8"
       data-testid="admin-enrol-page"
     >
-      <EnrolForm hasExisting={status.enrolled > 0} />
+      <EnrolForm credentials={status.credentials} />
     </main>
   );
 }

--- a/app/admin/unlock/page.tsx
+++ b/app/admin/unlock/page.tsx
@@ -20,7 +20,7 @@ export default async function AdminUnlockPage() {
     >
       <UnlockForm
         passkeyAvailable={status.availableOnThisHost}
-        passkeyEnrolled={status.enrolled > 0}
+        passkeyEnrolled={status.credentials.length > 0}
       />
     </main>
   );

--- a/docs/PASSKEY-CUTOVER.md
+++ b/docs/PASSKEY-CUTOVER.md
@@ -12,26 +12,25 @@ Background and the reasoning behind each decision: `Product-Definition/features/
 
 ## 1. Before you start
 
-### 1.1 The blocking check (OQ-PG-4)
+### 1.1 The measured result (OQ-PG-4) — read this first
 
-The entire justification for this change is that a passkey prompt is **unobservable** — a child standing
-next to you learns nothing, whereas they can watch you type a passcode. That property depends on
-1Password performing a real user-verification check on each assertion rather than serving silently from
-an already-unlocked vault.
+This was tested on production on 2026-08-13, and **it came back negative.** With 1Password already
+unlocked, the passkey assertion completed on a **single button click, with no biometric prompt.**
 
-`requireUserVerification: true` is set on both ceremonies, which is the lever. Whether 1Password honours
-it per assertion is **unverified**.
+That is not a bug. `requireUserVerification: true` is set, and `verifyAuthenticationResponse` rejects any
+assertion whose UV flag is false — so 1Password asserted UV=true. It treats an unlocked vault as the user
+having already been verified. A legitimate reading of the spec, just a weaker one than assumed. WebAuthn
+gives a relying party no way to demand a *fresh* check; the authenticator alone decides what counts.
 
-**Do this after deploy 1 and before deploy 2:**
+**What still holds.** Nothing is typed, so nothing is observable. A child watching learns nothing
+reusable — that was the decisive argument for this whole change, and it survives intact.
 
-1. Unlock 1Password and leave it unlocked.
-2. Go to `/admin` and let the 20-second window lapse.
-3. Unlock with the passkey.
+**What does not.** An unattended device with an unlocked vault now opens the gate on one click. Under the
+passcode that required having *seen* the passcode. The risk shifts from *observation, permanent once
+seen* to *physical access, transient* — and both sit inside the stated threat model of a curious child at
+your desk.
 
-| What happens | Meaning | Do |
-|---|---|---|
-| 1Password asks for Face ID / Touch ID / Windows Hello | The property holds | Continue to deploy 2 |
-| It authorises with no verification prompt | **The property does not hold.** An unattended device with an unlocked vault lets a child through | Stop. See §6 |
+**Consequence: §3.5 is now a required step before deploy 2**, not an optional hardening.
 
 ### 1.2 What must be true
 
@@ -139,13 +138,46 @@ WebAuthn ceremony. This checklist is the compensating control. Work through all 
 If step 11 fails, 1Password sync is not covering both devices. Enrol a second passkey on that device
 (repeat 3–7) before continuing — it is why the schema is multi-credential.
 
-**Do not proceed to deploy 2 until every row passes.**
+**Do not proceed to §3.5 until every row passes.**
+
+---
+
+## 3.5 Swap to platform passkeys — required before deploy 2
+
+Because of the §1.1 result, a 1Password passkey opens the gate on one click. The fix is not in code —
+WebAuthn cannot force a fresh check — it is **which authenticator is enrolled**. A platform authenticator
+(Touch ID, Windows Hello, Android biometric) verifies per assertion.
+
+Do this **on each device you use `/admin` from**:
+
+| # | Step | Notes |
+|---|---|---|
+| 1 | `/admin/unlock` → **Manage passkeys** | Sends you through Google re-auth again |
+| 2 | Name it for the device, e.g. "MacBook Touch ID" | Optional; defaults to "This device" |
+| 3 | **Add this device (Touch ID / Windows Hello)** | Restricts the picker to a platform authenticator |
+| 4 | **Confirm the prompt actually asked for a biometric** | `authenticatorAttachment: "platform"` is a hint, not a guarantee — some systems register a password manager as a platform provider |
+| 5 | Repeat on your other device | Platform passkeys do **not** sync across ecosystems. That is the cost of this route |
+
+Then, **once every device you use has its own platform passkey**:
+
+| # | Step | Notes |
+|---|---|---|
+| 6 | `/admin/unlock` → **Manage passkeys** → **Remove** the 1Password entry | Leaving it enrolled defeats the point: it stays offerable at the unlock prompt, so anyone at an unlocked device can just pick it |
+| 7 | Unlock again on each device | The biometric must fire every time |
+
+> **Do not do step 6 before step 5 on every device.** Removing the synced credential while a device has
+> no platform passkey of its own leaves that device with no passkey at all. Not a lockout — Google
+> re-auth still enrols a new one — but an avoidable detour.
+
+If a device cannot do platform passkeys at all, keep a 1Password credential for it and accept the
+one-click behaviour there, or reconsider removing the passcode (§6.3).
 
 ---
 
 ## 4. Deploy 2 — remove the passcode
 
-Only after §3 is fully green and §1.1 came out clean.
+Only after §3 is fully green **and** §3.5 is complete — every device has its own platform passkey and
+the 1Password credential has been removed.
 
 ### 4.1 Code removals
 
@@ -238,16 +270,19 @@ Before that, try the cheaper things:
 | Enrolment loops back to "Confirm it's you" | The Google re-auth is not stamping `authTime`. Sign out completely and sign in again |
 | Nothing works, but Google sign-in does | Enrol a fresh passkey via `/admin/enrol` — this is the designed recovery path and needs no passcode |
 
-### 6.3 If §1.1 failed
+### 6.3 If §3.5 cannot be completed
 
-If 1Password authorises without a verification prompt, **do not do deploy 2**. The passkey is still a
-large ergonomic win and is no weaker than the passcode, but the shoulder-surfing property does not hold,
-so removing the passcode buys less than the discovery assumed. Options, in rough order of cost:
+§3.5 is the chosen answer to the §1.1 result. If a device cannot do platform passkeys, or the per-device
+enrolment is not worth it to you, these are the alternatives that were weighed:
 
-- Set 1Password's vault auto-lock to a short interval — makes the unlocked-vault window small.
-- Keep the passcode as a second factor rather than deleting it (revisit OQ-PG-2).
-- Enrol a **platform** passkey (Touch ID / Windows Hello directly) instead of a 1Password one. Device-bound,
-  always verifies — at the cost of one enrolment per device, which is what 1Password was avoiding.
+| Option | What it buys | What it costs |
+|---|---|---|
+| **Shorten 1Password's auto-lock** to ~1–5 min | Shrinks the unlocked window | Does not close it — while unlocked, one click still opens the gate |
+| **Keep the passcode** as a second factor; cancel deploy 2 | Defence in depth | Keeps a secret the kids may already have seen. Reopens OQ-PG-2 |
+| **Accept the one-click behaviour** and do deploy 2 anyway | Simplest end state, no standing secret | An unattended unlocked device opens the gate |
+
+None of these is wrong. The first is cheapest, the second most conservative, the third cleanest. What
+would be wrong is doing deploy 2 while believing the biometric fires when it does not.
 
 ---
 

--- a/src/features/admin/UnlockForm.tsx
+++ b/src/features/admin/UnlockForm.tsx
@@ -62,6 +62,18 @@ export function UnlockForm({
         </Link>
       )}
 
+      {passkeyAvailable && passkeyEnrolled && (
+        // Reachable even once a passkey exists: adding a per-assertion-verifying
+        // platform passkey, and removing a weaker one, both live behind this link.
+        <Link
+          href="/admin/enrol"
+          data-testid="admin-passkey-manage-link"
+          className="text-center text-xs text-[color:var(--ink-soft)] underline"
+        >
+          Manage passkeys
+        </Link>
+      )}
+
       <div className="flex items-center gap-3 text-xs text-[color:var(--ink-soft)]">
         <span className="h-px flex-1 bg-white/15" />
         <span>or use the passcode</span>

--- a/src/features/admin/webauthn/EnrolForm.tsx
+++ b/src/features/admin/webauthn/EnrolForm.tsx
@@ -5,9 +5,12 @@ import { useRouter } from "next/navigation";
 import { startRegistration } from "@simplewebauthn/browser";
 import { ErrorBanner } from "@/features/ui/ErrorBanner";
 import { TEXT_INPUT_CLASS } from "@/features/ui/styles";
+import type { PasskeySummary } from "./availability";
 import {
   beginPasskeyEnrolAction,
   finishPasskeyEnrolAction,
+  removePasskeyAction,
+  type EnrolTarget,
   type PasskeyFailure,
 } from "./passkey-actions";
 
@@ -19,21 +22,32 @@ const MESSAGES: Record<PasskeyFailure, string> = {
   duplicate: "That passkey is already set up on this account.",
 };
 
+const DEFAULT_LABELS: Record<EnrolTarget, string> = {
+  platform: "This device",
+  any: "1Password",
+};
+
 /**
- * Enrol a passkey for the admin gate (parent-gate-auth). Reached only with a
+ * Enrol and manage admin gate passkeys (parent-gate-auth). Reached only with a
  * fresh Google re-authentication — the server enforces that, not this component.
+ *
+ * The two enrol buttons are not a style preference. A password manager that keeps
+ * its vault unlocked will authorise on one click; a platform authenticator asks
+ * for a biometric every time (OQ-PG-4). Which one you enrol is the only control
+ * the app has over that, which is also why removal lives here: a weaker
+ * credential left enrolled stays offerable at the unlock prompt.
  */
-export function EnrolForm({ hasExisting }: { hasExisting: boolean }) {
+export function EnrolForm({ credentials }: { credentials: PasskeySummary[] }) {
   const router = useRouter();
-  const [label, setLabel] = useState("1Password");
+  const [label, setLabel] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
   const [pending, startTransition] = useTransition();
 
-  function enrol() {
+  function enrol(target: EnrolTarget) {
     setError(null);
     startTransition(async () => {
-      const begun = await beginPasskeyEnrolAction();
+      const begun = await beginPasskeyEnrolAction(target);
       if (!begun.ok) {
         setError(MESSAGES[begun.reason]);
         return;
@@ -43,85 +57,138 @@ export function EnrolForm({ hasExisting }: { hasExisting: boolean }) {
       try {
         attestation = await startRegistration({ optionsJSON: begun.options });
       } catch {
-        // Cancelled at the prompt, or the authenticator refused (often because
-        // excludeCredentials matched something it already holds).
+        // Cancelled at the prompt, or the authenticator refused — often because
+        // excludeCredentials matched something it already holds.
         setError("Passkey setup cancelled.");
         return;
       }
 
-      const finished = await finishPasskeyEnrolAction(attestation, begun.token, label);
+      const finished = await finishPasskeyEnrolAction(
+        attestation,
+        begun.token,
+        label.trim() || DEFAULT_LABELS[target],
+      );
       if (!finished.ok) {
         setError(MESSAGES[finished.reason]);
         return;
       }
       setDone(true);
+      setLabel("");
       router.refresh();
     });
   }
 
-  if (done) {
-    return (
-      <div className="panel flex w-full max-w-sm flex-col gap-4 p-8 text-center">
-        <div className="text-5xl" aria-hidden>
-          ✅
-        </div>
-        <h1 className="text-2xl font-bold">Passkey ready</h1>
-        <p className="text-sm text-[color:var(--ink-soft)]">
-          You can now unlock the admin area without typing anything.
-        </p>
-        <button
-          type="button"
-          onClick={() => router.replace("/admin/unlock")}
-          className="btn btn--primary"
-          data-testid="admin-enrol-continue"
-        >
-          Continue
-        </button>
-      </div>
-    );
+  function remove(id: string) {
+    setError(null);
+    startTransition(async () => {
+      const result = await removePasskeyAction(id);
+      if (!result.ok) setError(MESSAGES[result.reason]);
+      else router.refresh();
+    });
   }
 
   return (
-    <div className="panel flex w-full max-w-sm flex-col gap-5 p-8" data-testid="admin-enrol-form">
+    <div className="panel flex w-full max-w-md flex-col gap-6 p-8" data-testid="admin-enrol-form">
       <div className="flex flex-col items-center gap-1 text-center">
         <div className="text-5xl" aria-hidden>
           🔑
         </div>
-        <h1 className="text-2xl font-bold">
-          {hasExisting ? "Add another passkey" : "Set up a passkey"}
-        </h1>
+        <h1 className="text-2xl font-bold">Passkeys</h1>
         <p className="text-sm text-[color:var(--ink-soft)]">
-          Your password manager or device will ask you to confirm. Nothing is typed,
-          so nobody watching can copy it.
+          Nothing is typed, so nobody watching can copy it.
         </p>
       </div>
 
-      <label className="flex flex-col gap-2 text-sm">
-        <span className="text-[color:var(--ink-soft)]">Name this passkey</span>
-        <input
-          value={label}
-          onChange={(e) => setLabel(e.target.value)}
-          maxLength={40}
-          data-testid="admin-enrol-label"
-          className={TEXT_INPUT_CLASS}
-        />
-      </label>
+      {credentials.length > 0 && (
+        <ul className="flex flex-col gap-2" data-testid="admin-passkey-list">
+          {credentials.map((c) => (
+            <li
+              key={c.id}
+              className="flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-black/20 px-4 py-3"
+            >
+              <div className="min-w-0">
+                <p className="truncate font-semibold">{c.label}</p>
+                <p className="text-xs text-[color:var(--ink-soft)]">
+                  {c.lastUsedAt
+                    ? `Last used ${new Date(c.lastUsedAt).toLocaleDateString()}`
+                    : "Never used"}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => remove(c.id)}
+                disabled={pending}
+                data-testid="admin-passkey-remove"
+                className="btn btn--ghost shrink-0 text-sm"
+              >
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
 
-      <button
-        type="button"
-        onClick={enrol}
-        disabled={pending}
-        data-testid="admin-enrol-button"
-        className="btn btn--primary"
-      >
-        {pending ? "Waiting…" : "Create passkey"}
-      </button>
+      <div className="flex flex-col gap-3">
+        <label className="flex flex-col gap-2 text-sm">
+          <span className="text-[color:var(--ink-soft)]">Name (optional)</span>
+          <input
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            maxLength={40}
+            placeholder="e.g. MacBook Touch ID"
+            data-testid="admin-enrol-label"
+            className={TEXT_INPUT_CLASS}
+          />
+        </label>
+
+        <button
+          type="button"
+          onClick={() => enrol("platform")}
+          disabled={pending}
+          data-testid="admin-enrol-platform"
+          className="btn btn--primary"
+        >
+          {pending ? "Waiting…" : "Add this device (Touch ID / Windows Hello)"}
+        </button>
+        <p className="text-xs text-[color:var(--ink-soft)]">
+          Asks for your fingerprint or face <strong>every time</strong> the gate opens.
+        </p>
+
+        <button
+          type="button"
+          onClick={() => enrol("any")}
+          disabled={pending}
+          data-testid="admin-enrol-any"
+          className="btn btn--ghost"
+        >
+          Add a password manager or another device
+        </button>
+        <p className="text-xs text-[color:var(--ink-soft)]">
+          Syncs everywhere, but if the vault is already unlocked it opens the gate on a
+          single click.
+        </p>
+      </div>
 
       <ErrorBanner
         testId="admin-enrol-error"
         message={error}
         className="text-center text-sm text-red-300"
       />
+
+      {done && (
+        <p data-testid="admin-enrol-done" className="text-center text-sm text-green-300">
+          Passkey added.
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={() => router.replace("/admin/unlock")}
+        className="btn btn--ghost"
+        data-testid="admin-enrol-continue"
+      >
+        Done
+      </button>
     </div>
   );
 }

--- a/src/features/admin/webauthn/availability.ts
+++ b/src/features/admin/webauthn/availability.ts
@@ -5,16 +5,24 @@ import { captureServerException } from "@/lib/posthog-server";
 import { pgAdminCredentialStore } from "@/db/stores/credential-store.pg";
 import { passkeyRp } from "./rp";
 
+/** Client-safe view of an enrolled passkey (dates flattened to ISO strings). */
+export interface PasskeySummary {
+  id: string;
+  label: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+}
+
 export interface PasskeyStatus {
   /** False on any host that is not the configured rpID — e.g. a preview deployment. */
   availableOnThisHost: boolean;
-  /** How many passkeys this parent has enrolled. 0 if the lookup failed — see below. */
-  enrolled: number;
+  /** Enrolled passkeys, newest first. Empty if the lookup failed — see below. */
+  credentials: PasskeySummary[];
 }
 
 /**
  * What the unlock and enrolment pages need to know before rendering: whether this
- * host can do passkeys at all, and whether anything is enrolled yet.
+ * host can do passkeys at all, and what is enrolled.
  *
  * Kept out of `passkey-actions.ts` because that file is `"use server"`, where
  * every export must be a Server Action.
@@ -33,11 +41,19 @@ export interface PasskeyStatus {
 export async function passkeyStatus(parentId: string): Promise<PasskeyStatus> {
   const h = await headers();
   const rp = passkeyRp(env.webauthnRpId, h.get("host"));
-  if (!rp) return { availableOnThisHost: false, enrolled: 0 };
+  if (!rp) return { availableOnThisHost: false, credentials: [] };
 
   try {
-    const credentials = await pgAdminCredentialStore.listByParent(parentId);
-    return { availableOnThisHost: true, enrolled: credentials.length };
+    const rows = await pgAdminCredentialStore.listByParent(parentId);
+    return {
+      availableOnThisHost: true,
+      credentials: rows.map((r) => ({
+        id: r.id,
+        label: r.label,
+        createdAt: r.createdAt.toISOString(),
+        lastUsedAt: r.lastUsedAt?.toISOString() ?? null,
+      })),
+    };
   } catch (error) {
     // Reported, never silent: a failure here means the passkey path is invisible
     // to the parent, which must not pass unnoticed just because the page renders.
@@ -45,6 +61,6 @@ export async function passkeyStatus(parentId: string): Promise<PasskeyStatus> {
       distinctId: parentId,
       action: "passkey_status",
     });
-    return { availableOnThisHost: true, enrolled: 0 };
+    return { availableOnThisHost: true, credentials: [] };
   }
 }

--- a/src/features/admin/webauthn/passkey-actions.ts
+++ b/src/features/admin/webauthn/passkey-actions.ts
@@ -28,11 +28,13 @@ import { signChallenge, verifyChallenge } from "./challenge";
  * re-authentication rather than by the gate itself, which is what breaks the
  * chicken-and-egg of "the enrolment page lives behind the gate the passkey opens".
  *
- * `requireUserVerification: true` on both ceremonies is deliberate and
- * load-bearing: it is what asks the authenticator (1Password, Touch ID, Windows
- * Hello) to actually verify the human, rather than silently asserting from an
- * already-unlocked vault. Whether every provider honours it per-assertion is the
- * open question OQ-PG-4 — verify by trial before trusting the property.
+ * `requireUserVerification: true` on both ceremonies rejects any assertion whose
+ * UV flag is false. Note what it does NOT buy, measured on production and now
+ * settled (OQ-PG-4): **1Password treats an unlocked vault as user verification**,
+ * so it sets UV=true and its assertions complete on one click with no biometric
+ * prompt. That is a legitimate reading of the spec, and WebAuthn gives a relying
+ * party no way to demand a *fresh* check — the authenticator alone decides what
+ * counts. The only lever is which authenticator is enrolled; see `EnrolTarget`.
  */
 
 const store = pgAdminCredentialStore;
@@ -172,8 +174,27 @@ export async function finishPasskeyUnlockAction(
 
 /* --------------------------------------------------------------- enrolment */
 
+/**
+ * Which kind of authenticator to enrol.
+ *
+ * This choice exists because of a measured result, not a preference. 1Password
+ * treats an unlocked vault as user verification, so its assertions complete on a
+ * single click with no biometric prompt (OQ-PG-4). A **platform** authenticator —
+ * Touch ID, Windows Hello, Android biometric — verifies per assertion, which is
+ * the behaviour the admin gate was assumed to have. WebAuthn cannot demand a
+ * fresh check from an authenticator that says it already verified, so the only
+ * lever is which authenticator gets enrolled.
+ *
+ * `"platform"` restricts the browser's picker to this device. It is a *hint*, not
+ * a guarantee: on some systems a password manager registers itself as a platform
+ * provider, so confirm the prompt actually asked for a biometric.
+ */
+export type EnrolTarget = "platform" | "any";
+
 /** Step 1 of enrolling: options for `navigator.credentials.create()` + a signed challenge. */
-export async function beginPasskeyEnrolAction(): Promise<
+export async function beginPasskeyEnrolAction(
+  target: EnrolTarget = "any",
+): Promise<
   PasskeyResult<{ options: PublicKeyCredentialCreationOptionsJSON; token: string }>
 > {
   // Fresh Google re-auth, not merely a live session — see requireFreshParent.
@@ -200,6 +221,7 @@ export async function beginPasskeyEnrolAction(): Promise<
     authenticatorSelection: {
       residentKey: "preferred",
       userVerification: "required",
+      ...(target === "platform" ? { authenticatorAttachment: "platform" as const } : {}),
     },
   });
 
@@ -265,6 +287,45 @@ export async function finishPasskeyEnrolAction(
     await captureServerException(error, {
       distinctId: parent.id,
       action: "passkey_enrol",
+    });
+    throw error;
+  }
+}
+
+/* -------------------------------------------------------------- management */
+
+/**
+ * Remove an enrolled passkey.
+ *
+ * Guarded by the same fresh Google re-auth as enrolment, not by the admin gate.
+ * Removal is how a *weaker* credential gets retired — the whole point of the
+ * management UI is dropping the one-click 1Password credential once a
+ * per-assertion-verifying platform passkey exists (OQ-PG-4). Letting that happen
+ * behind a gate the weak credential itself opens would be circular.
+ *
+ * Removing the last credential is permitted: enrolment is reachable through
+ * Google re-auth, so it is recoverable rather than a lockout.
+ */
+export async function removePasskeyAction(id: string): Promise<PasskeyResult> {
+  const parent = await requireFreshParent();
+  try {
+    // Ownership check before deleting: `id` is client-supplied and must not be
+    // able to name another parent's credential.
+    const owned = await store.listByParent(parent.id);
+    if (!owned.some((c) => c.id === id)) return { ok: false, reason: "rejected" };
+
+    await store.remove(id);
+
+    const posthog = getPostHogClient();
+    if (posthog) {
+      posthog.capture({ distinctId: parent.id, event: "admin_passkey_removed" });
+      await posthog.flush();
+    }
+    return { ok: true };
+  } catch (error) {
+    await captureServerException(error, {
+      distinctId: parent.id,
+      action: "passkey_remove",
     });
     throw error;
   }


### PR DESCRIPTION
Follow-up to #56. **OQ-PG-4 was tested on production and came back negative**, which
changes what deploy 2 needs.

## The finding

With 1Password already unlocked, the passkey assertion completed on a **single button
click, with no biometric prompt.**

Not a defect. `requireUserVerification: true` is set and `verifyAuthenticationResponse`
rejects any assertion whose UV flag is false — so 1Password asserted UV=true. It treats an
unlocked vault as the user having already been verified. That is a legitimate reading of
the spec, just weaker than the discovery assumed, and WebAuthn gives a relying party no way
to demand a *fresh* check. **The only lever is which authenticator is enrolled.**

**What still holds:** nothing is typed, so nothing is observable. That was the decisive
argument for the whole change and it survives.

**What does not:** an unattended device with an unlocked vault opens the gate on one click.
Under the passcode that required having *seen* it. The risk moves from observation-permanent
to physical-access-transient — both inside the stated threat model of a curious child at
your desk.

## What this adds

- **Platform enrolment path** — `authenticatorAttachment: "platform"` restricts the picker to
  Touch ID / Windows Hello, which verify per assertion. A hint, not a guarantee, so the UI
  tells you to confirm the biometric actually fired.
- **A credential list with removal**, reachable from the unlock page.
- Copy on each button stating the trade honestly: syncs everywhere vs. asks every time.

## Why removal is not optional

Enrolling a platform passkey is not sufficient on its own. While the 1Password credential
remains enrolled it stays offerable at the unlock prompt, so anyone at an unlocked device can
simply choose it. **Retiring the weaker credential is the whole point.**

That makes the management UI deferred by OQ-PG-1 a requirement rather than a nicety. The
multi-credential *schema*, kept in #56 despite 1Password making it look unnecessary, is what
makes this a UI addition rather than a migration.

## Decisions worth reviewing

**Removal is guarded by fresh Google re-auth, not the admin gate.** Gating it behind a gate
the weak credential itself opens would be circular.

**Removing the last credential is allowed.** Enrolment is reachable through Google re-auth, so
it is recoverable rather than a lockout. `/admin/enrol` re-checks ownership before deleting —
the id is client-supplied.

**The cost is real and worth naming:** platform passkeys do not sync across ecosystems, so the
per-device enrolment that 1Password had removed comes back. Amendment 1's reasoning was right
for the situation as understood then; the measured result changed the situation, not the
reasoning.

## Tests

`tsc` clean · 362 unit tests · `pnpm build` passes. No new pure logic to test — the change is
one server action plus UI; the store's `remove()` was already covered by the contract suite in
#56 against both adapters.

## Docs

`docs/PASSKEY-CUTOVER.md` §1.1 now records the measured result instead of asking you to test
it, and a new **§3.5** is a required step before deploy 2: enrol platform passkeys on every
device *first*, then remove the 1Password one. Doing it in the other order leaves a device with
no passkey.
