### PR TITLE
AI Horde escape hatch (#74) and the bake-off runbook (#70)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,13 +73,13 @@ POLLINATIONS_TOKEN=""
 # lost, so store it in a password manager the moment it is issued. AI Horde has
 # no payment surface at all, so $0 is structural here rather than a policy.
 # An escape hatch, not a bake-off lane (#71) — the pipeline does not fan out to
-# it. AIHORDE_MODEL pins an SDXL-baseline model, which is what makes 768x768 a
-# guarantee rather than a coin-flip against live queue depth; #74 picks it.
-# NOT WIRED YET: no adapter is registered, so nothing reads either variable and
-# `--providers=aihorde` is an unknown id until #74 lands. Recorded here so the
-# key issued by #65 is not lost.
+# it; reach it with `pnpm seed --review --providers=ai-horde`.
+# There is deliberately no AIHORDE_MODEL. #74 pinned the model in the adapter
+# instead (src/features/pool/providers/ai-horde.ts), because the model changes
+# the BYTES: it is hashed into the review filename, and on this provider a
+# mistyped name is not a 404 but a different model — several of the horde's
+# most-served ones are NSFW. That belongs in a diff, not in a dotfile.
 AIHORDE_API_KEY=""
-AIHORDE_MODEL=""
 
 # Only for local production runs (`next start`). `next dev` and Vercel trust the
 # host automatically; do not set this on a self-hosted deploy behind an untrusted proxy.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "db:studio": "drizzle-kit studio",
     "seed": "tsx --env-file-if-exists=.env.local scripts/seed/index.ts",
     "contact-sheet": "tsx --env-file-if-exists=.env.local scripts/contact-sheet/index.ts",
-    "reconcile": "tsx --env-file-if-exists=.env.local scripts/reconcile/index.ts"
+    "reconcile": "tsx --env-file-if-exists=.env.local scripts/reconcile/index.ts",
+    "prototype:74": "tsx --env-file-if-exists=.env.local scripts/prototype-74-aihorde/index.ts"
   },
   "dependencies": {
     "@neondatabase/serverless": "^0.10.4",

--- a/scripts/prototype-74-aihorde/index.ts
+++ b/scripts/prototype-74-aihorde/index.ts
@@ -1,0 +1,802 @@
+/**
+ * PROTOTYPE — #74. Throwaway. Do not import this from anything.
+ *
+ * The question, in two halves:
+ *
+ *   1. WHICH MODEL. AI Horde has no default, and the choice is not cosmetic.
+ *      `waiting_prompt.py` computes `max_res = 1024 + threads*10 - round(queue*0.9)`
+ *      for a request that names no model, so 768x768 is a coin-flip against live
+ *      queue depth. Naming a model whose baseline is `stable_diffusion_xl`,
+ *      `stable_cascade` or `flux_1` forces `max_res` to 1024 unconditionally.
+ *      Leaving `models` unset is also a CONTENT risk, not only a resolution one:
+ *      the highest-worker-count image models on the horde are NSFW.
+ *
+ *   2. DOES THE ESCAPE HATCH ACTUALLY DRAW. #71 keyed AI Horde for permission —
+ *      it is the only shortlisted provider whose content policy plainly allows
+ *      weapon-bearing subjects. Permission is not skill. If a volunteer-run SDXL
+ *      draws warriors no better than Cloudflare's SDXL, the hatch is permission
+ *      to produce the same 3-of-28, and the honest outcome is to reverse #71.
+ *
+ * So this run is a grid: the three hard subjects from `seed/NEW-THEME-RUNBOOK.md`
+ * plus one control, drawn several times by each candidate model AND by the two
+ * providers already in the seam. The reference columns are what make the verdict
+ * decidable — "no better than Cloudflare" needs Cloudflare in the picture, and
+ * the control needs Pollinations drawing it well for "different" not to be
+ * mistaken for "better".
+ *
+ * It produces EVIDENCE and nothing else. The seam is #67's; the adapter that
+ * carries the winning model is landed separately, from this run's verdict.
+ *
+ *   pnpm prototype:74 --dry-run    price it, check the models are online, submit nothing
+ *   pnpm prototype:74              run it; resumes, so an interrupted run is cheap
+ *   pnpm prototype:74 --hard-only  skip the control in the HORDE columns only, once
+ *                                  it has drawn the control at least once
+ *   pnpm prototype:74 --sheet-only rebuild the sheet from disk, generate nothing
+ *
+ * Output (gitignored scratch): seed/review/prototype-74/
+ */
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { buildPrompt } from "@/features/pool/prompt";
+import { CARD_SIZE, cloudflareSdxl, pollinations } from "@/features/pool/providers";
+import { readImageSize } from "@/features/pool/image-size";
+import { slug } from "@/features/pool/keys";
+
+const OUT_DIR = join(process.cwd(), "seed", "review", "prototype-74");
+const HORDE = "https://aihorde.net/api/v2";
+const CLIENT_AGENT = "kids-collection-prototype-74:1.0:github.com/nywleswoey/kids-collection";
+
+/** Samples per (subject, column). One sample is noise — these failures are probabilistic. */
+const SAMPLES = 3;
+/** Fixed so a re-run redraws the same grid rather than a new lottery. */
+const BASE_SEED = 74;
+
+/**
+ * The three failure classes from the runbook, one subject each, plus a control.
+ *
+ * Real cards, by name, so the prompts are the ones the pipeline actually sends —
+ * a hand-tuned prompt would prove nothing about the pipeline.
+ */
+const SUBJECTS = [
+  { card: "Longbowman", failureClass: "identity rests on a small held object", control: false },
+  { card: "Swiss Guard", failureClass: "identity rests on niche uniform accuracy", control: false },
+  { card: "Egyptian Charioteer", failureClass: "multi-object scene", control: false },
+  {
+    card: "Warhorse",
+    failureClass: "CONTROL — dodges all three; Pollinations draws it well",
+    control: true,
+  },
+] as const;
+
+interface HordeColumn {
+  kind: "horde";
+  id: string;
+  /** Exact catalogue name. Pinned — see the header. */
+  model: string;
+  /** Why this model earned one of the three slots. */
+  because: string;
+  steps: number;
+  cfgScale: number;
+}
+
+interface RefColumn {
+  kind: "ref";
+  id: string;
+  because: string;
+}
+
+type Column = HordeColumn | RefColumn;
+
+/**
+ * Three candidates, not seven. Each is here for a different reason, and every
+ * one has an `stable_diffusion_xl`/`flux_1` baseline — which is the half of the
+ * choice that makes 768x768 a guarantee rather than a coin-flip.
+ *
+ * Steps and CFG are NOT uniform across the three, deliberately. #71 fixed the
+ * request's ROUTING parameters (`slow_workers`, `replacement_filter`,
+ * `allow_downgrade`, `nsfw`, model) and those are identical below. Sampling
+ * parameters are a property of the architecture: Schnell is a 4-8 step
+ * distilled model at CFG 1, so running it at SDXL's 25/7.5 would produce a burnt
+ * image, cost 3x the kudos, and answer a question nobody asked.
+ */
+const COLUMNS: readonly Column[] = [
+  {
+    kind: "horde",
+    id: "horde-albedobase-xl",
+    model: "AlbedoBase XL (SDXL)",
+    because: "SDXL baseline, generalist, most workers of any SFW SDXL-class model",
+    steps: 25,
+    cfgScale: 7.5,
+  },
+  {
+    kind: "horde",
+    id: "horde-fustercluck",
+    model: "Fustercluck",
+    because: "style=artistic — the catalogue entry that reads closest to ART_STYLE's cartoon",
+    steps: 25,
+    cfgScale: 7.5,
+  },
+  {
+    kind: "horde",
+    id: "horde-flux-schnell",
+    model: "Flux.1-Schnell fp8 (Compact)",
+    because:
+      "#62 established Cloudflare's flux-1-schnell cannot do 768x768 at any setting " +
+      "(no width/height in its schema), so the horde is the only free route to FLUX at card size",
+    steps: 8,
+    cfgScale: 1,
+  },
+  {
+    kind: "ref",
+    id: "ref-cloudflare-sdxl",
+    because: "the bar. 'No better than Cloudflare' is undecidable without Cloudflare in the grid",
+    },
+  {
+    kind: "ref",
+    id: "ref-pollinations",
+    because: "calibrates the control, so 'different' is not mistaken for 'better'",
+  },
+];
+
+interface Cell {
+  subject: string;
+  columnId: string;
+  sample: number;
+  file?: string;
+  /** What the response NAMED, never what was requested (#64). */
+  model?: string;
+  worker?: string;
+  seed?: string;
+  /** Per-worker censorship: a black frame rather than a refusal. #71 accepted this risk sight-unseen. */
+  censored?: boolean;
+  error?: string;
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const hardOnly = process.argv.includes("--hard-only");
+  const sheetOnly = process.argv.includes("--sheet-only");
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  const cards = loadSubjects();
+
+  // Rebuild the sheet from whatever is on disk, generating nothing.
+  //
+  // Needed because a run at this queue depth takes hours and is routinely
+  // interrupted, and a grid does not have to be COMPLETE to be decidable — it
+  // has to be honest about which cells are empty, which the renderer already is.
+  // Without this the sheet only exists if a run reaches its final line, so an
+  // interrupted run leaves hours of paid-for images unreadable on disk.
+  if (sheetOnly) {
+    const cells = cellsFromDisk(cards);
+    writeFileSync(join(OUT_DIR, "sheet.html"), renderSheet(cards, cells));
+    console.log(`${cells.length} cell(s) on disk`);
+    console.log(`open ${join(OUT_DIR, "sheet.html")}`);
+    return;
+  }
+  await preflight(cards, dryRun);
+  if (dryRun) return;
+
+  const cells: Cell[] = [];
+  await Promise.all([
+    // ONE horde job in flight at a time, across all three models.
+    //
+    // The first run fanned the three models out in parallel and lost 27 of 46
+    // images to `HTTP 404` on /generate/check — the horde had dropped the
+    // requests out from under them. At 0-14 kudos the horde will not hold nine
+    // pending images (~600 kudos of work) for a user who cannot cover them, and
+    // an expired request is not recoverable, only resubmittable to the back of
+    // the queue. Serialised, one job is ~70-174 kudos and survives.
+    //
+    // Slower in principle, far faster in practice: the parallel run spent its
+    // wall-clock generating 404s.
+    (async () => {
+      // `--hard-only` drops the CONTROL from the horde columns once the horde
+      // has already drawn it. The control's job is to prove the horde can draw
+      // *something* well, so that a bad hard subject reads as a failure of the
+      // subject rather than of the provider — and one or two models answering it
+      // discharges that job completely. Every further control image is queue
+      // time not spent on the question the ticket actually asks.
+      const forHorde = hardOnly ? cards.filter((c) => !c.control) : cards;
+      for (const col of COLUMNS) {
+        if (col.kind === "horde") await hordeLane(col, forHorde, cells);
+      }
+    })(),
+    ...COLUMNS.filter((c) => c.kind === "ref").map((col) => refLane(col as RefColumn, cards, cells)),
+  ]);
+
+  writeFileSync(join(OUT_DIR, "run.json"), JSON.stringify({ subjects: SUBJECTS, cells }, null, 2));
+  writeFileSync(join(OUT_DIR, "sheet.html"), renderSheet(cards, cells));
+
+  const censored = cells.filter((c) => c.censored).length;
+  const failed = cells.filter((c) => c.error).length;
+  console.log(
+    `\ndone — ${cells.filter((c) => c.file).length}/${cells.length} images, ` +
+      `${failed} failed, ${censored} censored by a worker`,
+  );
+  console.log(`open ${join(OUT_DIR, "sheet.html")}`);
+}
+
+/**
+ * Reconstruct the grid from the files on disk, enriched with whatever `run.json`
+ * remembers about each cell (the serving model, the worker, censorship).
+ *
+ * Disk is the authority on PRESENCE and `run.json` only annotates, deliberately:
+ * the two disagree after an interrupted run, and the images are the thing that
+ * was paid for.
+ */
+function cellsFromDisk(cards: readonly Subject[]): Cell[] {
+  let remembered: Cell[] = [];
+  try {
+    remembered = (JSON.parse(readFileSync(join(OUT_DIR, "run.json"), "utf8")) as { cells: Cell[] })
+      .cells;
+  } catch {
+    // No previous run recorded — presence alone still renders a readable grid.
+  }
+
+  const onDisk = new Set(readdirSync(OUT_DIR));
+  const cells: Cell[] = [];
+  for (const card of cards) {
+    for (const col of COLUMNS) {
+      for (let i = 0; i < SAMPLES; i++) {
+        const file = ["webp", "png", "jpeg", "jpg"]
+          .map((ext) => cellName(col.id, card.name, i, ext))
+          .find((f) => onDisk.has(f));
+        if (!file) continue;
+        const prior = remembered.find(
+          (c) => c.subject === card.name && c.columnId === col.id && c.sample === i,
+        );
+        cells.push({ ...prior, subject: card.name, columnId: col.id, sample: i, file });
+      }
+    }
+  }
+  return cells;
+}
+
+// ── subjects ────────────────────────────────────────────────────────────────
+
+interface Subject {
+  name: string;
+  failureClass: string;
+  control: boolean;
+  imagePrompt: string;
+  prompt: string;
+}
+
+function loadSubjects(): Subject[] {
+  const seed = JSON.parse(readFileSync(join(process.cwd(), "seed", "cards.json"), "utf8")) as {
+    themes: { name: string; cards: { name: string; imagePrompt: string }[] }[];
+  };
+  const all = seed.themes.flatMap((t) => t.cards);
+  return SUBJECTS.map((s) => {
+    const card = all.find((c) => c.name === s.card);
+    if (!card) throw new Error(`no card named "${s.card}" in seed/cards.json`);
+    return {
+      name: card.name,
+      failureClass: s.failureClass,
+      control: s.control,
+      imagePrompt: card.imagePrompt,
+      // Through buildPrompt, so ART_STYLE and the real prompt length are exercised.
+      prompt: buildPrompt(card),
+    };
+  });
+}
+
+// ── preflight ───────────────────────────────────────────────────────────────
+
+/**
+ * Everything that can be checked before a single kudo is spent.
+ *
+ * The `max_res` line is the evidence for half of this ticket: it prints what an
+ * unpinned request would be allowed to ask for RIGHT NOW, next to the 768 the
+ * app requires.
+ */
+async function preflight(cards: Subject[], dryRun: boolean) {
+  const key = requireKey();
+
+  const online = (await getJson(`${HORDE}/status/models?type=image`)) as {
+    name: string;
+    count: number;
+    jobs: number;
+    eta: number;
+  }[];
+  const perf = (await getJson(`${HORDE}/status/performance`)) as {
+    queued_requests: number;
+    thread_count: number;
+  };
+  const user = (await getJson(`${HORDE}/find_user`, { apikey: key })) as {
+    username: string;
+    kudos: number;
+  };
+
+  const unpinnedMaxRes =
+    1024 + perf.thread_count * 10 - Math.round(perf.queued_requests * 0.9);
+  console.log(`horde: ${perf.thread_count} threads, ${perf.queued_requests} queued`);
+  console.log(
+    `  an UNPINNED request would be capped at ${unpinnedMaxRes}px — ` +
+      `${unpinnedMaxRes >= CARD_SIZE.width ? "768 clears" : `768 would be REFUSED`}`,
+  );
+  console.log(`  user ${user.username}, ${user.kudos} kudos`);
+
+  for (const col of COLUMNS) {
+    if (col.kind !== "horde") continue;
+    const m = online.find((o) => o.name === col.model);
+    console.log(
+      m
+        ? `  ✓ ${col.model} — ${m.count} worker(s), ${m.jobs} queued, eta ${m.eta}s`
+        : `  ✗ ${col.model} — OFFLINE right now (volunteer infrastructure; the set moves)`,
+    );
+  }
+
+  // The ticket says to re-check the candidate set at run time, because this is
+  // volunteer infrastructure and the shortlist it printed has already moved.
+  // Printing the whole live SFW SDXL-class field is what makes "these three"
+  // a choice rather than a copy — and it is the only way an offline candidate
+  // gets replaced by a real one rather than by a blank column.
+  const reference = (await getJson(
+    "https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/stable_diffusion.json",
+  )) as Record<string, { baseline?: string; nsfw?: boolean; style?: string }>;
+  const chosen = new Set(COLUMNS.filter((c) => c.kind === "horde").map((c) => (c as HordeColumn).model));
+  const field = online
+    .filter((o) => {
+      const ref = reference[o.name];
+      // Only baselines that force max_res to 1024, and only SFW ones.
+      return (
+        ref?.nsfw === false &&
+        ["stable_diffusion_xl", "stable_cascade", "flux_1"].includes(ref.baseline ?? "")
+      );
+    })
+    .sort((a, b) => b.count - a.count);
+  console.log(`\nlive SFW SDXL-class field (${field.length} online, ${chosen.size} chosen):`);
+  for (const m of field) {
+    console.log(
+      `  ${chosen.has(m.name) ? "*" : " "} ${String(m.count).padStart(2)}w  ${m.name}  ` +
+        `[${reference[m.name]?.baseline}, ${reference[m.name]?.style}]`,
+    );
+  }
+  console.log("");
+
+  // Price it before committing, per the ticket.
+  let total = 0;
+  for (const col of COLUMNS) {
+    if (col.kind !== "horde") continue;
+    const priced = (await postJson(`${HORDE}/generate/async`, key, {
+      ...hordePayload(col, cards[0]!.prompt),
+      dry_run: true,
+    })) as { kudos?: number; message?: string };
+    if (priced.kudos === undefined) {
+      console.log(`  ! ${col.model} dry-run refused: ${priced.message ?? "unknown"}`);
+      continue;
+    }
+    total += priced.kudos * cards.length;
+    console.log(`  ${col.model}: ${priced.kudos} kudos per subject (${SAMPLES} samples)`);
+  }
+  console.log(`estimated total: ~${Math.round(total)} kudos`);
+  if (dryRun) console.log("\n--dry-run: nothing submitted.");
+}
+
+function requireKey(): string {
+  const key = process.env.AIHORDE_API_KEY;
+  if (!key) throw new Error("AIHORDE_API_KEY is not set — see .env.example");
+  return key;
+}
+
+// ── AI Horde lane ───────────────────────────────────────────────────────────
+
+/**
+ * #71's routing parameters, unchanged and in one place:
+ *   slow_workers: true        — do not exclude the slow volunteers; at 0 kudos they are the queue
+ *   replacement_filter: false — never let the horde silently rewrite the prompt
+ *   allow_downgrade           — NEVER SET. Setting it permits a smaller image than asked for,
+ *                               which is the exact failure the model pin exists to prevent.
+ *   nsfw: false               — an SFW request. Also what exposes it to per-worker censorship.
+ *   models: [one]             — pinned. Unset is a resolution risk AND a content risk.
+ */
+function hordePayload(col: HordeColumn, prompt: string) {
+  return {
+    prompt,
+    params: {
+      width: CARD_SIZE.width,
+      height: CARD_SIZE.height,
+      steps: col.steps,
+      cfg_scale: col.cfgScale,
+      sampler_name: "k_euler_a",
+      karras: true,
+      n: SAMPLES,
+      seed: String(BASE_SEED),
+    },
+    nsfw: false,
+    models: [col.model],
+    slow_workers: true,
+    replacement_filter: false,
+    r2: true,
+    shared: false,
+    trusted_workers: false,
+  };
+}
+
+async function hordeLane(col: HordeColumn, cards: Subject[], cells: Cell[]) {
+  const key = requireKey();
+  for (const card of cards) {
+    if (allSamplesOnDisk(col.id, card.name)) {
+      console.log(`  · ${card.name} [${col.id}] already on disk`);
+      continue;
+    }
+    try {
+      await hordeGenerate(col, card, key, cells);
+    } catch (err) {
+      console.error(`  ✗ ${card.name} [${col.id}]: ${String(err)}`);
+      for (let i = 0; i < SAMPLES; i++) {
+        cells.push({ subject: card.name, columnId: col.id, sample: i, error: String(err) });
+      }
+    }
+  }
+}
+
+/**
+ * Submit, poll, download. Requests go stale after ~10 minutes at the back of the
+ * queue, so one resubmit is expected rather than exceptional.
+ */
+async function hordeGenerate(col: HordeColumn, card: Subject, key: string, cells: Cell[]) {
+  // Four attempts, not two: a dropped job is the ordinary case at this kudos
+  // balance, and each resubmit costs only queue position.
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const submitted = (await postJson(
+      `${HORDE}/generate/async`,
+      key,
+      hordePayload(col, card.prompt),
+    )) as { id?: string; message?: string };
+    if (!submitted.id) throw new Error(`submit refused: ${submitted.message ?? "no id"}`);
+
+    console.log(`  → ${card.name} [${col.id}] queued as ${submitted.id}`);
+    const done = await pollUntilDone(submitted.id, key, `${card.name} [${col.id}]`);
+    if (!done) {
+      console.warn(`  ⟳ ${card.name} [${col.id}] gave up after 90min — resubmitting`);
+      // Through the gate like every other horde call: the 2-per-second limit is
+      // per-IP across the whole API, and a cancel that skips the gate can be the
+      // request that gets a real submission thrown away.
+      await hordeGate();
+      await fetch(`${HORDE}/generate/status/${submitted.id}`, {
+        method: "DELETE",
+        headers: { apikey: key, "Client-Agent": CLIENT_AGENT },
+      });
+      continue;
+    }
+
+    const status = (await getJson(`${HORDE}/generate/status/${submitted.id}`, {
+      apikey: key,
+    })) as {
+      generations: {
+        img: string;
+        seed: string;
+        model: string;
+        worker_name: string;
+        censored?: boolean;
+      }[];
+    };
+    for (const [i, gen] of status.generations.entries()) {
+      const cell: Cell = {
+        subject: card.name,
+        columnId: col.id,
+        sample: i,
+        model: gen.model,
+        worker: gen.worker_name,
+        seed: gen.seed,
+        censored: gen.censored === true,
+      };
+      try {
+        cell.file = await saveImage(col.id, card.name, i, await downloadBytes(gen.img));
+      } catch (err) {
+        cell.error = String(err);
+      }
+      cells.push(cell);
+    }
+    console.log(`  ✓ ${card.name} [${col.id}] — ${status.generations.length} image(s)`);
+    return;
+  }
+  throw new Error("the horde dropped this job on all 4 attempts");
+}
+
+/**
+ * Poll until done.
+ *
+ * The deadline is deliberately huge. Measured on this prototype's second run: a
+ * 20-minute client deadline made all three lanes abandon jobs that had reached
+ * queue position 58 of 800 and resubmit to the BACK of that queue. The horde
+ * expires a request nobody CHECKS, not one that is merely slow, so polling keeps
+ * a job alive and giving up is a pure self-inflicted loss.
+ */
+async function pollUntilDone(id: string, key: string, label: string): Promise<boolean> {
+  const deadline = Date.now() + 90 * 60_000;
+  let lastLog = 0;
+  while (Date.now() < deadline) {
+    await sleep(8_000);
+    let check: {
+      done: boolean;
+      faulted: boolean;
+      is_possible: boolean;
+      finished: number;
+      queue_position: number;
+      wait_time: number;
+    };
+    try {
+      check = (await getJson(`${HORDE}/generate/check/${id}`, { apikey: key })) as typeof check;
+    } catch (err) {
+      // THIS is what "requests go stale" looks like on the wire: the horde
+      // forgets the job and /check answers 404. It is not a client timeout, and
+      // it fires while the job is still advancing in the queue — so it must
+      // resubmit rather than fail the cell.
+      if (String(err).includes("404")) {
+        console.warn(`    ⟳ ${label}: the horde dropped this job (404) — resubmitting`);
+        return false;
+      }
+      // A network blip is not a verdict on the model. Keep polling.
+      console.warn(`    … ${label}: ${String(err)} — retrying`);
+      continue;
+    }
+    if (check.done) return true;
+    if (check.faulted) throw new Error("horde reported the request faulted");
+    if (!check.is_possible) throw new Error("no worker can serve this request");
+    if (Date.now() - lastLog > 60_000) {
+      lastLog = Date.now();
+      console.log(
+        `    … ${label}: ${check.finished}/${SAMPLES} done, ` +
+          `queue position ${check.queue_position}, ~${check.wait_time}s`,
+      );
+    }
+  }
+  return false;
+}
+
+// ── reference lanes ─────────────────────────────────────────────────────────
+
+/**
+ * The two providers already in the seam, drawn through their own adapters.
+ *
+ * Both adapters pin `seed: 42` (#64), which for a benchmark column is exactly
+ * wrong — three identical bytes is one sample, not three. So the seed is varied
+ * per sample here. That is a prototype liberty and the reason this lane does not
+ * go through `runBakeOff`: the seam is built to hold a param bag STILL, and this
+ * run needs it to move.
+ */
+async function refLane(col: RefColumn, cards: Subject[], cells: Cell[]) {
+  const isPollinations = col.id === "ref-pollinations";
+  const minIntervalMs = isPollinations ? 5_000 : 250;
+
+  for (const card of cards) {
+    for (let i = 0; i < SAMPLES; i++) {
+      if (existsSync(join(OUT_DIR, cellName(col.id, card.name, i, "png"))) ||
+          existsSync(join(OUT_DIR, cellName(col.id, card.name, i, "jpeg")))) {
+        continue;
+      }
+      await sleep(minIntervalMs);
+      const seed = BASE_SEED + i;
+      const provider = isPollinations
+        ? withSeed(pollinations(), seed)
+        : withSeed(cloudflareSdxl(), seed);
+      const cell: Cell = { subject: card.name, columnId: col.id, sample: i, seed: String(seed) };
+      try {
+        const image = await provider.generate(card.prompt, CARD_SIZE);
+        cell.model = image.model;
+        cell.file = await saveImage(col.id, card.name, i, image.bytes, image.format);
+        console.log(`  ✓ ${card.name} [${col.id}] #${i}`);
+      } catch (err) {
+        cell.error = String(err);
+        console.error(`  ✗ ${card.name} [${col.id}] #${i}: ${String(err)}`);
+      }
+      cells.push(cell);
+    }
+  }
+}
+
+/** Re-point an adapter at one seed. Throwaway — the seam intentionally forbids this. */
+function withSeed<P extends { params: Readonly<Record<string, string | number | boolean>> }>(
+  provider: P,
+  seed: number,
+): P {
+  return { ...provider, params: { ...provider.params, seed } };
+}
+
+// ── files ───────────────────────────────────────────────────────────────────
+
+function cellName(columnId: string, subject: string, sample: number, ext: string): string {
+  return `${slug(subject)}--${columnId}--${sample}.${ext}`;
+}
+
+function allSamplesOnDisk(columnId: string, subject: string): boolean {
+  return Array.from({ length: SAMPLES }, (_, i) =>
+    ["webp", "png", "jpeg"].some((ext) =>
+      existsSync(join(OUT_DIR, cellName(columnId, subject, i, ext))),
+    ),
+  ).every(Boolean);
+}
+
+async function saveImage(
+  columnId: string,
+  subject: string,
+  sample: number,
+  bytes: Uint8Array,
+  format?: string,
+): Promise<string> {
+  const ext = format ?? readImageSize(bytes)?.format ?? "bin";
+  const name = cellName(columnId, subject, sample, ext);
+  writeFileSync(join(OUT_DIR, name), bytes);
+  return name;
+}
+
+/**
+ * Fetch the generated bytes, with retries.
+ *
+ * The horde hands back a short-lived R2 URL, and the first run reported
+ * "Egyptian Charioteer [horde-flux-schnell] — 3 image(s)" while saving none of
+ * them: the images were drawn, queued for, and paid for, then lost on the last
+ * hop. Worth three attempts.
+ */
+async function downloadBytes(url: string): Promise<Uint8Array> {
+  let last = "";
+  for (let n = 0; n < 3; n++) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return new Uint8Array(await res.arrayBuffer());
+      last = `HTTP ${res.status}`;
+    } catch (err) {
+      last = String(err);
+    }
+    await sleep(1_500 * 2 ** n);
+  }
+  throw new Error(`download failed after 3 attempts: ${last}`);
+}
+
+// ── contact sheet ───────────────────────────────────────────────────────────
+
+function renderSheet(cards: Subject[], cells: Cell[]): string {
+  const cell = (subject: string, columnId: string, sample: number) =>
+    cells.find((c) => c.subject === subject && c.columnId === columnId && c.sample === sample);
+
+  const head = COLUMNS.map(
+    (c) =>
+      `<th><div class=cid>${esc(c.id)}</div>` +
+      `<div class=why>${esc(c.kind === "horde" ? c.model : "already in the seam")}</div>` +
+      `<div class=why>${esc(c.because)}</div></th>`,
+  ).join("");
+
+  const rows = cards
+    .map(
+      (card) => `<tr>
+<th scope=row><b>${esc(card.name)}</b>
+<div class=fc>${esc(card.failureClass)}</div>
+<div class=pr>${esc(card.imagePrompt)}</div></th>
+${COLUMNS.map((col) => {
+  const strip = Array.from({ length: SAMPLES }, (_, i) => {
+    const c = cell(card.name, col.id, i);
+    if (!c) return `<div class=miss>not run</div>`;
+    if (c.error) return `<div class=miss title="${esc(c.error)}">FAILED</div>`;
+    if (c.censored) return `<div class=cens>CENSORED by worker</div>`;
+    return `<img src="${esc(c.file ?? "")}" loading=lazy alt="${esc(card.name)} #${i}">`;
+  }).join("");
+  const witness = cells.find((c) => c.subject === card.name && c.columnId === col.id && c.model);
+  return `<td><div class=strip>${strip}</div><div class=m>${esc(
+    witness?.model ?? "model not reported",
+  )}${witness?.worker ? ` · ${esc(witness.worker)}` : ""}</div></td>`;
+}).join("")}
+</tr>`,
+    )
+    .join("\n");
+
+  const censored = cells.filter((c) => c.censored).length;
+  const failed = cells.filter((c) => c.error).length;
+
+  return `<!doctype html><meta charset=utf-8><title>#74 — AI Horde model bake-off</title>
+<style>
+body{font:14px system-ui;background:#111;color:#eee;margin:24px}
+h1{font-size:20px;margin:0 0 4px}
+.sub{opacity:.65;margin:0 0 16px;max-width:80ch;line-height:1.5}
+.warn{background:#3a2410;border-left:3px solid #d78c33;padding:8px 12px;margin:8px 0}
+table{border-collapse:collapse;width:100%}
+th,td{vertical-align:top;padding:8px;border-top:1px solid #2a2a2a}
+thead th{position:sticky;top:0;background:#111;text-align:left;font-size:12px}
+th[scope=row]{text-align:left;width:200px;font-weight:400}
+.strip{display:grid;grid-template-columns:repeat(${SAMPLES},1fr);gap:4px}
+img{width:100%;border-radius:6px;display:block;background:#222}
+.cid{font-weight:600;font-size:13px}
+.why{opacity:.6;font-weight:400;font-size:11px;margin-top:3px;line-height:1.4;text-transform:none;letter-spacing:0}
+.fc{opacity:.75;font-size:12px;margin-top:6px;color:#d78c33}
+.pr{opacity:.5;font-size:11px;margin-top:6px;line-height:1.4}
+.m{font-size:11px;opacity:.55;margin-top:6px}
+.miss{color:#f66;border:1px dashed #f66;border-radius:6px;padding:20px 4px;text-align:center;font-size:11px}
+.cens{color:#f6f;border:1px dashed #f6f;border-radius:6px;padding:20px 4px;text-align:center;font-size:11px}
+</style>
+<h1>#74 — which AI Horde model, and does the escape hatch draw the hard subjects?</h1>
+<p class=sub>Rows are the three failure classes from <code>NEW-THEME-RUNBOOK.md</code> plus one control.
+Columns are the three AI Horde candidates and the two providers already in the seam. Prompts are real
+<code>buildPrompt()</code> output at 768&times;768, ${SAMPLES} samples each.
+<b>The verdict is yours.</b> The hatch earns its keep only if a horde column draws a hard subject
+better than <code>ref-cloudflare-sdxl</code> does; if it does not, the honest outcome is to reverse #71
+and drop AI Horde entirely.</p>
+${
+  censored > 0
+    ? `<p class=warn>⚠ ${censored} frame(s) were censored by a worker — a black frame rather than a refusal. #71 accepted this risk on the grounds it fails visibly into review. This is the first measurement of how often it fires.</p>`
+    : `<p class=sub>No worker censorship fired in this run.</p>`
+}
+${failed > 0 ? `<p class=warn>⚠ ${failed} cell(s) failed outright. Hover for the error.</p>` : ""}
+<table><thead><tr><th>Subject</th>${head}</tr></thead><tbody>
+${rows}
+</tbody></table>`;
+}
+
+function esc(s: string): string {
+  return s.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+}
+
+// ── http ────────────────────────────────────────────────────────────────────
+
+/**
+ * ONE gate in front of every AI Horde call, submits and polls alike.
+ *
+ * Measured, the hard way, on this prototype's first run: the horde answers
+ * `429 {"message": "2 per 1 second"}` and the three lanes fanning out
+ * concurrently lost 7 of 12 submissions to it in the first second. The limit is
+ * per-IP across the whole API, not per-endpoint and not per-lane, so a
+ * per-lane gate cannot express it — which is a fact about AI Horde's adapter
+ * pacing, not only about this script.
+ *
+ * A submit refused this way costs nothing and is retryable, so it is retried
+ * rather than counted as a failed cell. A cell that says FAILED must mean the
+ * model could not draw the subject; it must never mean the script was impatient.
+ */
+const HORDE_MIN_INTERVAL_MS = 1_200;
+let nextHordeSlot = 0;
+
+async function hordeGate(): Promise<void> {
+  const now = Date.now();
+  const wait = Math.max(0, nextHordeSlot - now);
+  nextHordeSlot = Math.max(now, nextHordeSlot) + HORDE_MIN_INTERVAL_MS;
+  if (wait > 0) await sleep(wait);
+}
+
+async function getJson(url: string, headers: Record<string, string> = {}): Promise<unknown> {
+  for (let n = 0; ; n++) {
+    await hordeGate();
+    const res = await fetch(url, { headers: { "Client-Agent": CLIENT_AGENT, ...headers } });
+    if (res.status === 429 && n < 5) {
+      await sleep(2_000 * 2 ** n);
+      continue;
+    }
+    if (!res.ok) throw new Error(`GET ${url} → HTTP ${res.status}`);
+    return res.json();
+  }
+}
+
+async function postJson(url: string, key: string, body: unknown): Promise<unknown> {
+  for (let n = 0; ; n++) {
+    await hordeGate();
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        apikey: key,
+        "Content-Type": "application/json",
+        "Client-Agent": CLIENT_AGENT,
+      },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as { message?: string };
+    if (res.status === 429 && n < 5) {
+      console.log(`    ⟳ throttled (${json.message ?? "429"}) — backing off`);
+      await sleep(2_000 * 2 ** n);
+      continue;
+    }
+    return json;
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/seed/NEW-THEME-RUNBOOK.md
+++ b/seed/NEW-THEME-RUNBOOK.md
@@ -240,6 +240,19 @@ provider drew the subject well, that is a pick, not a re-prompt (#63). **Cap thi
 an image still fails everywhere, take it to the human at the checkpoint with the problem named — do not swap
 the subject silently, and do not spend the session fighting the model.
 
+**The escape hatch, for a card the lanes refuse.** `ai-horde` is registered but sits out the fan-out (#71),
+so it never appears in a normal run. Reach it by name, for the handful of cards that need it:
+
+```bash
+pnpm seed --review --providers=ai-horde     # after the lanes have run; it resumes past what exists
+```
+
+It exists for **permission**, not for speed or quality: it is the only provider whose content policy plainly
+allows weapon-bearing subjects. It is also the slowest thing in this runbook by an order of magnitude —
+a volunteer queue, and this project's account holds no kudos, so **one image can take 30–45 minutes**. Use it
+for one or two cards, never for a theme. Its candidates land in `seed/review/` and appear in the contact
+sheet exactly like a lane's, so the pick is recorded the same way.
+
 **Record the pick.** Set `provider` on the theme for whichever provider wins most of the time, and add
 `provider` to individual cards only where a different one wins. `--sync` publishes the resolved provider's
 bytes and refuses any card with no pick.
@@ -258,8 +271,9 @@ publish is outlined.
 
 The page states three things rather than hiding them, and so does the command:
 
-- **MISSING cells** — that provider produced nothing for that card. A dead lane or a narrowed run, *not* a
-  provider that drew badly.
+- **MISSING cells** — that *lane* produced nothing for that card. A dead lane or a narrowed run, *not* a
+  provider that drew badly. An escape-hatch column (`ai-horde`) is labelled as such and blank by default —
+  that is the arrangement working, so it is not counted here.
 - **cards with no pick** — `--sync` will refuse these until a `provider` is set on the card or the theme.
 - **orphan files** — candidates on disk from a provider no longer registered.
 

--- a/seed/NEW-THEME-RUNBOOK.md
+++ b/seed/NEW-THEME-RUNBOOK.md
@@ -13,8 +13,8 @@ This file supersedes the old `seed/AUTHORING_PROMPT.md`. It is the only card-aut
 | | |
 |---|---|
 | **Input** | A theme name. Nothing else. Any extra steer from the human (e.g. "lean historical") overrides this document's defaults where they conflict. |
-| **Output** | 30 published cards, images reviewed, `seed/cards.json` committed on a branch, a PR open. |
-| **Human checkpoints** | Exactly **two**: the 30-name list (Step 3), and the image contact sheet (Step 7). Stop dead at both — do not proceed on silence, and never answer them yourself. |
+| **Output** | 30 published cards, images reviewed, the winning provider recorded in `seed/cards.json`, committed on a branch, a PR open. |
+| **Human checkpoints** | Exactly **two**: the 30-name list (Step 3), and the image contact sheet (Step 7). Still two — the bake-off did **not** add a third; it changed what the second one *is*, from approve/reject to **choose among N candidates**. Stop dead at both — do not proceed on silence, and never answer them yourself. |
 | **Blast radius** | `pnpm seed --sync` writes to the **production** Neon DB and Blob store that the children play against. `--check-urls` and `--review` do not write to it. |
 | **Session** | One theme per run. Do not batch two themes. |
 
@@ -124,28 +124,40 @@ added at Step 6, on the theme and — sparsely — on individual cards.
 - **`sourceUrl`** — a real, resolvable URL backing the fact. Wikipedia is fine. Parenthesised suffixes
   often 404; Step 5 catches it.
 - **`imagePrompt`** — concrete, kid-friendly, **no art-style words**: `buildPrompt()` appends `ART_STYLE`
-  for you. What works with this image model: name **one** subject ("a single …"), give a viewpoint ("side
+  for you. What works across every provider: name **one** subject ("a single …"), give a viewpoint ("side
   view"), put it somewhere plain ("parked on grass"). Sleek aircraft photographed in flight are the shape
-  it most often renders as two overlapping copies.
+  most often rendered as two overlapping copies.
 
-### What the image model can and cannot draw
+### What the providers can and cannot draw
 
-Learned the hard way on *Warriors*, where the first pass returned 3 usable images out of 28. Read this
-**before** you pick subjects, not after — some of it is a constraint on Step 3, not on your wording.
+Read this **before** you pick subjects, not after — some of it is a constraint on Step 3, not on your
+wording. It is written **per provider**, because they do not fail the same way. There is no such thing as
+"the image model" here any more: Step 6 draws every card on every lane and a human picks (#63).
 
-`ART_STYLE` asks for a bright cartoon. Long, photo-real prompts fight it and come back as dim resin
-statuettes on display bases. The prompts that land look like the ones already in `cards.json`: a short
-noun phrase, **one** cheerful subject, outdoors in daylight, **at most one** held object.
+The failure classes below were learned the hard way on *Warriors*, where a Pollinations-only pass returned
+3 usable images out of 28. #66 re-ran three of those cards through the shipped seam on both lanes, and #74
+ran them through the escape hatch. What survives is narrower than the old blanket claim:
 
-Three kinds of subject fail no matter how you word them. Prefer subjects that dodge all three:
+| Failure class | `pollinations` (asks for `flux`, served by `sana` — #64) | `cloudflare-sdxl` | `ai-horde` (escape hatch) |
+|---|---|---|---|
+| Identity rests on a **small held object** — bow, spear, tool | **fails** — the object goes wire-thin, smears, or duplicates | **fails** — right style, still draws two bows, and has baked a decorative frame border in | **the one it fixes** — #74's single bow, single arrow, no frame: the first usable Longbowman this project has had |
+| Identity rests on **niche uniform accuracy** | **fails** — a plausible costume from the wrong century or country, or a photoreal toddler in fancy dress | **usually passes** — #66 drew the Swiss Guard's blue/yellow stripes and ruff correctly; #74 saw a generic modern uniform on a different sample, so treat it as *much better, not reliable* | **fails differently** — costume correct, but rendered photo-real, which loses `ART_STYLE` |
+| **Multi-object scene** — a rider and a vehicle, a crowd | **fails** — the parts recombine into something else (a Victorian pony-trap for an Egyptian chariot; one figurine for the Terracotta Army) | **passes** — two horses, gold chariot, nemes headdress; rows of clay soldiers in a trench | **best seen for the class**, but miscounts (one horse where the prompt says two) |
 
-| Failure class | What you get | Seen on |
-|---|---|---|
-| Identity rests on a **small held object** | the object renders as a bent wire or a smear, or duplicates | Longbowman, Crossbowman, Chainmail |
-| Identity rests on **niche uniform accuracy** | a plausible costume from the wrong century or country | Swiss Guard (modern police), Ashigaru (farmer with a broom), Spartan Hoplite (19th-c dragoon helmet) |
-| **Multi-object scene** | the parts recombine into something else entirely | Egyptian Charioteer (a Victorian pony-trap), Terracotta Army (one figurine, not an army) |
+**What that means for Step 3.** Niche uniforms and multi-object scenes are **no longer disqualifying** —
+a theme that needs them is viable, on the Cloudflare lane. **Small held objects still are**: both lanes fail
+them, and the two answers are cheap-then-expensive — drop the object and let clothing carry the subject
+(the wording lever below), or reach for the escape hatch at 30–45 minutes per image. Budget one or two such
+cards per theme, not fifteen.
 
-Wording levers, in the order worth trying:
+`ART_STYLE` asks for a bright cartoon, and **the lanes do not agree about what they are drawing**:
+Cloudflare renders bright cartoon, `sana` renders painterly semi-realism on *every* subject, and the horde's
+model drifts photo-real on costume subjects. So a picture that looks wrong in style is usually the wrong
+lane rather than the wrong words. Long, photo-real prompts make it worse everywhere. The prompts that land
+look like the ones already in `cards.json`: a short noun phrase, **one** cheerful subject, outdoors in
+daylight, **at most one** held object.
+
+Wording levers, in the order worth trying — these apply to every provider:
 
 - **Lead with the defining object** when a subject needs one — "a tall wooden longbow held upright by a
   cheerful archer…" beats "an archer holding a longbow". It moves the odds; it does not fix the class.
@@ -156,21 +168,40 @@ Wording levers, in the order worth trying:
 - **Never say "on a display stand"** — objects photograph fine simply lying on grass.
 - Watch for **monochrome**: a red subject on a red ground renders as a red blur. Contrast the two.
 
-**Reverting an `imagePrompt` restores that exact earlier image.** Generation is reproducible — same
-prompt, same size, same bytes — so if round 3 is worse than round 2, paste round 2's prompt back and the
-picture returns verbatim. Keep the superseded prompts somewhere until the theme ships.
+#### Reproducibility is a per-provider fact, not a property of the pipeline
 
-That trick is reliable *within* a theme run, which is the only place you need it. It is **not** a
-long-term guarantee: the provider can change the model behind a prompt without notice, and has (#64), so
-a prompt that drew one picture in July draws a different one weeks later. Never use it to recover art
-that has already shipped — a published card is protected by the Blob URL already stored in the database,
-and `--sync` only updates text on an existing card, never regenerating or re-uploading its image. The
-reviewed bytes in `seed/review/` protect a card at insert time only, and that directory is gitignored
-local scratch a fresh clone will not have.
+| Provider | Same prompt twice | So the revert trick… |
+|---|---|---|
+| `pollinations` | **same bytes** — measured over 50 minutes and across cache misses (#64), with the seed pinned to 42 | **works.** Paste round 2's prompt back and round 2's picture returns verbatim |
+| `cloudflare-sdxl` | **different bytes**, despite the same pinned seed (#66) | **does not work.** A reverted prompt draws a *new* picture on this lane |
+| `ai-horde` | unmeasured, and it is a pool of volunteer machines | **assume it does not.** Do not plan around it |
 
-Expect **429 rate-limit failures** on a 30-card run. They are retryable and cost you nothing: re-run
-`pnpm seed --review` and it resumes. A 429 is not a prompt problem and does not count as a re-prompt
-round. If they persist, that is the free allocation's ceiling doing its job — wait and resume later.
+So: **keep every superseded `imagePrompt` in the session** until the theme ships — that is the only
+recovery mechanism that spans all three. On a non-deterministic lane, deleting a candidate and re-running
+is a **re-roll**: you get a different picture and you cannot get the old one back. That is occasionally the
+right move (it is how you clear a blank frame, below); it is never reversible.
+
+Even on Pollinations the trick is bounded: the provider can change the model behind a prompt without notice,
+and has (#64) — a request for `flux` is served by `sana` today — so a prompt that drew one picture in July
+draws a different one weeks later. Never use it to recover art that has already shipped: a published card is
+protected by the Blob URL already in the database, and `--sync` only updates text on an existing card, never
+regenerating or re-uploading its image. The reviewed bytes in `seed/review/` protect a card at insert time
+only, and that directory is gitignored local scratch a fresh clone will not have.
+
+#### Rate limits, per provider
+
+Each lane paces itself from its own declared limits, and the lanes run alongside each other — so the
+numbers below are *why a run takes as long as it does*, not knobs for you to turn.
+
+| Provider | The ceiling | What you see |
+|---|---|---|
+| `pollinations` | **one queued request per IP** (anonymous; no key, and the paid path is a wall #72 forbids crossing) — 1 at a time, 15s apart | the slow lane: ~8 minutes for a 30-card theme, and it sets the wall-clock floor for the whole bake-off |
+| `cloudflare-sdxl` | a published 10,000 neurons/day on the free plan, but **the exhaustion signal is undocumented** (#68) — so a lane that dies for no stated reason may be this. What guarantees $0 is the card-free account, not the number | 4 at a time, ~6–8s per image |
+| `ai-horde` | **2 requests/second per IP** across the whole API, and a volunteer queue you sit at the back of at zero kudos | 1 at a time; **30–45 minutes for one image** |
+
+A rate-limit failure is retryable and costs you nothing: re-run `pnpm seed --review` and it resumes past
+everything already on disk. It is **not** a prompt problem and does not count as a re-prompt round. If a
+provider keeps refusing, that is the free allocation's ceiling doing its job — wait and resume later.
 **Never attach a payment method to unblock it.**
 
 **Append** the theme object to the `themes` array of `seed/cards.json`. Array position **is** the theme's
@@ -197,8 +228,11 @@ pnpm seed --review         # generates images for NEW cards only, into seed/revi
 nothing to it. It skips cards already published and already-reviewed prompts, so an interrupted or
 rate-limited run resumes rather than restarting.
 
-`--review` generates each new card from **every registered provider**, in parallel lanes, so you can compare
-them side by side and pick the best draughtsman per subject. A 30-card theme is 30 images *per provider*.
+`--review` is a **bake-off** (#63): it generates each new card from **every registered lane**, in parallel,
+so a human can compare candidates side by side and pick the best draughtsman per subject. A 30-card theme is
+30 images *per lane* — 60 today, on `pollinations` and `cloudflare-sdxl`. The lanes run alongside each other
+and pace themselves independently, so the wall-clock is the slowest lane, not the sum: expect ~8 minutes,
+set by Pollinations. `ai-horde` is an **escape hatch**, not a lane, and sits out unless named (below).
 
 If a provider's key is missing the run **aborts and generates nothing**, rather than quietly leaving that
 provider out — a lane absent from a comparison looks like a provider that drew badly. Add the key, or narrow
@@ -211,53 +245,110 @@ pnpm seed --review --providers=pollinations
 Review files land at `seed/review/<theme-slug>-<card-slug>-<hash8>-<provider>-<params4>.<ext>`. `<hash8>`
 covers the *full* prompt including `ART_STYLE` and is identical across providers, so a subject's candidates
 sort together. `<params4>` covers that provider's request settings, so changing them invalidates the reviews
-they would change. The extension follows the provider — Pollinations writes JPEG, Cloudflare PNG. Each image
-has a `.json` sidecar recording which model actually answered.
+they would change. The extension follows the provider — Pollinations writes JPEG, Cloudflare PNG, AI Horde
+WebP. Each image has a `.json` sidecar recording what was requested and, *where the provider says so*, which
+model actually answered: Pollinations names it except on a cache hit, and Cloudflare names nothing at all,
+so a blank `model` means unwitnessed, never "the model I asked for".
 
 If a provider stops responding, its lane is abandoned after 3 consecutive failures and the run reports it.
 Re-run to resume: images already on disk are never regenerated.
 
-### Screen every image yourself, first
+### Screen the grid yourself, first — and form a *recommendation*, not a verdict
 
 Build the contact sheet (Step 7) and screen from it — it is a grid, so you are comparing a row rather than
-opening every candidate file (30 × however many providers ran). Reject a candidate on:
+opening every candidate file (30 × however many providers ran). Your job here changed with the bake-off:
+you are no longer accepting or rejecting one image per card, you are **reading a row of N candidates and
+saying which you would pick and why**. The human still chooses (Step 7). Screening removes their grind; it
+does not pre-empt them.
+
+Rule out a candidate on:
 
 - **Two overlapping copies of the subject**, or a subject fused with scenery. The most common failure.
 - Gore, damage, fire, combat, casualties — anything from the prohibited list above.
 - Scary rather than friendly.
 - Wrong subject, or unreadable mush.
-- Text baked into the image (`ART_STYLE` asks for none; the model sometimes disagrees).
+- Text baked into the image, or a decorative frame border (`ART_STYLE` asks for neither; the models
+  sometimes disagree — Cloudflare in particular has drawn frames).
+- **A blank frame.** Cloudflare can return a *pure black* 768×768 PNG for a perfectly innocuous prompt —
+  ~40% of attempts on one measured prompt. It is a valid PNG at exactly the right size, so the seam accepts
+  it and it lands looking like a real candidate; the tell is file size, ~2 KB against a normal 750–900 KB.
+  Known and open as **#78**. The fix is a re-roll, not a re-prompt: delete that one file and re-run
+  `--review`. Retrying cleared it both times it was tried.
 
-**To fix a reject, edit its `imagePrompt`** — deleting the file is not enough. The image service returns
-the *same bytes for the same prompt* (verified in #64: the omitted `seed` takes a fixed server-side
-default, and identical prompts return an identical sha256), so deleting a review file
-and re-running regenerates the picture you just rejected. Editing the prompt changes the content hash,
-which both asks for a different picture and makes the stale review file stop matching. Delete the stale
-file too, to keep the folder honest.
+Then, for each row, write down one of three outcomes: **a recommended provider with a one-line reason**,
+**a genuine tie** (say so — the human may have a taste preference), or **nothing usable**. Only the third
+one leads to more generation.
 
-Then re-run `pnpm seed --review`. **Re-prompt only the cards that NO provider drew acceptably** — where one
-provider drew the subject well, that is a pick, not a re-prompt (#63). **Cap this at 2 re-prompt rounds.** If
-an image still fails everywhere, take it to the human at the checkpoint with the problem named — do not swap
-the subject silently, and do not spend the session fighting the model.
+### Which lever: pick another provider, or change the words?
+
+Getting this wrong wastes a round, so the distinction is worth holding: **a bake-off fixes the wrong model;
+re-prompting fixes the wrong words.**
+
+| What the row looks like | Lever |
+|---|---|
+| One provider drew it well, another badly | **Neither.** That is a *pick* — record it in Step 8. Do not re-prompt a card another lane already nailed (#63) |
+| Every candidate is the same subject drawn in a style you dislike | **Pick**, or accept. Style is a property of the lane, not of your wording — see the per-provider table in Step 4 |
+| Every candidate misreads the *subject* — wrong object, fused parts, duplicated weapon | **Re-prompt.** Apply Step 4's wording levers |
+| Every candidate fails and the subject is a small held object | **The escape hatch**, below. Re-prompting this class has never fixed it on either lane |
+| One candidate is blank/black, the rest are fine | **Re-roll** that one file (#78). Not a re-prompt round |
+
+**To re-prompt, edit the `imagePrompt`** — deleting files is not enough on the Pollinations lane, which
+returns the same bytes for the same prompt (#64), so a delete-and-rerun there regenerates the picture you
+just rejected. Editing the prompt changes `<hash8>`, which both asks for a different picture on every lane
+*and* makes the old candidates stop matching.
+
+Those old candidates are now **N files per card, plus their `.json` sidecars**, and they are invisible to
+the contact sheet (it looks up the *current* hash). Leaving them is harmless; if you want the folder honest,
+delete the whole superseded set at once and never a subset of it:
+
+```bash
+rm seed/review/<theme-slug>-<card-slug>-<oldhash8>-*
+```
+
+Never delete a *current* candidate to tidy a row. A missing cell reads as "that lane failed", and removing a
+rival is you making the human's choice for them.
+
+Then re-run `pnpm seed --review`. **Re-prompt only the cards that NO provider drew acceptably.** **Cap this
+at 2 re-prompt rounds.** If a card still fails everywhere after two, take it to the human at the checkpoint
+with the problem named — do not swap the subject silently, and do not spend the session fighting the model.
 
 **The escape hatch, for a card the lanes refuse.** `ai-horde` is registered but sits out the fan-out (#71),
-so it never appears in a normal run. Reach it by name, for the handful of cards that need it:
+so it never appears in a normal run. Two signatures say to reach for it:
+
+- **a subject only the hatch draws** — the small-held-object class in Step 4's table; or
+- **"Cloudflare returned nothing and won't say why"** — that lane has an undocumented, non-disablable NSFW
+  input filter (error 3030) with no opt-out. #66 never once made it fire, including on a longbow and a
+  chariot, so this is rare rather than expected — but an unexplained Cloudflare refusal on a
+  weapon-bearing subject is what it looks like, and the hatch is the only provider whose content policy
+  plainly permits those subjects.
+
+Reach it by name, for the handful of cards that need it:
 
 ```bash
 pnpm seed --review --providers=ai-horde     # after the lanes have run; it resumes past what exists
 ```
 
-It exists for **permission**, not for speed or quality: it is the only provider whose content policy plainly
-allows weapon-bearing subjects. It is also the slowest thing in this runbook by an order of magnitude —
-a volunteer queue, and this project's account holds no kudos, so **one image can take 30–45 minutes**. Use it
-for one or two cards, never for a theme. Its candidates land in `seed/review/` and appear in the contact
-sheet exactly like a lane's, so the pick is recorded the same way.
+It exists for **permission** first — it is the only provider whose content policy plainly allows
+weapon-bearing subjects — and #74 found it also draws the one class both lanes fail: a **small held object**
+(the first clean single bow this project has had). It is not better in general: it renders costume subjects
+photo-real and loses `ART_STYLE`. It is also the slowest thing in this runbook by an order of magnitude — a
+volunteer queue, and this project's account holds no kudos, so **one image can take 30–45 minutes**. Use it
+for the one or two cards that earned it, never for a theme. Its candidates land in `seed/review/` and appear
+in the contact sheet exactly like a lane's, so a pick on the hatch is recorded exactly like any other.
 
-**Record the pick.** Set `provider` on the theme for whichever provider wins most of the time, and add
-`provider` to individual cards only where a different one wins. `--sync` publishes the resolved provider's
-bytes and refuses any card with no pick.
+**If the horde refuses the prompt, stop — do not re-run it.** Two or more matches against its content regex
+in one prompt is a `CorruptPrompt`: a terminal failure *plus* a timeout on this machine's IP that escalates
+**3 → 9 → 15 → 21 minutes**, on a 24-hour counter. Retrying immediately makes the next wait longer. The
+refusal is also information — this prompt is unworkable on the one provider whose policy was supposed to be
+permissive — so the response is to reword it (Step 4's levers) or take the card to the human, never to
+re-submit it as-is. Only the hatch's lane is affected; Cloudflare and Pollinations carry on.
 
-Amend the commit if you changed any `imagePrompt`.
+One thing is easier here than anywhere else: **on AI Horde, paying is not merely forbidden, it is
+impossible.** The service has no payment surface at all, so this is the only provider where the $0 constraint
+is enforced by the service rather than by the account state you are trusted to preserve.
+
+Amend the commit if you changed any `imagePrompt`. **Do not write a `provider` value yet** — that is the
+human's choice, recorded in Step 8.
 
 ## Step 7 — Build the contact sheet → **CHECKPOINT 2**
 
@@ -274,15 +365,52 @@ The page states three things rather than hiding them, and so does the command:
 - **MISSING cells** — that *lane* produced nothing for that card. A dead lane or a narrowed run, *not* a
   provider that drew badly. An escape-hatch column (`ai-horde`) is labelled as such and blank by default —
   that is the arrangement working, so it is not counted here.
-- **cards with no pick** — `--sync` will refuse these until a `provider` is set on the card or the theme.
+- **cards with no pick** — expected at this point, since the picking happens *here*. `--sync` refuses every
+  one of them until Step 8 sets a `provider` on the card or its theme.
 - **orphan files** — candidates on disk from a provider no longer registered.
 
-Give the human the file path, tell them anything you re-prompted and anything you are unsure about, and
-**stop and wait for an explicit approval.** The human holds the kid-safety veto; your screening only
-removes their grind, it does not replace them. `seed/review/*.html` is a local scratch artifact — do not
+**This checkpoint is a choice, not a yes/no.** The human is picking a provider per row, so give them what a
+chooser needs and nothing more:
+
+- the file path;
+- your **recommendation per row** — provider and a one-line reason — and which rows you think are ties;
+- every card you re-prompted, and how many rounds it took;
+- every card **nothing drew acceptably**, named as such;
+- anything you are unsure about, including any cell you suspect is a blank frame (#78).
+
+Then **stop and wait for an explicit approval.** The human holds the kid-safety veto and the taste call;
+your screening only removes their grind, it does not replace them. This is the **second and last**
+checkpoint — publishing does not get another one. `seed/review/*.html` is a local scratch artifact — do not
 commit it.
 
-## Step 8 — Publish
+## Step 8 — Record the pick
+
+The human has chosen; write it down. This is the one step with no counterpart in the old single-provider
+pipeline, and it is what stands between a reviewed image and a published one.
+
+In `seed/cards.json`, set **`provider` on the theme** to whichever provider won most rows, and add
+`provider` to **individual cards only where a different one won** — a sparse override list, not 30 repeats:
+
+Add one key to the theme object, and one key to each overridden card. Everything else in the file is left
+exactly as it is — no other field is touched by this step:
+
+```jsonc
+// on the theme object, alongside "name" and "cards":
+"provider": "cloudflare-sdxl",
+
+// on a card object that a different provider won, alongside its five fields:
+"provider": "ai-horde",
+```
+
+`--sync` resolves `card.provider ?? theme.provider` and publishes **that** provider's reviewed bytes. The id
+must match a registered provider exactly (`pollinations`, `cloudflare-sdxl`, `ai-horde`); a typo is refused
+by name rather than treated as a missing review.
+
+```bash
+git add seed/cards.json && git commit -m "feat(seed): record the <Theme> bake-off picks"
+```
+
+## Step 9 — Publish
 
 Only after approval:
 
@@ -291,7 +419,12 @@ pnpm seed --sync           # publishes the REVIEWED bytes -> Blob -> DB insert; 
 ```
 
 `--sync` is delta-only: it inserts new cards, updates text on existing ones, and republishes nothing it
-does not have to. It refuses to insert any card lacking a reviewed image.
+does not have to. It refuses to insert any card lacking a reviewed image from its resolved provider.
+
+**The fail-safe, stated so nobody works around it:** a theme with **no pick recorded publishes nothing.**
+`--sync` reports each such card as *"no provider chosen (bake-off not judged)"* and exits without writing.
+That is the design working — an unjudged bake-off has no reviewed image, only candidates — not a bug. The
+fix is always Step 8, never `--allow-unreviewed`.
 
 Then:
 
@@ -312,9 +445,12 @@ Abort the run and report. Do not improvise past any of these.
 |---|---|
 | `--sync` reports a pending **prune**, or asks you to type a collection-row count | Something was renamed or dropped in the seed file. A prune deletes cards **out of the children's collections**. Fix the file. **Never pass `--allow-prune`.** |
 | `--sync` refuses: "would be inserted with no reviewed image" | Run `--review` first. **Never pass `--allow-unreviewed`** — it defeats the guarantee that no unreviewed image reaches a child. |
+| `--sync` refuses: "no provider chosen (bake-off not judged)" | The pick was never recorded. Go back to Step 8 — the human's choice, written into `seed/cards.json`. Never route around it with `--allow-unreviewed`. |
+| `--sync` refuses: "name a provider that is not registered" | A typo, or an adapter that was retired. Fix the `provider` value; re-running `--review` cannot satisfy this one. |
+| `--review` aborts naming an unconfigured provider | Add the key, or narrow the run *on purpose* with `--providers=`. Never let a lane drop out silently — a blank column reads as a provider that drew badly. |
 | Schema failure you cannot resolve without dropping below 30 cards or off the pyramid | The theme is not viable as scoped. That is a human call. |
 | A `sourceUrl` you cannot make resolve for a subject you consider essential | Ditto. |
-| An image still failing after 2 re-prompt rounds | Take it to the checkpoint, named. |
+| An image still failing after 2 re-prompt rounds on every provider | Take it to the checkpoint, named. |
 | `DATABASE_URL` / `BLOB_READ_WRITE_TOKEN` missing | Report it; do not go hunting for credentials. |
 
 ## Never
@@ -323,8 +459,23 @@ Abort the run and report. Do not improvise past any of these.
   child's collection**.
 - Never reorder the `themes` array.
 - Never pass `--allow-prune`, `--allow-unreviewed`, or `--reset`.
-- Never answer a checkpoint on the human's behalf.
+- Never answer a checkpoint on the human's behalf — including the bake-off pick, which is a *choice* the
+  human makes at checkpoint 2 and you only ever recommend.
+- **Never rename, copy or hand-edit a file in `seed/review/` to make a card look picked.** The filename is
+  the whole audit trail: `<hash8>` says which prompt drew it and `<provider>-<params4>` says who drew it
+  with what settings. Renaming one provider's candidate to another's is publishing bytes no one reviewed
+  under that name — the exact hole `--sync`'s refusal exists to close. A card is picked by writing
+  `provider` into `seed/cards.json`, and by nothing else.
+- Never delete a current candidate to narrow a row. A missing cell means a lane failed; making a rival
+  disappear is answering checkpoint 2 for the human.
 - Never edit `src/features/pool/seed-schema.ts` to make a theme fit. The theme bends, not the pyramid.
+- Never move a provider between lane and escape hatch, or add one, to get a run through. The registry
+  (`src/features/pool/providers/index.ts`) is a reviewed code change, not a lever in an authoring session.
+- **Never turn on AI Horde's `replacement_filter` to get a blocked prompt through.** It does make the
+  refusal and its IP timeout disappear — by silently rewriting the prompt before a worker sees it, with no
+  signal anywhere in the response. You would then review an image drawn from words this project never sent,
+  filed under a hash of the words it did. Same for any other pinned request parameter: they are pinned
+  because they change the bytes.
 - **Never attach a payment method to an image-provider account, and never sign in to one that already
   has a card.** Recurring cost for this pipeline is $0, and the guarantee is the account state, not a
   budget: a card-free account can only ever refuse a request, whereas a carded one bills silently and you

--- a/src/features/pool/contact-sheet.ts
+++ b/src/features/pool/contact-sheet.ts
@@ -24,6 +24,14 @@
  *     cannot tell those apart and says so instead of implying one). #63's grid
  *     is only readable if a blank cell is distinguishable from a provider that
  *     drew badly.
+ *
+ *     An escape hatch (#71) is exempt from the COUNT but not from the GRID. It
+ *     sits out the fan-out by design, so it is blank for almost every card —
+ *     that is the arrangement working. Counting those blanks would fire the "N
+ *     candidate(s) missing" banner on every sheet forever, which teaches a
+ *     reviewer to ignore the one warning that says a lane died. Its column still
+ *     renders, because a hatch that WAS invoked for a card has to be visible
+ *     beside the lanes it beat.
  *   - an UNPICKED row — no `provider` resolved, so `--sync` will refuse the card.
  *     Better learned here than at the publish gate.
  *   - an ORPHAN file — a candidate on disk belonging to no registered provider,
@@ -35,6 +43,17 @@
  */
 import { slug } from "./keys";
 import { reviewFileName, resolveProviderId, type NamingProvider } from "./review-files";
