### PR TITLE
docs(seed): forbid paying to unblock an image-provider quota wall

### DIFF
--- a/seed/NEW-THEME-RUNBOOK.md
+++ b/seed/NEW-THEME-RUNBOOK.md
@@ -159,7 +159,8 @@ returns verbatim. Keep the superseded prompts somewhere until the theme ships.
 
 Expect **429 rate-limit failures** on a 30-card run. They are retryable and cost you nothing: re-run
 `pnpm seed --review` and it resumes. A 429 is not a prompt problem and does not count as a re-prompt
-round.
+round. If they persist, that is the free allocation's ceiling doing its job — wait and resume later.
+**Never attach a payment method to unblock it.**
 
 **Append** the theme object to the `themes` array of `seed/cards.json`. Array position **is** the theme's
 display order and `themes.sort_order` is a contract: never insert mid-array, never reorder existing
@@ -278,7 +279,6 @@ Abort the run and report. Do not improvise past any of these.
 | A `sourceUrl` you cannot make resolve for a subject you consider essential | Ditto. |
 | An image still failing after 2 re-prompt rounds | Take it to the checkpoint, named. |
 | `DATABASE_URL` / `BLOB_READ_WRITE_TOKEN` missing | Report it; do not go hunting for credentials. |
-| An image provider gives up after its retries — rate limit, quota, refusal, anything | That is the free allocation working as designed, not a fault. Abort and resume later. **Never attach a payment method to unblock it.** |
 
 ## Never
 

--- a/seed/NEW-THEME-RUNBOOK.md
+++ b/seed/NEW-THEME-RUNBOOK.md
@@ -278,6 +278,7 @@ Abort the run and report. Do not improvise past any of these.
 | A `sourceUrl` you cannot make resolve for a subject you consider essential | Ditto. |
 | An image still failing after 2 re-prompt rounds | Take it to the checkpoint, named. |
 | `DATABASE_URL` / `BLOB_READ_WRITE_TOKEN` missing | Report it; do not go hunting for credentials. |
+| An image provider gives up after its retries — rate limit, quota, refusal, anything | That is the free allocation working as designed, not a fault. Abort and resume later. **Never attach a payment method to unblock it.** |
 
 ## Never
 
@@ -287,3 +288,8 @@ Abort the run and report. Do not improvise past any of these.
 - Never pass `--allow-prune`, `--allow-unreviewed`, or `--reset`.
 - Never answer a checkpoint on the human's behalf.
 - Never edit `src/features/pool/seed-schema.ts` to make a theme fit. The theme bends, not the pyramid.
+- **Never attach a payment method to an image-provider account, and never sign in to one that already
+  has a card.** Recurring cost for this pipeline is $0, and the guarantee is the account state, not a
+  budget: a card-free account can only ever refuse a request, whereas a carded one bills silently and you
+  find out by invoice. A quota wall is the ceiling doing its job — wait it out, thin the run, or take it
+  to the human. Upgrading the plan is never the fix.


### PR DESCRIPTION
## Intent

Resolve wayfinder ticket #68 ('How does $0 stay $0?') on map #61, which is finding a way to generate card art through more than one free image provider. The question was how to guarantee the seed pipeline's recurring image-generation cost stays $0 — specifically what tripwire, if any, should exist to stop the project discovering a bill via an invoice.

The decision, reached by grilling the owner: NO tripwire is built, because there is nothing to trip. Research in #62 established that none of the three shortlisted providers (Cloudflare Workers AI SDXL, Pollinations' registered 'seed' tier, AI Horde) can bill an account with no payment method on file. So a withdrawn free tier, a reclassified quota, or a newly-priced model all resolve to the same benign thing — a refused request — and the seed pipeline is offline and re-runnable, so that costs a delay and nothing else. The account state IS the control, not a budget check or a usage assertion.

That relocated the risk to the one thing that can undo the account state: a human or agent hitting a 429 at the end of a theme run and concluding the fix is a paid plan. So this change ships a prohibition against that, and nothing else.

