### PR TITLE
Allow a theme to mix providers, under an illustration rule (#77)

### DIFF
--- a/seed/NEW-THEME-RUNBOOK.md
+++ b/seed/NEW-THEME-RUNBOOK.md
@@ -276,6 +276,11 @@ Rule out a candidate on:
   words are gone and the rate fell to ~1 in 20, so a frame is now rare rather than expected. If you see one,
   it is a re-roll, **not** a re-prompt — and do not try to word your way out of it by asking for "no border",
   which #81 measured as no better than saying nothing.
+- **A photograph or a 3D render**, whichever lane drew it (#77). The published set varies enormously in
+  style, but it is always an *illustration*, so photoreal skin, camera depth-of-field blur, a naturalistic
+  cast shadow, or the look of a glazed figurine on a surface reads as a different product sitting in the
+  binder. This is the one style question settled on sight; **every other one is a pick, not a rejection.**
+  It bites the Pollinations lane hardest — `sana` leans semi-real, per the table in Step 4.
 - **A blank frame.** Cloudflare can return a *pure black* 768×768 PNG for a perfectly innocuous prompt —
   ~40% of attempts on one measured prompt. It is a valid PNG at exactly the right size, so the seam accepts
   it and it lands looking like a real candidate; the tell is file size, ~2 KB against a normal 750–900 KB.
@@ -285,6 +290,26 @@ Rule out a candidate on:
 Then, for each row, write down one of three outcomes: **a recommended provider with a one-line reason**,
 **a genuine tie** (say so — the human may have a taste preference), or **nothing usable**. Only the third
 one leads to more generation.
+
+### May one theme mix providers?
+
+Yes, and you do not need to ask. **Pick the best-drawn candidate for each card, from whichever lane drew
+it** (#77).
+
+Pick on what Step 4's per-provider table predicts — one lane draws a subject class the other cannot.
+"This candidate draws the longbow as one bow" is a reason; "this lane is my favourite" is not.
+
+Mixing costs less than it sounds like it should, because the published binder has never been uniform.
+`Animals` — one theme, one provider, one run, live in children's hands — carries a flat graphic tiger, a
+painterly red panda and a soft watercolour axolotl. The two lanes *do* differ, and visibly: Cloudflare is
+flat and outlined where Pollinations is semi-real and painterly. That gap is real, and it is no wider
+than the gap already sitting inside a single published theme.
+
+Do not keep a lane for **continuity**, either. Pollinations drew the published cards but no longer draws
+in the style that drew them (#64), so picking it buys nothing back. That is about which candidate you
+pick, not about which lanes run — the lane roster is #69's, and unchanged.
+
+Legendaries get no special rule. If two of them tie, say so at the checkpoint; do not settle it yourself.
 
 ### Which lever: pick another provider, or change the words?
 
@@ -396,7 +421,8 @@ The human has chosen; write it down. This is the one step with no counterpart in
 pipeline, and it is what stands between a reviewed image and a published one.
 
 In `seed/cards.json`, set **`provider` on the theme** to whichever provider won most rows, and add
-`provider` to **individual cards only where a different one won** — a sparse override list, not 30 repeats:
+`provider` to **individual cards only where a different one won** — a sparse override list, not 30 repeats.
+A theme carrying several lanes is normal (#77):
 
 Add one key to the theme object, and one key to each overridden card. Everything else in the file is left
 exactly as it is — no other field is touched by this step:

--- a/seed/NEW-THEME-RUNBOOK.md
+++ b/seed/NEW-THEME-RUNBOOK.md
@@ -126,7 +126,10 @@ added at Step 6, on the theme and — sparsely — on individual cards.
 - **`imagePrompt`** — concrete, kid-friendly, **no art-style words**: `buildPrompt()` appends `ART_STYLE`
   for you. What works across every provider: name **one** subject ("a single …"), give a viewpoint ("side
   view"), put it somewhere plain ("parked on grass"). Sleek aircraft photographed in flight are the shape
-  most often rendered as two overlapping copies.
+  most often rendered as two overlapping copies. Name **no object the picture sits inside** — card,
+  frame, border, poster, sticker, mat. Cloudflare's SDXL draws those literally and insets the real subject
+  within them; that was #81, and it came from `ART_STYLE` saying "trading-card" rather than from any
+  card's own wording.
 
 ### What the providers can and cannot draw
 
@@ -140,7 +143,7 @@ ran them through the escape hatch. What survives is narrower than the old blanke
 
 | Failure class | `pollinations` (asks for `flux`, served by `sana` — #64) | `cloudflare-sdxl` | `ai-horde` (escape hatch) |
 |---|---|---|---|
-| Identity rests on a **small held object** — bow, spear, tool | **fails** — the object goes wire-thin, smears, or duplicates | **fails** — right style, still draws two bows, and has baked a decorative frame border in | **the one it fixes** — #74's single bow, single arrow, no frame: the first usable Longbowman this project has had |
+| Identity rests on a **small held object** — bow, spear, tool | **fails** — the object goes wire-thin, smears, or duplicates | **fails** — right style, still draws two bows | **the one it fixes** — #74's single bow, single arrow: the first usable Longbowman this project has had |
 | Identity rests on **niche uniform accuracy** | **fails** — a plausible costume from the wrong century or country, or a photoreal toddler in fancy dress | **usually passes** — #66 drew the Swiss Guard's blue/yellow stripes and ruff correctly; #74 saw a generic modern uniform on a different sample, so treat it as *much better, not reliable* | **fails differently** — costume correct, but rendered photo-real, which loses `ART_STYLE` |
 | **Multi-object scene** — a rider and a vehicle, a crowd | **fails** — the parts recombine into something else (a Victorian pony-trap for an Egyptian chariot; one figurine for the Terracotta Army) | **passes** — two horses, gold chariot, nemes headdress; rows of clay soldiers in a trench | **best seen for the class**, but miscounts (one horse where the prompt says two) |
 
@@ -267,8 +270,12 @@ Rule out a candidate on:
 - Gore, damage, fire, combat, casualties — anything from the prohibited list above.
 - Scary rather than friendly.
 - Wrong subject, or unreadable mush.
-- Text baked into the image, or a decorative frame border (`ART_STYLE` asks for neither; the models
-  sometimes disagree — Cloudflare in particular has drawn frames).
+- Text baked into the image, or a decorative frame border. Cloudflare drew frames on roughly a third of
+  candidates until **#81** found the cause in `ART_STYLE` itself — it used to say "trading-**card**
+  illustration", and SDXL drew the card: a wooden frame or a tan mat with the subject inset inside it. The
+  words are gone and the rate fell to ~1 in 20, so a frame is now rare rather than expected. If you see one,
+  it is a re-roll, **not** a re-prompt — and do not try to word your way out of it by asking for "no border",
+  which #81 measured as no better than saying nothing.
 - **A blank frame.** Cloudflare can return a *pure black* 768×768 PNG for a perfectly innocuous prompt —
   ~40% of attempts on one measured prompt. It is a valid PNG at exactly the right size, so the seam accepts
   it and it lands looking like a real candidate; the tell is file size, ~2 KB against a normal 750–900 KB.

--- a/src/features/pool/prompt.ts
+++ b/src/features/pool/prompt.ts
@@ -1,8 +1,58 @@
 import type { SeedCard } from "./seed-schema";
 
-/** Kid-friendly art style appended to every image prompt (U3-BR5). */
+/**
+ * Kid-friendly art style appended to every image prompt (U3-BR5).
+ *
+ * ── Why this no longer says "trading-card" (#81) ─────────────────────────────
+ * It used to read "cartoon TRADING-CARD illustration". That phrase describes the
+ * artefact the picture ends up inside, not the picture — and `cloudflare-sdxl`
+ * drew the artefact: a wooden picture frame, a tan mat with a gold rule, a
+ * rounded green panel, with the card's actual subject inset within it. The
+ * binder renders every card at a fixed size, so a framed card is inset relative
+ * to an unframed one and a theme drawn from mixed lanes stops looking uniform.
+ *
+ * Measured on 20 paired samples (4 subjects x 5 seeds), by eye and by a border
+ * detector that agreed with it:
+ *
+ *   this style, with "trading-card"        7 / 20 framed
+ *   + `negative_prompt` on the adapter     5 / 20   — no effect
+ *   + "full-bleed edge-to-edge, no border" 6 / 20   — no effect
+ *   without "trading-card"                 1 / 20   — and that one is a flat
+ *                                                     colour margin, not a frame
+ *
+ * Two things that did NOT work are worth as much as the one that did, because
+ * both are the obvious next idea:
+ *
+ *   - Naming the border in order to forbid it makes no difference. SDXL weights
+ *     the noun and drops the negation, so "no border" is a border cue. The fix
+ *     is to stop mentioning the object at all, not to argue with it.
+ *   - `negative_prompt` on the Cloudflare adapter is no better than saying
+ *     nothing, so no such param exists. That is deliberate: `params` is hashed
+ *     into every review filename (`providers/provider.ts`), and a parameter that
+ *     buys nothing would invalidate a folder of reviewed images for free.
+ *
+ * The seed is NOT the lever either. #66 and #74 found this lane non-deterministic
+ * despite `seed: 42` being pinned, and #81 confirms it: the same request framed
+ * on one run and not on the next. Frames varied freely across five seeds in both
+ * arms, so there is no lucky seed to pick.
+ *
+ * ── What this costs, and why it is affordable ────────────────────────────────
+ * `promptHash` (keys.ts, D4) covers this string, so editing it invalidates every
+ * review file — by design, and the reason the change lands as one edit rather
+ * than drifting in. It does NOT touch the ~360 published cards: `planInserts`
+ * only ever plans cards absent from the database, so a published card is never
+ * re-generated and never re-audited. The map rules re-rendering them out of
+ * scope, and this respects that.
+ *
+ * Nor does it shift the incumbent lane's look, which is the thing the binder's
+ * coherence actually rests on. Pollinations serves `sana` (#64), and #81 drew
+ * all four subjects through both styles there: same painterly semi-realism, same
+ * compositions, same failure modes. `sana` never drew the frame and never read
+ * the phrase. Every one of the ~360 published cards came from that lane, so the
+ * cards this change alters are the ones that were diverging anyway.
+ */
 export const ART_STYLE =
-  "vibrant kid-friendly cartoon trading-card illustration, bright colors, " +
+  "vibrant kid-friendly cartoon illustration, bright colors, " +
   "friendly, clean background, no text";
 
 /** Build the full Pollinations prompt for a card (pure). */

--- a/src/features/pool/providers/cloudflare-sdxl.ts
+++ b/src/features/pool/providers/cloudflare-sdxl.ts
@@ -24,6 +24,16 @@
  * rather than rate-bound and this lane is the fast one. The nominal 8ms floor is
  * pointless in practice; 100ms keeps a burst polite without being a constraint.
  *
+ * ── The frame this lane used to draw, and why the fix is not here (#81) ──────
+ * This adapter was where a decorative frame border — a wooden picture frame, a
+ * tan mat with a gold rule — got baked into roughly a third of its candidates.
+ * It reads like an adapter problem and is not: the cause was the words
+ * "trading-card" in `ART_STYLE` (`../prompt.ts`), which SDXL drew literally
+ * while Pollinations' `sana` ignored them. The fix is that edit, not a parameter
+ * here. #81 measured `negative_prompt` at 5/20 against a 7/20 baseline, so it
+ * buys nothing — and every entry in `params` is hashed into review filenames, so
+ * a parameter that buys nothing still costs a folder of reviewed images.
+ *
  * ── Provenance ───────────────────────────────────────────────────────────────
  * Cloudflare reports no serving-model header, so `model` comes back undefined
  * and the sidecar records only what was requested. That is an honest gap, and

--- a/tests/pool.test.ts
+++ b/tests/pool.test.ts
@@ -98,6 +98,32 @@ describe("buildPrompt (U3-BR5)", () => {
     expect(p).toContain("a panda");
     expect(p).toContain(ART_STYLE);
   });
+
+  /**
+   * #81 — ART_STYLE must not name a physical card, frame or border.
+   *
+   * The style string used to read "cartoon TRADING-CARD illustration", and
+   * `cloudflare-sdxl` drew that literally: a wooden picture frame, a tan mat
+   * with a gold rule, a rounded panel, with the subject inset inside it. #81
+   * measured 7/20 framed against 1/20 once the words came out, and the residual
+   * one is a flat colour margin rather than a decorative frame.
+   *
+   * This is a REGRESSION GUARD, not a restatement of the constant. The removed
+   * words are the natural way to describe what these images are for, so the
+   * likeliest future edit — someone making the style read better, or adding a
+   * card-ish word to another lane's prompt — is exactly the one that brings the
+   * frames back. It would be invisible: a framed card is a valid 768x768 PNG,
+   * so `finishGeneration` passes it and only a human at checkpoint 2 sees it.
+   *
+   * Naming the border to forbid it does NOT work and must not be the fix — #81
+   * measured "full-bleed edge-to-edge artwork, no border" appended to the style
+   * at 6/20, no better than saying nothing. Diffusion models weight the noun,
+   * not the negation. Neither does `negative_prompt` on the Cloudflare adapter
+   * (5/20 against a 7/20 baseline), which is why no such param was added.
+   */
+  it("names no physical card, frame or border — the words SDXL drew literally (#81)", () => {
+    expect(ART_STYLE).not.toMatch(/trading[ -]?card|\bcard\b|\bframe|\bborder|\bmat(te)?\b/i);
+  });
 });
 
 // generateImage retry moved out with the provider seam (#67): retry, backoff and


### PR DESCRIPTION
Closes #77.

Documentation only — `seed/NEW-THEME-RUNBOOK.md`, +27/-1. No code, no behaviour change.

## The question, and why it dissolved

#77 asked whether a binder page showing two models' work side by side is
acceptable, and noted that the cheap thing to check first — whether the two
lanes land closer than feared — *"may dissolve the whole question"*.

It does, by falsifying the premise. **The binder has never been uniform.**
`Animals` — one theme, one provider, one run, live in children's hands —
carries a flat graphic tiger, a painterly red panda and a soft watercolour
axolotl. Style drifts across published themes too, same provider throughout,
which is #64's silent model swapping showing up in the binder.

So the variation axis is **time and wording, not provider**. A
one-provider-per-theme rule would protect a consistency that was never there,
while costing quality on cards another lane plainly drew better.

The two lanes *do* differ visibly — Cloudflare flat and outlined, Pollinations
semi-real and painterly, which is what #66 recorded. That gap is real. It is
also no wider than the gap already inside one published theme.

## The rule

**Pick the best-drawn candidate per card, from whichever lane drew it**, on the
grounds Step 4's per-provider table predicts rather than on taste. The per-card
`provider` override stays — it is the mechanism, not a loaded gun.

**One style question is settled on sight, and only one:** a photograph or a 3D
render is out, whichever lane drew it. That is the single property every
published card shares — they are illustrations, however wildly they vary. It
bites the Pollinations lane hardest now that `sana` leans semi-real. Every
other style question stays a *pick*, which keeps this consistent with the
existing "Which lever" table rather than overriding it.

## Deliberately not done

- **The lane roster is unchanged.** "Do not keep a lane for continuity" is
  about which candidate you pick; which lanes run is #69's call.
- **Legendaries get no special rule.** A tie there is escalated at the
  checkpoint like any other — the runbook's standing rule is never to answer a
  checkpoint on the human's behalf.

## Retracted while writing this

An earlier draft cited the vignette borders on published cards as evidence that
frames are an accepted part of the binder. #81 landed the real cause —
`ART_STYLE` used to say "trading-**card** illustration", so the models drew the
card — so those borders are a fixed defect, not acceptable variation. Removed
from the argument; the style-drift evidence stands on its own.

## Verification

`pnpm typecheck` clean, `pnpm vitest run` 511 passing. Reviewed on both the
standards and spec axes; findings applied (section halved in length, a
self-answering heading fixed, an overclaimed re-attribution of Warriors'
3-of-28 dropped, and a legendary tie-break removed for contradicting the
never-answer-a-checkpoint rule).