+import type { ProviderRole } from "./providers/provider";
+
+/**
+ * What the grid needs to know about a provider: how to name its file, and
+ * whether a blank cell is a gap or the arrangement working.
+ *
+ * `role` is required rather than optional-with-a-default for the reason
+ * `reviewKey`'s provider segment is: an optional one would silently count a
+ * hatch as a lane, which is the exact miscount this type exists to prevent.
+ */
+export type SheetProvider = NamingProvider & { role: ProviderRole };
 
 /** Display order — legendary first, so the cards that matter most are seen first. */
 const RARITY_ORDER: Record<string, number> = {
@@ -79,6 +98,8 @@ export interface SheetRow {
 export interface ContactSheet {
   theme: string;
   providerIds: string[];
+  /** Of those, the ones that sit out the fan-out (#71) — expected to be sparse. */
+  escapeHatchIds: string[];
   rows: SheetRow[];
   /** (card, provider) pairs with no candidate on disk. */
   missing: number;
@@ -107,7 +128,7 @@ export interface SheetDeps {
  */
 export function planContactSheet(
   theme: SheetTheme,
-  providers: readonly NamingProvider[],
+  providers: readonly SheetProvider[],
   deps: SheetDeps,
   siblingThemeNames: readonly string[] = [],
 ): ContactSheet {
@@ -125,7 +146,8 @@ export function planContactSheet(
         const fileName = reviewFileName(theme.name, card, provider);
         expected.add(fileName);
         const present = deps.exists(fileName);
-        if (!present) missing++;
+        // A hatch's blank is not a gap — see the header note.
+        if (!present && provider.role === "lane") missing++;
         return {
           providerId: provider.id,
           fileName,
@@ -168,6 +190,7 @@ export function planContactSheet(
   return {
     theme: theme.name,
     providerIds: providers.map((p) => p.id),
+    escapeHatchIds: providers.filter((p) => p.role === "escape-hatch").map((p) => p.id),
     rows,
     missing,
     unpicked,
@@ -182,7 +205,10 @@ export function renderContactSheet(sheet: ContactSheet): string {
       ? `<p class="warn">⚠ ${sheet.unpicked} card(s) have no provider chosen. <code>--sync</code> will refuse them until a <code>provider</code> is set on the card or the theme.</p>`
       : "",
     sheet.missing > 0
-      ? `<p class="warn">⚠ ${sheet.missing} of ${sheet.rows.length * (sheet.providerIds.length || 1)} cell(s) have no candidate on disk. A blank cell means that provider produced nothing for that card — a dead lane, a run that was narrowed, or a card <code>--review</code> never generated because it is already published — NOT that it drew badly.</p>`
+      ? `<p class="warn">⚠ ${sheet.missing} lane cell(s) have no candidate on disk. A blank cell means that lane produced nothing for that card — a dead lane, a run that was narrowed, or a card <code>--review</code> never generated because it is already published — NOT that it drew badly.</p>`
+      : "",
+    sheet.escapeHatchIds.length > 0
+      ? `<p class="sub">${sheet.escapeHatchIds.map(esc).join(", ")} ${sheet.escapeHatchIds.length === 1 ? "is an escape hatch" : "are escape hatches"} (#71): not part of the fan-out, so blank is the normal state. A filled cell there means someone invoked it deliberately for that card.</p>`
       : "",
     sheet.orphans.length > 0
       ? `<p class="warn">⚠ ${sheet.orphans.length} file(s) in seed/review/ belong to no registered provider (a rename or a retirement): ${sheet.orphans.map(esc).join(", ")}</p>`
@@ -225,6 +251,7 @@ img{width:100%;border-radius:8px;display:block;background:#222}
 .e{opacity:.8;margin-top:6px}
 .p{margin-top:6px;font-size:12px;opacity:.8}
 .m{font-size:11px;opacity:.55;margin-top:4px}
+.hatch{font-size:10px;opacity:.6;font-weight:400;letter-spacing:.04em;margin-top:3px}
 .miss{color:#f66;border:1px dashed #f66;border-radius:8px;padding:24px;text-align:center}
 td.pick{outline:2px solid #6c9;outline-offset:-2px;border-radius:8px}
 </style>
@@ -232,7 +259,14 @@ td.pick{outline:2px solid #6c9;outline-offset:-2px;border-radius:8px}
 <p class="sub">Every card this theme declares in <code>seed/cards.json</code>, not just the unpublished ones — this sheet reads no database. One row per subject, one column per provider. The outlined cell is what <code>--sync</code> would publish.</p>
 ${banner}
 <table>
-<thead><tr><th>Card</th>${sheet.providerIds.map((p) => `<th>${esc(p)}</th>`).join("")}</tr></thead>
+<thead><tr><th>Card</th>${sheet.providerIds
+    .map(
+      (p) =>
+        `<th>${esc(p)}${
+          sheet.escapeHatchIds.includes(p) ? `<div class="hatch">escape hatch</div>` : ""
+        }</th>`,
+    )
+    .join("")}</tr></thead>
 <tbody>
 ${rows}
 </tbody>

--- a/src/features/pool/providers/ai-horde.ts
+++ b/src/features/pool/providers/ai-horde.ts
@@ -1,0 +1,334 @@
+/**
+ * AI Horde adapter — the escape hatch (#71 keyed it, #74 pinned its model).
+ *
+ * ── The verdict #74 reached ──────────────────────────────────────────────────
+ * KEEP the hatch, pinned to `AlbedoBase XL (SDXL)`. #74 offered the opposite
+ * outcome explicitly — if the horde drew the hard subjects no better than
+ * Cloudflare, the honest answer was to reverse #71 and drop AI Horde entirely.
+ * It did draw them better on two of the three failure classes, so the hatch
+ * stays. The per-class evidence is on `params.model` below, where the choice is.
+ *
+ * ── Why it exists, and what its claim actually is ────────────────────────────
+ * #71 keyed AI Horde for PERMISSION, not for skill: it is the only shortlisted
+ * provider whose content policy plainly allows the weapon-bearing subjects the
+ * runbook's hardest cards need, and it has no payment surface at all, so $0 is
+ * structural rather than a policy that could change. It is deliberately NOT a
+ * bake-off lane — registration buys about one image of kudos permanently, a
+ * 30-card burst costs ~720, and #74 measured a queue position of 352 with a
+ * ~2850s wait at zero kudos. That loses the map's throughput driver outright.
+ * It earns its place as insurance for cards the lanes refused or drew badly,
+ * invoked by name.
+ *
+ * ── The model pin is the whole of #74, and it is load-bearing twice ──────────
+ * AI Horde has no default model, and leaving `models` unset is not a shrug — it
+ * is two separate ways to break this app.
+ *
+ *   RESOLUTION. `waiting_prompt.py` caps an unpinned request at
+ *   `max_res = 1024 + threads*10 - round(queue*0.9)`. That is not a tail risk
+ *   at this horde's load: #74 measured 456px, 519px and 529px on three separate
+ *   samples within one hour. A 768x768 request is REFUSED at those caps, not
+ *   downgraded. Naming a model whose baseline is `stable_diffusion_xl`,
+ *   `stable_cascade` or `flux_1` forces `max_res` to 1024 unconditionally, which
+ *   is what turns the map's 768x768 invariant from a coin-flip into a guarantee.
+ *
+ *   CONTENT. The horde's catalogue is ranked by volunteer popularity, and its
+ *   most-served image models are NSFW — `WAI-NSFW-illustrious-SDXL` has the
+ *   highest worker count on the whole horde, then `Pony Diffusion XL`,
+ *   `Hassaku XL`, `CyberRealistic Pony`. An unpinned request in a children's app
+ *   is routed at those by popularity. Even inside the shortlist the trap is
+ *   live: `AlbedoBase XL 3.1` is one character away from the pinned model's name
+ *   and is flagged `nsfw: true` in the model reference.
+ *
+ * So the model is pinned HERE, in code, rather than read from `AIHORDE_MODEL`.
+ * That follows the registry's own rule (`providers/index.ts`): the environment
+ * carries secrets and nothing else, because anything that changes the BYTES must
+ * be diffable in a pull request. It is also forced by the port — `params` is
+ * hashed into the review filename, so an env-driven model would silently rename
+ * every reviewed candidate the moment someone edited their `.env.local`, and
+ * would let a typo point a kids' app at the NSFW near-namesake above with no
+ * review step in between.
+ *
+ * ── What the pin does NOT promise ────────────────────────────────────────────
+ * That the model is online. This is volunteer infrastructure and the catalogue
+ * moves hour to hour — #74 watched Flux.1-Schnell's worker count drop from 2 to
+ * 1 mid-run. A pinned model with no workers surfaces as `is_possible: false`,
+ * which this adapter fails on by name rather than polling to the deadline.
+ *
+ * ── One logical attempt, four round-trips ────────────────────────────────────
+ * Submit, poll, read status, download. The port is explicit that this loop lives
+ * inside the adapter so the runner never learns that one provider is
+ * asynchronous and the others are not.
+ *
+ * ── Pacing is per-IP, not per-endpoint ───────────────────────────────────────
+ * Measured on #74's first run: the horde answers `429 {"message": "2 per 1
+ * second"}`, and it counts every call — submits and polls together — against one
+ * per-IP budget. Three lanes fanning out lost 7 of 12 submissions inside the
+ * first second. The seam's gate is per-lane, so the only honest way to declare
+ * that here is one request in flight at a time with a gap wider than the limit.
+ * That costs nothing: an escape hatch generates one card at a time by design.
+ */
+import {
+  assertOk,
+  type FetchImpl,
+  type HttpAdapterOptions,
+  finishGeneration,
+  readBytes,
+} from "./http";
+import {
+  ProviderRetryable,
+  type GeneratedImage,
+  type ImageProvider,
+  type ImageSizeRequest,
+} from "./provider";
+
+const ENDPOINT = "https://aihorde.net/api/v2";
+
+/**
+ * Identifies this client to the horde, as its API asks. Volunteer
+ * infrastructure: being reachable when a client misbehaves is the etiquette.
+ */
+const CLIENT_AGENT = "kids-collection:1.0:github.com/nywleswoey/kids-collection";
+
+export interface AiHordeOptions extends HttpAdapterOptions {
+  /** Injectable so tests do not spend real seconds proving a poll loop. */
+  sleep?: (ms: number) => Promise<void>;
+  pollIntervalMs?: number;
+  /**
+   * How long one attempt waits before giving up on a job.
+   *
+   * Set GENEROUSLY, and measured the hard way during #74. The horde expires a
+   * request that nobody CHECKS, not one that is merely slow — so an active poll
+   * loop keeps a job alive indefinitely, and a client-side deadline is a pure
+   * self-inflicted loss. #74's first run set this to 20 minutes and watched all
+   * three lanes abandon jobs that had reached queue position 58 of 800, then
+   * resubmit to the BACK of that queue. Giving up is strictly worse than waiting
+   * whenever the job is still advancing.
+   *
+   * So this is a runaway guard, not a service-level expectation. At zero kudos a
+   * single generation legitimately takes 30-45 minutes.
+   */
+  pollTimeoutMs?: number;
+}
+
+export function aiHorde(opts: AiHordeOptions = {}): ImageProvider {
+  const fetchImpl: FetchImpl = opts.fetchImpl ?? fetch;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const pollIntervalMs = opts.pollIntervalMs ?? 8_000;
+  const pollTimeoutMs = opts.pollTimeoutMs ?? 60 * 60_000;
+
+  return {
+    id: "ai-horde",
+    role: "escape-hatch",
+    // R2 delivery is WebP. `finishGeneration` sniffs the bytes, so a worker that
+    // ever returned something else fails loudly rather than filling seed/review/
+    // with extensions that lie.
+    format: "webp",
+    params: {
+      /**
+       * #74's answer, chosen by a human from a subject x model contact sheet.
+       *
+       * Exact catalogue name — the horde matches it literally, and a near-miss
+       * is not a 404 but a DIFFERENT model. `AlbedoBase XL 3.1` is one character
+       * away and is flagged `nsfw: true`. Baseline `stable_diffusion_xl`,
+       * `nsfw: false`, highest worker count of any SFW SDXL-class model.
+       *
+       * What the bake-off actually found, against `cloudflare-sdxl` on the
+       * runbook's three failure classes, 3 samples each at 768x768 through
+       * `buildPrompt()`:
+       *
+       *   Longbowman (identity in a small held object) — the hatch EARNS ITS
+       *   KEEP here. Cloudflare returned 0 of 3 usable: every sample duplicated
+       *   the bow and baked a decorative frame border into the image, against
+       *   ART_STYLE's "clean background". This model returned a clean single
+       *   bow, single arrow, no frame — the first usable Longbowman the project
+       *   has had.
+       *
+       *   Egyptian Charioteer (multi-object scene) — the best result seen for
+       *   this class: correct golden two-wheeled chariot, nemes headdress, reins,
+       *   sand. It still miscounts (one horse where the prompt says two), but
+       *   nothing like the Victorian pony-trap the runbook records.
+       *
+       *   Swiss Guard (niche uniform accuracy) — NOT solved, and the failure is
+       *   worth knowing before reaching for the hatch: this model gets the
+       *   costume right where Cloudflare invents a generic modern uniform, but
+       *   renders it PHOTO-REAL rather than cartoon, so it loses ART_STYLE. Both
+       *   providers fail this class, differently.
+       *
+       * Per-worker censorship (#71's accepted risk) fired ZERO times across the
+       * run, including on the weapon-bearing Longbowman.
+       *
+       * `Fustercluck` (style=artistic) is the live alternative and is UNTESTED —
+       * the run was interrupted before it drew a hard subject. If the photo-real
+       * drift above shows up on more subjects, it is the next thing to try.
+       */
+      model: "AlbedoBase XL (SDXL)",
+      steps: 25,
+      cfg_scale: 7.5,
+      sampler_name: "k_euler_a",
+      karras: true,
+      // Pinned like every other adapter's seed (#64) — never inherit a server
+      // default nobody can see.
+      seed: 42,
+
+      /**
+       * #71's ROUTING parameters live in the hashed bag too, because on this
+       * provider routing decides the bytes.
+       *
+       * The port's rule is that `params` must be TOTAL — `generate()` builds its
+       * request from `{prompt, size, ...params}` and nothing else — and these
+       * are not incidental transport settings:
+       *
+       *   replacement_filter  false: the horde may otherwise rewrite the prompt
+       *                       before a worker sees it, which would make the
+       *                       review file's promptHash name a prompt that was
+       *                       never sent.
+       *   nsfw                false: gates which workers and models may take the
+       *                       job, so it changes who draws the card.
+       *   slow_workers        true: widens the worker pool to the slow
+       *                       volunteers — at zero kudos they ARE the queue.
+       *   r2                  true: decides the DELIVERY ENCODING. False returns
+       *                       inline base64 PNG; true returns a WebP download.
+       *                       It therefore decides `format` above, which names
+       *                       the review file's extension.
+       *   shared              false: false keeps generations out of the public
+       *                       LAION dataset. True would earn a kudos bonus and
+       *                       publish every card this app draws; that is an
+       *                       outward-facing choice, so it is pinned off and
+       *                       visible in the hash rather than left to a default.
+       *   trusted_workers     false: does not restrict to trusted workers, which
+       *                       at this queue depth would mean waiting far longer.
+       *
+       * `allow_downgrade` is absent from this bag ON PURPOSE and must stay
+       * absent. The horde reads its PRESENCE, and it permits a smaller image
+       * than requested — undoing the model pin above, which exists precisely to
+       * stop 768x768 being negotiable.
+       */
+      replacement_filter: false,
+      nsfw: false,
+      slow_workers: true,
+      r2: true,
+      shared: false,
+      trusted_workers: false,
+    },
+    // See the pacing note: the limit is per-IP across the whole API.
+    minIntervalMs: 1_200,
+    concurrency: 1,
+    requiredEnv: ["AIHORDE_API_KEY"],
+    isConfigured: () => Boolean(process.env.AIHORDE_API_KEY),
+
+    async generate(prompt: string, size: ImageSizeRequest): Promise<GeneratedImage> {
+      const apikey = process.env.AIHORDE_API_KEY ?? "";
+      const headers = { apikey, "Client-Agent": CLIENT_AGENT };
+
+      const submitted = await fetchImpl(`${ENDPOINT}/generate/async`, {
+        method: "POST",
+        headers: { ...headers, "Content-Type": "application/json" },
+        // Built from `{prompt, size, ...params}` and nothing else, so "does this
+        // adapter read anything outside params?" stays a checkable review
+        // question. `n: 1` is the only literal, and it is not a parameter — one
+        // generate() call is one card by definition of the port.
+        body: JSON.stringify({
+          prompt,
+          params: {
+            width: size.width,
+            height: size.height,
+            steps: this.params.steps,
+            cfg_scale: this.params.cfg_scale,
+            sampler_name: this.params.sampler_name,
+            karras: this.params.karras,
+            seed: String(this.params.seed),
+            n: 1,
+          },
+          models: [this.params.model],
+          nsfw: this.params.nsfw,
+          slow_workers: this.params.slow_workers,
+          replacement_filter: this.params.replacement_filter,
+          r2: this.params.r2,
+          shared: this.params.shared,
+          trusted_workers: this.params.trusted_workers,
+        }),
+      });
+      assertOk(this.id, submitted);
+      const job = (await submitted.json()) as { id?: string; message?: string };
+      if (!job.id) {
+        throw new Error(`${this.id}: submit refused — ${job.message ?? "no job id returned"}`);
+      }
+
+      const deadline = Date.now() + pollTimeoutMs;
+      for (;;) {
+        const res = await fetchImpl(`${ENDPOINT}/generate/check/${job.id}`, { headers });
+        if (res.status === 404) {
+          // How staleness ACTUALLY presents, measured on #74's run: the horde
+          // forgets a queued job and /check answers 404 — while the job is
+          // still advancing, not after any client deadline. At a low kudos
+          // balance it will not hold work the requester cannot cover, so this
+          // is the ordinary case rather than an edge one (27 of 46 images on
+          // one run).
+          //
+          // Retryable, and that classification is load-bearing: `assertOk`
+          // would map a bare 404 to a non-retryable 4xx, the lane runner's
+          // breaker would count three and abandon the lane, and the contact
+          // sheet would report a provider that drew badly when in fact it never
+          // drew at all.
+          throw new ProviderRetryable(
+            `${this.id}: the horde dropped job ${job.id} before it ran (404) — resubmitting is the remedy`,
+          );
+        }
+        assertOk(this.id, res);
+        const check = (await res.json()) as {
+          done?: boolean;
+          faulted?: boolean;
+          is_possible?: boolean;
+        };
+        if (check.faulted) throw new Error(`${this.id}: the horde reported job ${job.id} faulted`);
+        if (check.is_possible === false) {
+          // Nothing online can serve it — which is what the pinned model losing
+          // its last worker looks like. Not retryable: another attempt asks the
+          // same impossible question.
+          throw new Error(
+            `${this.id}: no worker can serve this request — is "${String(this.params.model)}" still online?`,
+          );
+        }
+        if (check.done) break;
+        if (Date.now() >= deadline) {
+          // A runaway guard, not a service level — see `pollTimeoutMs`. Retryable
+          // rather than fatal, but note that a retry resubmits to the BACK of the
+          // queue, so this is a loss either way and the deadline is set high
+          // enough that reaching it means something is genuinely wrong.
+          throw new ProviderRetryable(
+            `${this.id}: gave up on job ${job.id} after ${Math.round(pollTimeoutMs / 60_000)} minutes`,
+          );
+        }
+        await sleep(pollIntervalMs);
+      }
+
+      const statusRes = await fetchImpl(`${ENDPOINT}/generate/status/${job.id}`, { headers });
+      assertOk(this.id, statusRes);
+      const status = (await statusRes.json()) as {
+        generations?: { img?: string; model?: string; censored?: boolean }[];
+      };
+      const generation = status.generations?.[0];
+      if (!generation?.img) {
+        throw new ProviderRetryable(`${this.id}: job ${job.id} finished with no generation`);
+      }
+      if (generation.censored) {
+        // A censoring worker returns a BLACK FRAME, not a refusal. #71 accepted
+        // that risk because it "fails visibly into review" — but a black frame
+        // in seed/review/ is not visible, it reads as a model that drew nothing.
+        // It is one volunteer's filter rather than a verdict on the prompt, so
+        // another worker is a real remedy.
+        throw new ProviderRetryable(
+          `${this.id}: a worker censored this generation (a black frame, not a refusal) — retrying may reach a different worker`,
+        );
+      }
+
+      const download = await fetchImpl(generation.img);
+      assertOk(this.id, download);
+      const bytes = await readBytes(this.id, download);
+      // The WORKER's model, never the requested one (#64) — on the horde these
+      // genuinely differ, since the pin is matched against a catalogue a
+      // volunteer populated.
+      return finishGeneration(this, bytes, size, generation.model);
+    },
+  };
+}

--- a/src/features/pool/providers/http.ts
+++ b/src/features/pool/providers/http.ts
@@ -69,13 +69,6 @@ export async function readBytes(
   return bytes;
 }
 
-/** Decode a base64 payload (AI Horde returns images inline rather than as bytes). */
-export function fromBase64(providerId: string, b64: string): Uint8Array {
-  const bytes = new Uint8Array(Buffer.from(b64, "base64"));
-  if (bytes.byteLength === 0) throw new ProviderRetryable(`${providerId}: empty payload`);
-  return bytes;
-}
-
 /**
  * Turn raw bytes into a `GeneratedImage`, refusing anything that is not a usable
  * card. Every adapter ends here, which is what makes these two checks uniform

--- a/src/features/pool/providers/index.ts
+++ b/src/features/pool/providers/index.ts
@@ -23,15 +23,20 @@
  * candidates are named the same way — because a card published from the hatch
  * must be as traceable as any other.
  *
- * ── AI Horde's adapter is not here yet ───────────────────────────────────────
+ * ── AI Horde, and why its model is in code rather than in the environment ────
  * #71 settled its request parameters (`slow_workers: true` mandatory,
  * `allow_downgrade` never set, `replacement_filter: false`) but explicitly left
- * the model to #74 — and pinning an SDXL-baseline model is what makes 768x768 a
- * guarantee rather than a coin-flip against live queue depth. `params` must be
- * total and hashed, so an adapter with an unpinned model would name its review
- * files after a request it did not make. It lands with #74; the role above is
- * the part #71 made binding here.
+ * the model to #74. #74 pinned it, so the hatch registers here.
+ *
+ * The model lives in `ai-horde.ts` and NOT in `AIHORDE_MODEL`, for this file's
+ * own reason one level down. The environment carries secrets; anything that
+ * changes the BYTES belongs in a diff. A model name changes the bytes twice
+ * over: `params` is hashed into the review filename, so an env-driven model
+ * would silently rename every reviewed candidate when someone edited their
+ * `.env.local` — and on this provider a mistyped name is not a 404 but a
+ * DIFFERENT model, with the horde's most-served models being NSFW ones.
  */
+import { aiHorde } from "./ai-horde";
 import { cloudflareSdxl } from "./cloudflare-sdxl";
 import { pollinations } from "./pollinations";
 import type { ImageProvider } from "./provider";
@@ -39,9 +44,10 @@ import type { ImageProvider } from "./provider";
 export * from "./provider";
 export { pollinations } from "./pollinations";
 export { cloudflareSdxl } from "./cloudflare-sdxl";
+export { aiHorde } from "./ai-horde";
 
 /** Every provider that exists. Adding or removing one is a reviewable code change. */
-export const PROVIDERS: readonly ImageProvider[] = [pollinations(), cloudflareSdxl()];
+export const PROVIDERS: readonly ImageProvider[] = [pollinations(), cloudflareSdxl(), aiHorde()];
 
 export const PROVIDER_IDS: readonly string[] = PROVIDERS.map((p) => p.id);
 

--- a/tests-live/providers.live.test.ts
+++ b/tests-live/providers.live.test.ts
@@ -28,8 +28,41 @@ import { CARD_SIZE, PROVIDERS } from "@/features/pool/providers";
  */
 const SALT = `kc-live-${Date.now()}`;
 
-const configured = PROVIDERS.filter((p) => p.isConfigured());
-const skipped = PROVIDERS.filter((p) => !p.isConfigured());
+/**
+ * Which providers this run covers.
+ *
+ * Lanes by default; an escape hatch only when NAMED — the same rule `selectLanes`
+ * applies to `--review`, for a sharper reason here. AI Horde is queue-backed and
+ * this project's account holds no kudos, so #74 measured a queue position of 352
+ * and a ~2850s wait for one generation. The contract makes several generations
+ * per provider. Including the hatch by default would turn `pnpm test:providers`
+ * from a ten-minute check into an all-afternoon one that times out anyway, and a
+ * suite nobody can afford to run is a suite nobody runs.
+ *
+ *   LIVE_PROVIDERS=ai-horde pnpm test:providers   # just the hatch
+ *   LIVE_PROVIDERS=ai-horde,pollinations ...      # both
+ *
+ * Set `testTimeout` accordingly when you do — the default 180s will not cover a
+ * cold horde queue.
+ */
+const named = process.env.LIVE_PROVIDERS?.split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const selected = named
+  ? PROVIDERS.filter((p) => named.includes(p.id))
+  : PROVIDERS.filter((p) => p.role === "lane");
+
+const sittingOut = PROVIDERS.filter((p) => !selected.includes(p));
+if (sittingOut.length > 0) {
+  console.warn(
+    `\n⚠️  Not covered by this run: ${sittingOut.map((p) => p.id).join(", ")}` +
+      `\n   Name them to include one: LIVE_PROVIDERS=${sittingOut[0]!.id} pnpm test:providers\n`,
+  );
+}
+
+const configured = selected.filter((p) => p.isConfigured());
+const skipped = selected.filter((p) => !p.isConfigured());
 
 if (skipped.length > 0) {
   console.warn(
@@ -42,10 +75,10 @@ if (skipped.length > 0) {
 describe("live providers", () => {
   it("reports what it actually exercised", () => {
     console.log(
-      `Live contract over ${configured.length}/${PROVIDERS.length} provider(s): ` +
+      `Live contract over ${configured.length}/${selected.length} selected provider(s): ` +
         `${configured.map((p) => p.id).join(", ") || "(none)"}`,
     );
-    expect(PROVIDERS.length).toBeGreaterThan(0);
+    expect(selected.length).toBeGreaterThan(0);
   });
 });
 

--- a/tests/contact-sheet.test.ts
+++ b/tests/contact-sheet.test.ts
@@ -114,6 +114,31 @@ describe("planContactSheet — the three absences it must not hide", () => {
     expect(cf.every((c) => !c.present)).toBe(true);
   });
 
+  it("does not count an escape hatch's blanks as missing candidates (#71, #74)", () => {
+    // An escape hatch sits out the fan-out by design, so it has no candidate for
+    // almost every card — that is the arrangement working, not a gap. Counting
+    // those blanks would fire the "N candidate(s) missing" banner on every sheet
+    // forever, which trains a reviewer to ignore the one warning that tells them
+    // a LANE died. The column still renders: a hatch that WAS invoked for a card
+    // has to be visible next to the lanes that lost to it.
+    const hatch = { ...fakeProvider({ id: "ai-horde", role: "escape-hatch" }), format: "webp" as const };
+    const sheet = planContactSheet(theme, [...PROVIDERS, hatch], deps(allFiles(theme)));
+    expect(sheet.providerIds).toContain("ai-horde");
+    expect(sheet.missing).toBe(0);
+    const cells = sheet.rows.flatMap((r) => r.candidates.filter((c) => c.providerId === "ai-horde"));
+    expect(cells).toHaveLength(2);
+    expect(cells.every((c) => !c.present)).toBe(true);
+  });
+
+  it("still counts a LANE's blanks when a hatch is in the grid too", () => {
+    // The exemption is about the hatch, not about the sheet giving up on
+    // counting. A dead lane must still be reported while a hatch sits out.
+    const hatch = { ...fakeProvider({ id: "ai-horde", role: "escape-hatch" }), format: "webp" as const };
+    const onlyJpeg = theme.cards.map((c) => reviewFileName(theme.name, c, jpegProvider));
+    const sheet = planContactSheet(theme, [...PROVIDERS, hatch], deps(onlyJpeg));
+    expect(sheet.missing).toBe(2);
+  });
+
   it("counts cards with no pick — the ones --sync will refuse", () => {
     const unjudged: SheetTheme = { name: "Warriors", cards };
     const sheet = planContactSheet(unjudged, PROVIDERS, deps(allFiles(unjudged)));

--- a/tests/image-provider.test.ts
+++ b/tests/image-provider.test.ts
@@ -7,6 +7,7 @@ import {
 import { fakeProvider, solidPng } from "@/features/pool/providers/fake";
 import { pollinations } from "@/features/pool/providers/pollinations";
 import { cloudflareSdxl } from "@/features/pool/providers/cloudflare-sdxl";
+import { aiHorde } from "@/features/pool/providers/ai-horde";
 import { CARD_SIZE, ProviderRetryable } from "@/features/pool/providers";
 
 /**
@@ -47,6 +48,24 @@ function syntheticJpeg(width: number, height: number): Uint8Array {
   ]);
 }
 
+/**
+ * Smallest byte sequence `readImageSize` will read as a lossy WebP of a given
+ * size: a RIFF/WEBP container holding a VP8 chunk whose frame header carries the
+ * start code and two 14-bit dimensions. Not decodable as a picture.
+ */
+function syntheticWebp(width: number, height: number): Uint8Array {
+  const b = new Uint8Array(32);
+  b.set([0x52, 0x49, 0x46, 0x46], 0); // "RIFF"
+  b.set([0x57, 0x45, 0x42, 0x50], 8); // "WEBP"
+  b.set([0x56, 0x50, 0x38, 0x20], 12); // "VP8 "
+  b.set([0x9d, 0x01, 0x2a], 23); // start code
+  b[26] = width & 0xff;
+  b[27] = (width >> 8) & 0x3f;
+  b[28] = height & 0xff;
+  b[29] = (height >> 8) & 0x3f;
+  return b;
+}
+
 function imageResponse(bytes: Uint8Array): Response {
   return new Response(bytes as unknown as BodyInit, { status: 200 });
 }
@@ -80,6 +99,51 @@ function makeFixtures(
 
 const jpegFixtures = makeFixtures(syntheticJpeg, solidPng);
 const pngFixtures = makeFixtures(solidPng, syntheticJpeg);
+const webpFixtures = makeFixtures(syntheticWebp, solidPng);
+
+/**
+ * AI Horde needs four round-trips where the others need one, so the shared
+ * fixtures cannot simply be the answer to every call (#67: "ONE logical attempt,
+ * however many HTTP round-trips that takes").
+ *
+ * The routing is chosen so the contract still asserts what it means to assert.
+ * A non-200 fixture is returned from the SUBMIT, which is where the retry
+ * taxonomy has to hold — a 429 on submit must be retryable, a 400 must not. A
+ * 200 fixture is carried all the way to the image DOWNLOAD, which is where the
+ * size, format and not-an-image checks belong. Either way the fixture is what
+ * decides the outcome; only the round-trip it lands on differs.
+ */
+function scriptedHorde(respond: () => Response) {
+  return async (input: RequestInfo | URL, _init?: RequestInit): Promise<Response> => {
+    const url = String(input);
+    if (url.includes("/generate/async")) {
+      const fixture = respond();
+      if (!fixture.ok) return fixture;
+      return Response.json({ id: "job-1", kudos: 24 });
+    }
+    if (url.includes("/generate/check/")) {
+      return Response.json({ done: true, faulted: false, is_possible: true, finished: 1 });
+    }
+    if (url.includes("/generate/status/")) {
+      return Response.json({
+        done: true,
+        faulted: false,
+        generations: [
+          {
+            img: "https://r2.example/job-1.webp",
+            seed: "42",
+            // Deliberately NOT the model that was requested — see #64.
+            model: "SomeOtherModel",
+            worker_name: "volunteer-7",
+            state: "ok",
+            censored: false,
+          },
+        ],
+      });
+    }
+    return respond();
+  };
+}
 
 // ── the runs ─────────────────────────────────────────────────────────────────
 
@@ -94,6 +158,7 @@ describe("real adapters", () => {
     process.env.POLLINATIONS_TOKEN = "test-token";
     process.env.CLOUDFLARE_ACCOUNT_ID = "test-account";
     process.env.CLOUDFLARE_API_TOKEN = "test-token";
+    process.env.AIHORDE_API_KEY = "test-key";
   });
   afterEach(() => {
     process.env = { ...saved };
@@ -109,6 +174,12 @@ describe("real adapters", () => {
     "cloudflare-sdxl",
     (respond) => cloudflareSdxl({ fetchImpl: async () => respond() }),
     pngFixtures,
+  );
+
+  runHttpProviderContract(
+    "ai-horde",
+    (respond) => aiHorde({ fetchImpl: scriptedHorde(respond), sleep: async () => {} }),
+    webpFixtures,
   );
 });
 
@@ -221,5 +292,280 @@ describe("cloudflare-sdxl adapter", () => {
     delete process.env.CLOUDFLARE_ACCOUNT_ID;
     process.env.CLOUDFLARE_API_TOKEN = "tok";
     expect(cloudflareSdxl().isConfigured()).toBe(false);
+  });
+});
+
+describe("ai-horde adapter (#74)", () => {
+  const saved = { ...process.env };
+  beforeEach(() => {
+    process.env.AIHORDE_API_KEY = "test-key";
+  });
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  const okWebp = () => imageResponse(syntheticWebp(768, 768));
+
+  /** Run one generation and hand back the body the adapter POSTed to /generate/async. */
+  async function capturedSubmit(): Promise<Record<string, unknown>> {
+    let body: Record<string, unknown> = {};
+    const scripted = scriptedHorde(okWebp);
+    const provider = aiHorde({
+      sleep: async () => {},
+      fetchImpl: async (input, init) => {
+        if (String(input).includes("/generate/async")) {
+          body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        }
+        return scripted(input);
+      },
+    });
+    await provider.generate("a longbowman", CARD_SIZE);
+    return body;
+  }
+
+  it("always names exactly one model — never leaves `models` unset", async () => {
+    // Two separate risks, both measured during #74 and both fatal:
+    //
+    //   Resolution. An unpinned request is capped at
+    //   `1024 + threads*10 - round(queue*0.9)`. Measured mid-run: 15 threads,
+    //   728 queued -> 519px. 768 would have been REFUSED outright, not
+    //   downgraded — this is not a tail risk, it is the normal case.
+    //
+    //   Content. The highest-worker-count image models on the horde are NSFW
+    //   (WAI-NSFW-illustrious-SDXL, Pony Diffusion XL, CyberRealistic Pony), so
+    //   an unpinned request in a kids' app is routed by popularity straight at
+    //   them.
+    const body = await capturedSubmit();
+    expect(Array.isArray(body.models)).toBe(true);
+    expect(body.models).toHaveLength(1);
+    expect((body.models as string[])[0]).toBe(aiHorde().params.model);
+    expect((body.models as string[])[0]).not.toBe("");
+  });
+
+  it("never sets allow_downgrade (#71)", async () => {
+    // Setting it permits a SMALLER image than asked for. That is the precise
+    // failure the model pin exists to prevent, so the adapter must not hold both
+    // ends of the argument. Asserting the key is ABSENT, not false: the horde
+    // reads presence.
+    expect(Object.keys(await capturedSubmit())).not.toContain("allow_downgrade");
+  });
+
+  it("sends #71's routing parameters and asks for an SFW image", async () => {
+    const body = await capturedSubmit();
+    // slow_workers: at 0 kudos the slow volunteers ARE the queue — excluding
+    // them is excluding the horde.
+    expect(body.slow_workers).toBe(true);
+    // replacement_filter: never let the horde silently rewrite the prompt, which
+    // would make the review file's promptHash a lie.
+    expect(body.replacement_filter).toBe(false);
+    expect(body.nsfw).toBe(false);
+  });
+
+  it("asks for exactly one image at exactly the card size", async () => {
+    const body = await capturedSubmit();
+    const params = body.params as Record<string, unknown>;
+    expect(params.width).toBe(CARD_SIZE.width);
+    expect(params.height).toBe(CARD_SIZE.height);
+    expect(params.n).toBe(1);
+  });
+
+  it("builds its request from params and nothing else", async () => {
+    // The port's rule, enforced rather than asserted: "generate() must build its
+    // request from {prompt, size, ...params} and nothing else, so that 'does
+    // this adapter read anything outside params?' is a checkable review
+    // question rather than a hope."
+    //
+    // This walks the request in the OTHER direction — from the wire back to the
+    // declared bag — so a knob added to the body without a matching param fails
+    // here. Checking only the knobs you remembered to list would assert the
+    // title of this test and not its rule; that is how `r2` (which decides the
+    // delivery encoding, and therefore `format`, and therefore the review file's
+    // extension) sat unhashed.
+    const body = await capturedSubmit();
+    const declared = aiHorde().params;
+
+    // Everything the horde is told, flattened. `params` is the nested sampling
+    // bag; the rest are top-level routing fields.
+    const sent: Record<string, unknown> = {
+      ...(body.params as Record<string, unknown>),
+      ...body,
+    };
+    delete sent.params;
+
+    // Not parameters: the prompt and size are generate()'s own arguments, `n` is
+    // fixed by the port (one call, one card), and `models` is the wire's array
+    // spelling of the declared scalar `model`.
+    const notParams = new Set(["prompt", "width", "height", "n", "models"]);
+
+    for (const [key, value] of Object.entries(sent)) {
+      if (notParams.has(key)) continue;
+      expect(declared, `"${key}" is sent to the horde but is not a declared param`).toHaveProperty(
+        key,
+      );
+      // The horde's `seed` is a string on the wire where every other adapter's
+      // is a number. The declared param stays a number so `paramHash` sees the
+      // same shape everywhere; only the encoding differs.
+      expect(String(value), `params.${key}`).toBe(String(declared[key]));
+    }
+    expect(body.models).toEqual([declared.model]);
+  });
+
+  it("hashes the routing parameters, because on this provider they decide the bytes", async () => {
+    // A regression guard with teeth: flipping any of these changes the review
+    // filename, so a reviewed candidate can never be silently re-attributed to a
+    // different request. `r2` is the sharpest case — it swaps WebP for inline
+    // base64 PNG, i.e. it changes `format` and the file's extension.
+    const declared = aiHorde().params;
+    for (const key of [
+      "replacement_filter",
+      "nsfw",
+      "slow_workers",
+      "r2",
+      "shared",
+      "trusted_workers",
+    ]) {
+      expect(declared, `${key} must be hashed`).toHaveProperty(key);
+    }
+  });
+
+  it("reports the model the WORKER named, not the one it requested (#64)", async () => {
+    const provider = aiHorde({ fetchImpl: scriptedHorde(okWebp), sleep: async () => {} });
+    const image = await provider.generate("x", CARD_SIZE);
+    expect(image.model).toBe("SomeOtherModel");
+    expect(image.model).not.toBe(provider.params.model);
+  });
+
+  it("polls until the job is done rather than returning the first check (#67)", async () => {
+    // One generate() call is ONE logical attempt however many round-trips it
+    // takes. If the adapter gave up at the first not-done check, every real
+    // generation would fail — nothing at the back of a 350-deep queue is ready
+    // on the first poll.
+    let checks = 0;
+    const scripted = scriptedHorde(okWebp);
+    const provider = aiHorde({
+      sleep: async () => {},
+      fetchImpl: async (input, init) => {
+        if (String(input).includes("/generate/check/")) {
+          checks++;
+          if (checks < 3) {
+            return Response.json({ done: false, faulted: false, is_possible: true, finished: 0 });
+          }
+        }
+        return scripted(input, init);
+      },
+    });
+    const image = await provider.generate("x", CARD_SIZE);
+    expect(checks).toBe(3);
+    expect(image.bytes.byteLength).toBeGreaterThan(0);
+  });
+
+  it("treats a worker's censorship as retryable, not as a drawing (#71)", async () => {
+    // Per-worker censorship returns a BLACK FRAME rather than a refusal. #71
+    // accepted that risk on the grounds it fails visibly into review — but a
+    // black frame saved to seed/review/ is not visible, it is a card that looks
+    // like the model drew nothing. It is also one volunteer's filter, not a
+    // verdict on the prompt, so another worker is a real remedy: retryable.
+    const provider = aiHorde({
+      sleep: async () => {},
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes("/generate/async")) return Response.json({ id: "job-1" });
+        if (url.includes("/generate/check/")) {
+          return Response.json({ done: true, faulted: false, is_possible: true });
+        }
+        if (url.includes("/generate/status/")) {
+          return Response.json({
+            done: true,
+            generations: [{ img: "https://r2.example/x.webp", model: "m", censored: true }],
+          });
+        }
+        return okWebp();
+      },
+    });
+    const err = await provider.generate("x", CARD_SIZE).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ProviderRetryable);
+    expect(String(err)).toMatch(/censor/i);
+  });
+
+  it("fails a faulted job instead of polling it to the deadline", async () => {
+    const provider = aiHorde({
+      sleep: async () => {},
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes("/generate/async")) return Response.json({ id: "job-1" });
+        return Response.json({ done: false, faulted: true, is_possible: true });
+      },
+    });
+    await expect(provider.generate("x", CARD_SIZE)).rejects.toThrow(/fault/i);
+  });
+
+  it("gives up when no worker can serve the request", async () => {
+    // `is_possible: false` means nothing online can satisfy it — which is what a
+    // model going offline looks like. Volunteer infrastructure: the set moves.
+    const provider = aiHorde({
+      sleep: async () => {},
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes("/generate/async")) return Response.json({ id: "job-1" });
+        return Response.json({ done: false, faulted: false, is_possible: false });
+      },
+    });
+    await expect(provider.generate("x", CARD_SIZE)).rejects.toThrow(/no worker/i);
+  });
+
+  it("treats a 404 from /check as the horde dropping the job, and retries", async () => {
+    // Measured on #74's second run: 27 of 46 images were lost this way. A job
+    // that goes stale does NOT time out — the horde forgets it and /check
+    // answers 404 while the job is still advancing in the queue. Left as a bare
+    // HTTP error this is non-retryable (4xx), so the runner's circuit breaker
+    // counts three of them and abandons the lane, reporting a dead provider for
+    // what is really an empty wallet.
+    const provider = aiHorde({
+      sleep: async () => {},
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes("/generate/async")) return Response.json({ id: "job-1" });
+        return new Response(null, { status: 404 });
+      },
+    });
+    const err = await provider.generate("x", CARD_SIZE).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ProviderRetryable);
+    expect(String(err)).toMatch(/dropped|stale/i);
+  });
+
+  it("gives up after the deadline rather than polling forever", async () => {
+    // Requests expire uncollected at the back of the queue. #74 measured a
+    // queue position of 352 and a ~2850s wait at 0 kudos, so this is the
+    // ordinary case, not an edge one — and resubmitting is exactly the remedy.
+    const provider = aiHorde({
+      sleep: async () => {},
+      pollTimeoutMs: 0,
+      fetchImpl: async (input) => {
+        const url = String(input);
+        if (url.includes("/generate/async")) return Response.json({ id: "job-1" });
+        return Response.json({ done: false, faulted: false, is_possible: true });
+      },
+    });
+    const err = await provider.generate("x", CARD_SIZE).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(ProviderRetryable);
+  });
+
+  it("is an escape hatch, not a bake-off lane (#71)", () => {
+    expect(aiHorde().role).toBe("escape-hatch");
+  });
+
+  it("paces for a limit that is per-IP across the whole API, not per-endpoint", () => {
+    // Measured on #74's first run: the horde answers 429 {"message":"2 per 1
+    // second"} and three lanes fanning out lost 7 of 12 submissions in the first
+    // second. One request in flight at a time is the only honest way to declare
+    // that through a seam whose gate is per-lane.
+    expect(aiHorde().minIntervalMs).toBeGreaterThanOrEqual(500);
+    expect(aiHorde().concurrency).toBe(1);
+  });
+
+  it("needs its key", () => {
+    delete process.env.AIHORDE_API_KEY;
+    expect(aiHorde().isConfigured()).toBe(false);
+    expect(aiHorde().requiredEnv).toContain("AIHORDE_API_KEY");
   });
 });

--- a/tests/review-files.test.ts
+++ b/tests/review-files.test.ts
@@ -236,16 +236,33 @@ describe("the registry (#67)", () => {
     expect(LANES.length).toBeLessThanOrEqual(PROVIDERS.length);
   });
 
-  it("does not yet register AI Horde — #71 keyed it, #74 picks its model", () => {
+  it("registers AI Horde as an escape hatch with a pinned model (#74)", () => {
     // #71 settled the hatch's role and its request parameters but left the model
-    // to #74, and an unpinned model would make 768x768 a coin-flip against live
-    // queue depth — and would name review files after a request never made.
-    expect(PROVIDER_IDS).not.toContain("ai-horde");
+    // to #74, because an unpinned model makes 768x768 a coin-flip against live
+    // queue depth — measured at 456-529px during #74's run, where a 768 request
+    // is refused outright — and would name review files after a request never
+    // made. With the model pinned, the hatch can register.
+    expect(PROVIDER_IDS).toContain("ai-horde");
+    const horde = providerById("ai-horde")!;
+    expect(horde.role).toBe("escape-hatch");
+    expect(horde.params.model).toBeTruthy();
+    // Never in the default fan-out — reachable only by name (#71).
+    expect(LANES.map((p) => p.id)).not.toContain("ai-horde");
   });
 
-  it("selects every lane when --providers is absent", () => {
+  it("reaches the escape hatch when it is named, and only then (#71)", () => {
     configureAll();
-    expect(selectLanes().map((p) => p.id)).toEqual([...PROVIDER_IDS]);
+    process.env.AIHORDE_API_KEY = "k";
+    expect(selectLanes(["ai-horde"]).map((p) => p.id)).toEqual(["ai-horde"]);
+  });
+
+  it("selects every lane when --providers is absent — and no hatch", () => {
+    // Compared against LANES rather than PROVIDER_IDS. The two were the same set
+    // while the registry held only lanes; #74 registered the first escape hatch,
+    // and the whole point of the role is that they now differ.
+    configureAll();
+    expect(selectLanes().map((p) => p.id)).toEqual(LANES.map((p) => p.id));
+    expect(LANES.length).toBeLessThan(PROVIDER_IDS.length);
   });
 
   it("narrows deliberately when --providers names a subset", () => {


### PR DESCRIPTION
Two tickets off map #61, on top of the seam PR #76 landed.

## #74 — pin AI Horde's model, land the escape hatch

#71 keyed AI Horde as an escape hatch but left two loose ends: nobody had picked its model, and nothing
proved the hatch draws the hard subjects. #74 offered the opposite outcome explicitly — if it drew them no
better than Cloudflare, the honest answer was to drop the provider entirely.

**It earns its keep.** Pinned to `AlbedoBase XL (SDXL)`, judged by a human from a subject x model contact
sheet:

- **Longbowman** (identity in a small held object) — the class *both lanes fail*. Cloudflare returned 0 of 3
  usable, every sample duplicating the bow and baking in a frame border. The hatch returned a clean single
  bow, single arrow, no frame: the first usable Longbowman this project has had.
- **Egyptian Charioteer** (multi-object) — the best result seen for the class. Still miscounts the horses.
- **Swiss Guard** (niche uniform) — *not* solved: costume correct but rendered photo-real, so it loses
  `ART_STYLE`. Both providers fail this class, differently.
- Per-worker censorship, #71's accepted risk, fired **zero** times — including on the weapon-bearing subject.

The model is pinned in code rather than `AIHORDE_MODEL`, following the registry's own rule: the environment
carries secrets, and anything that changes the bytes must be diffable. Twice load-bearing here — `params` is
hashed into the review filename, and on this provider a mistyped name is not a 404 but a *different* model,
with the horde's most-served ones being NSFW (`AlbedoBase XL 3.1` is one character away and flagged nsfw).

Also in this commit: the submit/poll/collect loop lives inside `generate()` so the runner never learns one
provider is asynchronous; pacing declared at one request in flight, 1.2s apart, because the horde's rate
limit is **per-IP across the whole API** and counts polls; a censored generation (a black frame, not a
refusal) is now a named retryable error rather than a candidate; and `pollTimeoutMs` is an hour, because the
horde expires a job nobody *checks*, so a client-side deadline is pure self-inflicted loss.

## #70 — rewrite the runbook for the bake-off pipeline

The runbook is agent-facing: an agent is handed it and drives a whole theme into the production pool. One
describing the old single-provider flow is not stale documentation, it is wrong instructions executed
against the children's database.

- **Step 4's "what the image model can and cannot draw" is now per provider.** There is no "the image
  model" any more. Niche uniforms and multi-object scenes are no longer disqualifying (Cloudflare draws
  both, #66); small held objects still are on both lanes, and that is the hatch's one win. This relaxes a
  Step 3 subject constraint — it changes which themes are viable at all.
- **Reproducibility is stated per lane.** #64's Pollinations measurement is preserved; #66 measured
  Cloudflare returning different bytes for the same pinned seed, so the revert-the-prompt lever is false
  there and saying so unconditionally would have an agent chase a picture that cannot come back.
- **The 429 paragraph became a per-provider ceiling table** — the old advice was Pollinations' anonymous
  tier generalised to everyone.
- **Step 6 screens N candidates and forms a recommendation**, with a lever table teaching the distinction
  the re-prompt cap depends on: a bake-off fixes the wrong model, re-prompting fixes the wrong words. Adds
  #78's blank frame, which the seam currently accepts as a valid candidate, and the horde's `CorruptPrompt`
  IP timeout (3 -> 9 -> 15 -> 21 minutes) so nobody retries into it.
- **Recording the pick is its own step**, after checkpoint 2, because the pick is the human's answer to it.
  Publish then states the fail-safe positively: a theme with no pick publishes nothing, by construction.
- **Hard stops** gain the three refusals `--sync` can actually print; **Never** gains the ways to fake a
  selection — renaming a review file, deleting a rival candidate, or switching off the horde's
  `replacement_filter` to get a blocked prompt through.

The "exactly two checkpoints" contract is restated rather than extended: the bake-off did not add a third,
it changed what the second one *is*, from approve/reject to choose-among-N.

## Verification

`pnpm typecheck` clean; `pnpm test` 510/510 across 63 files. The #74 evidence prototype is kept as a
throwaway under `scripts/prototype-74-aihorde/`, per the same convention #66 used.

Closes #74
Closes #70