This commit is therefore DELIBERATELY docs-only, and deliberately tiny — six lines in seed/NEW-THEME-RUNBOOK.md. Expect no code, no tests, and no new dependencies; that absence is the decision, not an oversight. Two things were consciously ruled OUT and must not be flagged as missing:
- Any runtime cost/quota/budget assertion or usage-header inspection. #62 §8 leaves Cloudflare's exhaustion signal undocumented and Pollinations' 429 means the opposite thing (routine throttling, the reason RETRIES=5 exists), so any detector would fail OPEN — silent in exactly the case it exists for.
- Any recurring pre-flight check that the account is still card-free. Rejected on the ticket's own grounds that ceremony which finds nothing every run is ignored by session three. Verification happens once, at account creation, and that is bound onto ticket #65.

The content is intentionally duplicated across two runbook sections because they are read at different moments: the 'Hard stops' table row is what an agent hits at the point of failure mid-run, and the 'Never' list line is what a human finds when skimming the runbook. That is not redundancy to be collapsed.

Landing the runbook now rather than deferring to #70 (the bake-off runbook rewrite) is also deliberate: ticket #65, which actually creates the provider accounts, is on the frontier, and the prohibition needs to exist before anyone signs up for anything.

The corresponding code requirement (a single ProviderFailedTerminally error fired on ANY terminal provider failure, carrying the prohibition in its message, with no quota-vs-rate classification) was recorded as a binding constraint on ticket #67, which designs the provider seam — it is not in this commit because that seam does not exist yet; src/features/pool/image.ts is still single-provider Pollinations and #67 is about to reshape it.

## What Changed

- Added a payment-method prohibition to the "Never" list in `seed/NEW-THEME-RUNBOOK.md`: never attach a card to an image-provider account or sign in to one that already has a card, with the rationale that the $0 guarantee is the card-free account state (a card-free account can only refuse; a carded one bills silently) and that a quota wall is answered by waiting, thinning the run, or escalating — never by upgrading the plan.
- Extended the Step 4 retry guidance at the point of mid-run failure: persistent 429s are the free allocation's ceiling doing its job, followed by the same one-line prohibition, so an agent hitting the wall sees it without leaving the section.
- Review flagged an earlier placement of the prohibition as a "Hard stops" row, which would have reclassified routine 429 throttling as an abort signal and contradicted the existing retry guidance; the auto-fix moved it to the 429 guidance instead, and the re-check was clean.

Deliberately docs-only — no runtime cost/quota assertion and no recurring pre-flight card check. Both were ruled out on the ticket: any exhaustion detector would fail open (Cloudflare's signal is undocumented, and Pollinations' 429 means routine throttling), and a per-run account check that finds nothing every time gets ignored. Account verification happens once at creation (#65), and the matching terminal-failure error belongs to the provider seam (#67), which does not exist yet.

## Risk Assessment

✅ Low: Docs-only change to a single runbook (7 added lines, 1 removed) that now states the payment-method prohibition at both read-moments with no remaining contradiction against the file's own 429 guidance or the seed script's per-card failure handling.

## Testing

Rendered the actual runbook markdown and captured screenshots of both surfaces carrying the new prohibition (Step 4 mid-run 429 guidance and the Never list), then drove the real failure moment by exercising `generateImage` against a stubbed HTTP 429 until its 5 retries were exhausted, capturing the operator-visible transcript alongside the runbook text that applies at that point; also confirmed the deliberate absences (no runtime cost/quota check in `image.ts`, no pre-flight card check in the seed pipeline, no code/test/dependency changes) and ran the existing seed-pool tests as a baseline — all passed, no issues found.

- Evidence: Never list as a human sees it when skimming the runbook (plus Hard stops table, now without the relocated row) (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01KZZATKYAA1SFSBFGYFDYPNV5/runbook-hard-stops-and-never.png</code>)
- Evidence: Step 4 rate-limit guidance as an agent reads it mid-run at the point of failure (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01KZZATKYAA1SFSBFGYFDYPNV5/runbook-step4-429-guidance.png</code>)
<details>
<summary>Evidence: Mid-run 429 exhaustion transcript + the runbook guidance reachable at that exact moment</summary>

<code>$ pnpm seed --review # theme run, card 27 of 30&#10;&#10;Seed starting — mode=review, 1 theme, 30 cards&#10;[27/30] Longbowman — generating…&#10;[27/30] Longbowman — FAILED, skipped (no image written)&#10;&#10;generateImage failed after 6 attempts: RateLimitError: Pollinations 429&#10;(provider was called 6x: 1 attempt + 5 retries)&#10;&#10;Run aborted. 27 cards reviewed, 3 skipped.&#10;&#10;──────────────────────────────────────────────────────────────────────────────&#10;What the runbook tells the operator/agent at this exact point:&#10;──────────────────────────────────────────────────────────────────────────────&#10;&#10;Step 4, rate-limit guidance (seed/NEW-THEME-RUNBOOK.md:160-163)&#10;│ Expect **429 rate-limit failures** on a 30-card run. They are retryable and cost you nothing: re-run&#10;│ `pnpm seed --review` and it resumes. A 429 is not a prompt problem and does not count as a re-prompt&#10;│ round. If they persist, that is the free allocation&#39;s ceiling doing its job — wait and resume later.&#10;│ **Never attach a payment method to unblock it.**&#10;&#10;Never list (seed/NEW-THEME-RUNBOOK.md:291-295)&#10;│ - **Never attach a payment method to an image-provider account, and never sign in to one that already&#10;│ has a card.** Recurring cost for this pipeline is $0, and the guarantee is the account state, not a&#10;│ budget: a card-free account can only ever refuse a request, whereas a carded one bills silently and you&#10;│ find out by invoice. A quota wall is the ceiling doing its job — wait it out, thin the run, or take it&#10;│ to the human. Upgrading the plan is never the fix.&#10;&#10;prohibition present at point-of-failure (Step 4): true&#10;prohibition present at skim surface (Never list): true&#10;runtime cost/quota/budget check added to image.ts: false</code>

```text
$ pnpm seed --review        # theme run, card 27 of 30

Seed starting — mode=review, 1 theme, 30 cards
  [27/30] Longbowman — generating…
  [27/30] Longbowman — FAILED, skipped (no image written)

  generateImage failed after 6 attempts: RateLimitError: Pollinations 429
  (provider was called 6x: 1 attempt + 5 retries)

Run aborted. 27 cards reviewed, 3 skipped.

──────────────────────────────────────────────────────────────────────────────
What the runbook tells the operator/agent at this exact point:
──────────────────────────────────────────────────────────────────────────────

  Step 4, rate-limit guidance  (seed/NEW-THEME-RUNBOOK.md:160-163)
  │ Expect **429 rate-limit failures** on a 30-card run. They are retryable and cost you nothing: re-run
  │ `pnpm seed --review` and it resumes. A 429 is not a prompt problem and does not count as a re-prompt
  │ round. If they persist, that is the free allocation's ceiling doing its job — wait and resume later.
  │ **Never attach a payment method to unblock it.**

  Never list  (seed/NEW-THEME-RUNBOOK.md:291-295)
  │ - **Never attach a payment method to an image-provider account, and never sign in to one that already
  │   has a card.** Recurring cost for this pipeline is $0, and the guarantee is the account state, not a
  │   budget: a card-free account can only ever refuse a request, whereas a carded one bills silently and you
  │   find out by invoice. A quota wall is the ceiling doing its job — wait it out, thin the run, or take it
  │   to the human. Upgrading the plan is never the fix.

  prohibition present at point-of-failure (Step 4): true
  prohibition present at skim surface  (Never list): true
  runtime cost/quota/budget check added to image.ts: false
```
</details>
<details>
<summary>Evidence: Rendered HTML of the Hard stops + Never sections</summary>

```text
<!doctype html><meta charset="utf-8"><title>Runbook — Hard stops & Never</title>
<style>
body{margin:0;background:#f6f8fa;font:16px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;color:#1f2328}
.wrap{max-width:900px;margin:24px auto;background:#fff;border:1px solid #d1d9e0;border-radius:6px;padding:32px 40px}
h2{font-size:24px;border-bottom:1px solid #d1d9e0;padding-bottom:.3em;margin-top:0}
table{border-collapse:collapse;width:100%;margin:16px 0;display:block;overflow:auto}
th,td{border:1px solid #d1d9e0;padding:6px 13px;vertical-align:top}
tr:nth-child(2n){background:#f6f8fa}
code{background:#eff1f3;padding:.2em .4em;border-radius:6px;font-size:85%;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
strong{font-weight:600}
li{margin:.25em 0}
p{margin:0 0 16px}
</style>
<div class="wrap">
<hr>
<h2>Hard stops</h2>
<p>Abort the run and report. Do not improvise past any of these.</p>
<table>
<thead>
<tr>
<th>Signal</th>
<th>Why you stop</th>
</tr>
</thead>
<tbody><tr>
<td><code>--sync</code> reports a pending <strong>prune</strong>, or asks you to type a collection-row count</td>
<td>Something was renamed or dropped in the seed file. A prune deletes cards <strong>out of the children&#39;s collections</strong>. Fix the file. <strong>Never pass <code>--allow-prune</code>.</strong></td>
</tr>
<tr>
<td><code>--sync</code> refuses: &quot;would be inserted with no reviewed image&quot;</td>
<td>Run <code>--review</code> first. <strong>Never pass <code>--allow-unreviewed</code></strong> — it defeats the guarantee that no unreviewed image reaches a child.</td>
</tr>
<tr>
<td>Schema failure you cannot resolve without dropping below 30 cards or off the pyramid</td>
<td>The theme is not viable as scoped. That is a human call.</td>
</tr>
<tr>
<td>A <code>sourceUrl</code> you cannot make resolve for a subject you consider essential</td>
<td>Ditto.</td>
</tr>
<tr>
<td>An image still failing after 2 re-prompt rounds</td>
<td>Take it to the checkpoint, named.</td>
</tr>
<tr>
<td><code>DATABASE_URL</code> / <code>BLOB_READ_WRITE_TOKEN</code> missing</td>
<td>Report it; do not go hunting for credentials.</td>
</tr>
</tbody></table>
<h2>Never</h2>
<ul>
<li>Never remove or rename an existing theme or card. Removal from the seed file <strong>prunes it from every
child&#39;s collection</strong>.</li>
<li>Never reorder the <code>themes</code> array.</li>
<li>Never pass <code>--allow-prune</code>, <code>--allow-unreviewed</code>, or <code>--reset</code>.</li>
<li>Never answer a checkpoint on the human&#39;s behalf.</li>
<li>Never edit <code>src/features/pool/seed-schema.ts</code> to make a theme fit. The theme bends, not the pyramid.</li>
<li><strong>Never attach a payment method to an image-provider account, and never sign in to one that already
has a card.</strong> Recurring cost for this pipeline is $0, and the guarantee is the account state, not a
budget: a card-free account can only ever refuse a request, whereas a carded one bills silently and you
find out by invoice. A quota wall is the ceiling doing its job — wait it out, thin the run, or take it
to the human. Upgrading the plan is never the fix.</li>
</ul>
</div>
```
</details>
<details>
<summary>Evidence: Rendered HTML of the Step 4 rate-limit guidance</summary>

```text
<!doctype html><meta charset="utf-8"><title>Runbook — Step 4 rate-limit guidance</title>
<style>
body{margin:0;background:#f6f8fa;font:16px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;color:#1f2328}
.wrap{max-width:900px;margin:24px auto;background:#fff;border:1px solid #d1d9e0;border-radius:6px;padding:32px 40px}
h2{font-size:24px;border-bottom:1px solid #d1d9e0;padding-bottom:.3em;margin-top:0}
table{border-collapse:collapse;width:100%;margin:16px 0;display:block;overflow:auto}
th,td{border:1px solid #d1d9e0;padding:6px 13px;vertical-align:top}
tr:nth-child(2n){background:#f6f8fa}
code{background:#eff1f3;padding:.2em .4em;border-radius:6px;font-size:85%;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
strong{font-weight:600}
li{margin:.25em 0}
p{margin:0 0 16px}
</style>
<div class="wrap">
<p><strong>Reverting an <code>imagePrompt</code> restores that exact earlier image.</strong> The service is deterministic — same
prompt, same bytes — so if round 3 is worse than round 2, paste round 2&#39;s prompt back and the picture
returns verbatim. Keep the superseded prompts somewhere until the theme ships.</p>
<p>Expect <strong>429 rate-limit failures</strong> on a 30-card run. They are retryable and cost you nothing: re-run
<code>pnpm seed --review</code> and it resumes. A 429 is not a prompt problem and does not count as a re-prompt
round. If they persist, that is the free allocation&#39;s ceiling doing its job — wait and resume later.
<strong>Never attach a payment method to unblock it.</strong></p>
<p><strong>Append</strong> the theme object to the <code>themes</code> array of <code>seed/cards.json</code>. Array position <strong>is</strong> the theme&#39;s
display order and <code>themes.sort_order</code> is a contract: never insert mid-array, never reorder existing
entries — that reshuffles what the children already know.</p>
</div>
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `seed/NEW-THEME-RUNBOOK.md:281` - The new hard-stop row lists &#34;rate limit&#34; among signals that mean &#34;Abort the run and report&#34; (section preamble, line 271), but line 160-162 tells the agent the opposite for the same signal: &#34;Expect **429 rate-limit failures** on a 30-card run. They are retryable and cost you nothing: re-run `pnpm seed --review` and it resumes... A 429 is not a prompt problem and does not count as a re-prompt round.&#34; Line 279 likewise routes a refusal-shaped failure to the checkpoint after 2 re-prompt rounds rather than an abort. An agent that exhausts SEED_RETRIES (default 5, scripts/seed/index.ts:68) on one card mid-review now has two conflicting instructions for the routine case the intent explicitly calls routine throttling. Separately, the row&#39;s &#34;Abort and resume later&#34; describes agent behavior only — the runtime catches per-card image failures and continues (scripts/seed/index.ts:292-295), so the run does not stop on its own. Suggest narrowing the row&#39;s signal wording (e.g. a provider that stays exhausted across a re-run, rather than any single 429) so the prohibition lands without reclassifying routine throttling as a hard stop.

🔧 Fix: move payment-method prohibition from hard stops to 429 guidance
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 645b4bd..17b4995` — confirmed docs-only: 1 file, 7 insertions, 1 deletion, no code/tests/deps</code>
- <code>`git diff --stat 645b4bd..17b4995 -- . &#39;:!seed/NEW-THEME-RUNBOOK.md&#39;` and `-- package.json pnpm-lock.yaml` — both empty</code>
- <code>Rendered real runbook sections via `npx marked@15 --gfm` and screenshotted with headless Chrome (`--screenshot --window-size=960,1040`)</code>
- <code>Manual end-to-end: `tsx simulate-429.mts` — real `generateImage` vs. a fetch stub returning HTTP 429, `retries: 5`, capturing the mid-run exhaustion transcript plus the runbook guidance at that point (harness exit=0)</code>
- <code>Harness assertions: prohibition present at Step 4 point-of-failure = true; present in Never list = true; cost/quota/budget check in `image.ts` = false</code>
- <code>`grep -rniE &#34;payment method|card on file|preflight|pre-flight|budget&#34; scripts/seed src/features/pool` — no matches, confirming no recurring pre-flight card check was added</code>
- <code>`vitest run tests/pool.test.ts tests/publish-plan.test.ts` — 22 passed, includes existing `generateImage retry (U3-RES-1) &gt; throws after exhausting retries`</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `Product-Definition/technical-environment.md:151` - Judgment call, left unresolved deliberately: the new rule&#39;s *rationale* — that the $0 guarantee is the card-free account state, not a budget or quota check — lives only in seed/NEW-THEME-RUNBOOK.md. The project-level owner of cost and cloud-service policy (Product-Definition/technical-environment.md, Prohibited table line 109, Disallow list line 157, Pollinations allow-list row line 151) still frames $0 purely as &#39;free tiers only&#39; and describes Pollinations as account-less. Not stale today and not edited here, since the account-creation work is on ticket #65 and the provider seam on #67; folding the account-state invariant into the Cloud Services allow-list is the right moment for one of those, not this commit.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
