### PR TITLE
Correct what #81 measured, and keep the harness that measured it

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "seed": "tsx --env-file-if-exists=.env.local scripts/seed/index.ts",
     "contact-sheet": "tsx --env-file-if-exists=.env.local scripts/contact-sheet/index.ts",
     "reconcile": "tsx --env-file-if-exists=.env.local scripts/reconcile/index.ts",
-    "prototype:74": "tsx --env-file-if-exists=.env.local scripts/prototype-74-aihorde/index.ts"
+    "prototype:74": "tsx --env-file-if-exists=.env.local scripts/prototype-74-aihorde/index.ts",
+    "prototype:81": "tsx --env-file-if-exists=.env.local scripts/prototype-81-frames/index.ts"
   },
   "dependencies": {
     "@neondatabase/serverless": "^0.10.4",

--- a/scripts/prototype-81-frames/index.ts
+++ b/scripts/prototype-81-frames/index.ts
@@ -1,0 +1,303 @@
+/**
+ * PROTOTYPE — #81. Throwaway. Do not import this from anything.
+ *
+ * The question: `cloudflare-sdxl` bakes a decorative frame border into most
+ * cards — a wooden picture frame, a tan mat with a gold rule, a rounded panel,
+ * with the card's subject inset inside it. #81 listed three leads and asked
+ * which, if any, suppresses it: the pinned seed, a negative prompt, and whether
+ * Pollinations does the same.
+ *
+ * It answers all three and finds the cause somewhere none of them pointed:
+ * `ART_STYLE` said "trading-CARD illustration", and SDXL drew the card.
+ *
+ * ── Why this is measured rather than eyeballed ───────────────────────────────
+ * A frame is invisible to every automated check the seam has — the bytes are a
+ * valid 768x768 PNG, so `finishGeneration` passes them, and it only shows up to
+ * a human at checkpoint 2. That makes eyeballing the only available instrument,
+ * and eyeballing a contact sheet is exactly where a small sample misleads: the
+ * first pass here read a 6-of-8 rate from #74's images, and #74 in turn had read
+ * "Warhorse 3/3 framed" from three. Both are true and neither generalises, since
+ * this lane is non-deterministic despite `seed: 42` being pinned (#66, #74) — the
+ * same request frames on one run and not the next.
+ *
+ * So: 20 samples per arm, 4 subjects x 5 seeds, PAIRED on seed so each treated
+ * sample has a same-seed control. And `--score` re-judges the same images
+ * mechanically (a uniform band along all four edges), because a second
+ * instrument that agrees is worth more than a bigger sample from the first one.
+ * It under-counts ornate frames, whose borders are too textured to read as a
+ * flat band — but it under-counts every arm equally, so the ranking holds.
+ *
+ * ── What it found ───────────────────────────────────────────────────────────
+ * Framed, by eye and by the detector on the same images. `src/features/pool/
+ * prompt.ts` holds the canonical table and the reasoning; this is the run that
+ * produced it:
+ *
+ *                                          by eye    detector
+ *                                          (1 run)   (2 runs)
+ *   ART_STYLE as-is                        11 / 20    13 / 40
+ *   + negative_prompt on the adapter        8 / 20     7 / 40
+ *   + "full-bleed edge-to-edge, no border" 10 / 20    10 / 40
+ *   without "trading-card"                  1 / 20     2 / 40
+ *   #74's cloudflare images, as filed            -     5 / 12
+ *   #74's pollinations images (control)     0 / 12     0 / 12
+ *
+ * Run it twice before believing any of it. The first run of 20 read
+ * `negative_prompt` as inert; the replication showed it roughly halving the
+ * rate — still not the fix, but not nothing, and a conclusion that flipped on a
+ * second sample of the same size.
+ *
+ * The `notext` arm answers a question the fix invites rather than one #81 asked:
+ * "no text" is the same shape as "no border", so is it a cue too? Text appeared
+ * once in 20 with the phrase and never in 20 without — no detectable effect at
+ * this sample size, so it stays. The asymmetry is about the noun: a trading card
+ * is depictable and "text" is not.
+ *
+ * The two failures earn their place: both are the obvious next idea. Naming the
+ * border in order to forbid it is a border CUE, because the model weights the
+ * noun and drops the negation. And `negative_prompt` buys nothing while every
+ * entry in `params` is hashed into review filenames, so adding one would
+ * invalidate a folder of reviewed images for free.
+ *
+ * The Pollinations arm is what made the fix affordable rather than merely
+ * correct: `sana` draws all four subjects the same either way — same painterly
+ * semi-realism, same compositions, same failure modes — and never drew a frame.
+ * It never read the phrase. Since every one of the ~360 published cards came
+ * from that lane, editing a globally-shared prompt constant costs the binder's
+ * coherence nothing.
+ *
+ * ── Why the detector is not in here ─────────────────────────────────────────
+ * It needed a decoder to reach pixels, and the only one in the tree is `sharp`.
+ * `pnpm-workspace.yaml` pins that on the express grounds that "sharp is invoked
+ * by `next` alone and never by this repo's own code", which is what makes a 0.x
+ * MINOR override safe there — `next build` exercises its whole surface. A
+ * prototype importing it would quietly retire that argument, for a
+ * cross-check that under-reads every arm anyway. So the committed harness emits
+ * the same thing #74's did: a contact sheet a human reads. The by-eye column is
+ * the canonical one regardless, and it is the more severe of the two.
+ *
+ *   pnpm prototype:81            run every arm; resumes, so an interrupt is cheap
+ *   pnpm prototype:81 --sheet    rebuild the contact sheet from disk, generate nothing
+ *
+ * Output (gitignored scratch): seed/review/prototype-81/
+ */
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { CARD_SIZE } from "@/features/pool/providers";
+
+const OUT_DIR = join(process.cwd(), "seed", "review", "prototype-81");
+const CF_MODEL = "@cf/stabilityai/stable-diffusion-xl-base-1.0";
+
+/**
+ * The style strings under test.
+ *
+ * `current` is what `ART_STYLE` said when #81 was filed, kept verbatim rather
+ * than imported: this script has to be able to reproduce the FRAMED arm after
+ * the constant is fixed, and an import would silently retire the control.
+ */
+const STYLES = {
+  current:
+    "vibrant kid-friendly cartoon trading-card illustration, bright colors, " +
+    "friendly, clean background, no text",
+  nocard:
+    "vibrant kid-friendly cartoon illustration, bright colors, " +
+    "friendly, clean background, no text",
+  fullbleed:
+    "vibrant kid-friendly cartoon trading-card illustration, bright colors, " +
+    "friendly, clean background, no text, full-bleed edge-to-edge artwork, no border",
+  /** The fix, with "no text" also removed — see the notext arm in the header. */
+  notext: "vibrant kid-friendly cartoon illustration, bright colors, friendly, clean background",
+} as const;
+
+/** Tried as `negative_prompt`, and measured to do nothing. Kept so that is checkable. */
+const NEGATIVE =
+  "frame, border, picture frame, framed, matte, mat board, vignette, " +
+  "ornate border, rounded corners, inset panel, text, watermark, signature";
+
+/**
+ * #74's three hard subjects plus its control, with the prompts that actually
+ * shipped in `seed/cards.json`. Warhorse is the load-bearing one: it dodges all
+ * three of the runbook's failure classes, so a frame on it cannot be blamed on a
+ * difficult subject. It framed 5/5 in the baseline arm.
+ */
+const SUBJECTS = [
+  {
+    slug: "warhorse",
+    prompt: "a friendly brown horse wearing a red and gold cloth blanket standing on green grass",
+  },
+  {
+    slug: "longbowman",
+    prompt:
+      "a tall wooden longbow held upright by a cheerful medieval archer in a green tunic on green grass",
+  },
+  {
+    slug: "swiss-guard",
+    prompt:
+      "a cheerful young guard in a puffy blue and yellow striped renaissance costume with a white ruff collar and a black beret on grey cobblestones",
+  },
+  {
+    slug: "charioteer",
+    prompt:
+      "two brown horses pulling a small golden two-wheeled chariot with a smiling egyptian driver holding the reins, on sand",
+  },
+] as const;
+
+/**
+ * Five seeds, not one. The adapter pins 42, and the point of varying it is to
+ * retire #81's own first lead: if the frame tracked the seed there would be a
+ * lucky one to pick. It does not — frames appear and vanish at every seed,
+ * including repeats of 42.
+ */
+const SEEDS = [42, 7, 123, 2024, 999] as const;
+
+interface Arm {
+  key: string;
+  style: keyof typeof STYLES;
+  negative: boolean;
+}
+
+const ARMS: readonly Arm[] = [
+  { key: "base", style: "current", negative: false },
+  { key: "neg", style: "current", negative: true },
+  { key: "nocard", style: "nocard", negative: false },
+  { key: "fullbleed", style: "fullbleed", negative: false },
+  { key: "notext", style: "notext", negative: false },
+];
+
+function fileFor(subject: string, seed: number, arm: string): string {
+  return join(OUT_DIR, `${subject}--seed${seed}--${arm}.png`);
+}
+
+async function generate(subject: string, prompt: string, seed: number, arm: Arm): Promise<void> {
+  const file = fileFor(subject, seed, arm.key);
+  if (existsSync(file)) return;
+
+  const body: Record<string, unknown> = {
+    prompt: `${prompt}, ${STYLES[arm.style]}`,
+    width: CARD_SIZE.width,
+    height: CARD_SIZE.height,
+    // The adapter's pinned bag, reproduced. Only what this run varies varies.
+    num_steps: 20,
+    guidance: 7.5,
+    seed,
+  };
+  if (arm.negative) body.negative_prompt = NEGATIVE;
+
+  const account = process.env.CLOUDFLARE_ACCOUNT_ID ?? "";
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${account}/ai/run/${CF_MODEL}`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN ?? ""}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+  if (!res.ok) {
+    console.log(`FAIL  ${subject} seed${seed} ${arm.key} — HTTP ${res.status}`);
+    return;
+  }
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  writeFileSync(file, bytes);
+  console.log(`ok    ${subject} seed${seed} ${arm.key.padEnd(9)} ${bytes.byteLength}B`);
+}
+
+/**
+ * The Pollinations control — the arm that decides whether the fix is affordable.
+ *
+ * One sample per subject per style, not five: this lane is anonymous and capped
+ * at one queued request per IP with 15s between starts (#69), so twenty samples
+ * would cost ten minutes to answer a question one sample answers. It is not
+ * measuring a RATE — `sana` never drew a frame at all, in #74's twelve or here —
+ * it is asking whether the house style moves. It does not.
+ */
+async function pollinationsControl(): Promise<void> {
+  const dir = join(OUT_DIR, "poll");
+  mkdirSync(dir, { recursive: true });
+  for (const s of SUBJECTS) {
+    for (const style of ["current", "nocard"] as const) {
+      const file = join(dir, `${s.slug}--${style}.jpeg`);
+      if (existsSync(file)) continue;
+      const full = `${s.prompt}, ${STYLES[style]}`;
+      const res = await fetch(
+        `https://image.pollinations.ai/prompt/${encodeURIComponent(full)}` +
+          `?width=${CARD_SIZE.width}&height=${CARD_SIZE.height}&model=flux&seed=42&nologo=true`,
+      );
+      if (!res.ok) {
+        console.log(`FAIL  pollinations ${s.slug} ${style} — HTTP ${res.status}`);
+        continue;
+      }
+      writeFileSync(file, new Uint8Array(await res.arrayBuffer()));
+      console.log(
+        `ok    pollinations ${s.slug} ${style.padEnd(7)} model=${res.headers.get("x-model-used") ?? "-"}`,
+      );
+      await new Promise((r) => setTimeout(r, 15_000)); // #69's serial cap
+    }
+  }
+}
+
+// ── The contact sheet ───────────────────────────────────────────────────────
+//
+// HTML with <img> tags, the way #74's prototype and `contact-sheet.ts` do it —
+// composing a montage would need a decoder this repo deliberately keeps out of
+// its own code (see the header). Rows are the arms in order, columns the seeds,
+// so a frame that tracks an arm shows up as a horizontal band and one that
+// tracks a seed as a vertical one. The baseline reads as neither, which is how
+// the run rules the seed out.
+
+const esc = (s: string): string =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+function sheet(): void {
+  const rows = SUBJECTS.map((s) => {
+    const arms = ARMS.map((arm) => {
+      const cells = SEEDS.map((seed) => {
+        const f = `${s.slug}--seed${seed}--${arm.key}.png`;
+        return existsSync(join(OUT_DIR, f))
+          ? `<td><img src="${esc(f)}" loading="lazy"><div>seed ${seed}</div></td>`
+          : `<td class=miss>—</td>`;
+      }).join("");
+      return `<tr><th>${esc(arm.key)}</th>${cells}</tr>`;
+    }).join("");
+    return `<h2>${esc(s.slug)}</h2><div class=pr>${esc(s.prompt)}</div><table>${arms}</table>`;
+  }).join("");
+
+  const html = `<!doctype html><meta charset=utf-8><title>#81 — frame borders</title>
+<style>
+body{font:14px/1.5 system-ui;margin:2rem;background:#111;color:#eee}
+img{width:220px;height:220px;display:block}
+table{border-collapse:collapse;margin:.5rem 0 2rem}
+th{text-align:right;padding-right:.75rem;font-weight:600;white-space:nowrap}
+td{padding:2px;text-align:center;font-size:11px;color:#888}
+td.miss{color:#555}
+.pr{color:#9a9;font-style:italic}
+</style>
+<h1>#81 — does the frame follow the arm or the seed?</h1>
+<p>Rows are treatments, columns are seeds. Judge by eye: a decorative frame is a
+border the card's art sits <em>inside</em>, not a flush horizon or a flat sky.</p>
+${rows}`;
+
+  const out = join(OUT_DIR, "sheet.html");
+  writeFileSync(out, html);
+  console.log(`sheet ${out}`);
+}
+
+async function main(): Promise<void> {
+  mkdirSync(OUT_DIR, { recursive: true });
+  const argv = process.argv.slice(2);
+
+  if (argv.includes("--sheet")) return sheet();
+
+  for (const arm of ARMS) {
+    for (const s of SUBJECTS) {
+      for (const seed of SEEDS) {
+        await generate(s.slug, s.prompt, seed, arm);
+      }
+    }
+  }
+  await pollinationsControl();
+  sheet();
+}
+
+void main();

--- a/seed/NEW-THEME-RUNBOOK.md
+++ b/seed/NEW-THEME-RUNBOOK.md
@@ -126,10 +126,12 @@ added at Step 6, on the theme and — sparsely — on individual cards.
 - **`imagePrompt`** — concrete, kid-friendly, **no art-style words**: `buildPrompt()` appends `ART_STYLE`
   for you. What works across every provider: name **one** subject ("a single …"), give a viewpoint ("side
   view"), put it somewhere plain ("parked on grass"). Sleek aircraft photographed in flight are the shape
-  most often rendered as two overlapping copies. Name **no object the picture sits inside** — card,
-  frame, border, poster, sticker, mat. Cloudflare's SDXL draws those literally and insets the real subject
-  within them; that was #81, and it came from `ART_STYLE` saying "trading-card" rather than from any
-  card's own wording.
+  most often rendered as two overlapping copies. And name **no object the picture sits inside** — a card,
+  a frame, a border, a mat. Cloudflare's SDXL draws those literally, insetting the real subject within
+  them. That was #81, and it came from `ART_STYLE` itself saying "trading-card" rather than from any
+  card's own wording — but the same words in an `imagePrompt` reach the same model, and nothing checks
+  for them. Note the rule is about **naming the object at all**: "no border" is a border cue, not a
+  prohibition (#81 measured it).
 
 ### What the providers can and cannot draw
 
@@ -143,7 +145,7 @@ ran them through the escape hatch. What survives is narrower than the old blanke
 
 | Failure class | `pollinations` (asks for `flux`, served by `sana` — #64) | `cloudflare-sdxl` | `ai-horde` (escape hatch) |
 |---|---|---|---|
-| Identity rests on a **small held object** — bow, spear, tool | **fails** — the object goes wire-thin, smears, or duplicates | **fails** — right style, still draws two bows | **the one it fixes** — #74's single bow, single arrow: the first usable Longbowman this project has had |
+| Identity rests on a **small held object** — bow, spear, tool | **fails** — the object goes wire-thin, smears, or duplicates | **fails** — right style, still draws two bows. (#74 also saw a frame border on every sample; that was #81's bug in `ART_STYLE`, since fixed, and is no longer part of this row) | **the one it fixes** — #74's single bow, single arrow: the first usable Longbowman this project has had |
 | Identity rests on **niche uniform accuracy** | **fails** — a plausible costume from the wrong century or country, or a photoreal toddler in fancy dress | **usually passes** — #66 drew the Swiss Guard's blue/yellow stripes and ruff correctly; #74 saw a generic modern uniform on a different sample, so treat it as *much better, not reliable* | **fails differently** — costume correct, but rendered photo-real, which loses `ART_STYLE` |
 | **Multi-object scene** — a rider and a vehicle, a crowd | **fails** — the parts recombine into something else (a Victorian pony-trap for an Egyptian chariot; one figurine for the Terracotta Army) | **passes** — two horses, gold chariot, nemes headdress; rows of clay soldiers in a trench | **best seen for the class**, but miscounts (one horse where the prompt says two) |
 
@@ -270,12 +272,12 @@ Rule out a candidate on:
 - Gore, damage, fire, combat, casualties — anything from the prohibited list above.
 - Scary rather than friendly.
 - Wrong subject, or unreadable mush.
-- Text baked into the image, or a decorative frame border. Cloudflare drew frames on roughly a third of
-  candidates until **#81** found the cause in `ART_STYLE` itself — it used to say "trading-**card**
-  illustration", and SDXL drew the card: a wooden frame or a tan mat with the subject inset inside it. The
-  words are gone and the rate fell to ~1 in 20, so a frame is now rare rather than expected. If you see one,
-  it is a re-roll, **not** a re-prompt — and do not try to word your way out of it by asking for "no border",
-  which #81 measured as no better than saying nothing.
+- Text baked into the image, or a decorative frame border. Cloudflare framed **most** candidates until
+  **#81** found the cause in `ART_STYLE` itself — it used to say "trading-**card** illustration", and SDXL
+  drew the card: a wooden frame or a tan mat with the subject inset inside it. The words are gone and the
+  rate fell to about 1 in 20, so a frame is now rare rather than expected. If you see one it is a
+  **re-roll, not a re-prompt** — and do not try to word your way out of it by asking for "no border",
+  which is a border cue rather than a prohibition. Measurements in `src/features/pool/prompt.ts`.
 - **A photograph or a 3D render**, whichever lane drew it (#77). The published set varies enormously in
   style, but it is always an *illustration*, so photoreal skin, camera depth-of-field blur, a naturalistic
   cast shadow, or the look of a glazed figurine on a surface reads as a different product sitting in the

--- a/src/features/pool/prompt.ts
+++ b/src/features/pool/prompt.ts
@@ -11,30 +11,68 @@ import type { SeedCard } from "./seed-schema";
  * binder renders every card at a fixed size, so a framed card is inset relative
  * to an unframed one and a theme drawn from mixed lanes stops looking uniform.
  *
- * Measured on 20 paired samples (4 subjects x 5 seeds), by eye and by a border
- * detector that agreed with it:
+ * THE NUMBERS BELOW ARE THE CANONICAL ONES. Everywhere else that mentions this —
+ * the Cloudflare adapter, `NEW-THEME-RUNBOOK.md`, the guard in `pool.test.ts` —
+ * points here rather than restating them, so re-measuring is one edit.
+ * `pnpm prototype:81` regenerates the images and the contact sheet they were
+ * judged from; the detector column is a one-off cross-check that is NOT in the
+ * repo, for the reason that prototype's header gives.
  *
- *   this style, with "trading-card"        7 / 20 framed
- *   + `negative_prompt` on the adapter     5 / 20   — no effect
- *   + "full-bleed edge-to-edge, no border" 6 / 20   — no effect
- *   without "trading-card"                 1 / 20   — and that one is a flat
- *                                                     colour margin, not a frame
+ * Measured on paired samples, 4 subjects x 5 seeds per arm, seed-paired so each
+ * treated sample has its own control. Two instruments, because a frame is
+ * invisible to every automated check the seam has and eyeballing is therefore
+ * the only native one; and the whole run was repeated, because this lane is not
+ * deterministic and one run of 20 is thin:
  *
- * Two things that did NOT work are worth as much as the one that did, because
+ *                                          by eye    detector
+ *                                          (1 run)   (2 runs)
+ *   this style, with "trading-card"        11 / 20    13 / 40
+ *   + `negative_prompt` on the adapter      8 / 20     7 / 40
+ *   + "full-bleed edge-to-edge, no border" 10 / 20    10 / 40
+ *   without "trading-card"                  1 / 20     2 / 40
+ *
+ * The instruments disagree on the RATE and agree on the RANKING. The detector
+ * reads a flat uniform band along all four edges, so it misses ornate frames
+ * whose borders carry too much detail to be flat — it under-reads every arm,
+ * and the by-eye column is the one to quote for severity: this was a *majority*
+ * of candidates, not a third.
+ *
+ * Two things that did not fix it are worth as much as the one that did, because
  * both are the obvious next idea:
  *
- *   - Naming the border in order to forbid it makes no difference. SDXL weights
+ *   - Naming the border in order to forbid it does nothing at all. SDXL weights
  *     the noun and drops the negation, so "no border" is a border cue. The fix
- *     is to stop mentioning the object at all, not to argue with it.
- *   - `negative_prompt` on the Cloudflare adapter is no better than saying
- *     nothing, so no such param exists. That is deliberate: `params` is hashed
- *     into every review filename (`providers/provider.ts`), and a parameter that
- *     buys nothing would invalidate a folder of reviewed images for free.
+ *     is to stop mentioning the object, not to argue with it.
+ *   - `negative_prompt` on the Cloudflare adapter is NOT inert — it roughly
+ *     halves the rate, and a first run of 20 was too thin to see that. It is
+ *     still not the fix: it leaves frames on a sixth of candidates where
+ *     deleting two words leaves them on a twentieth, and it does not address
+ *     the cause. And it is not free — `params` is hashed into every review
+ *     filename (`providers/provider.ts`), so adding one invalidates a folder of
+ *     reviewed images. A partial fix at that price, stacked on top of the real
+ *     one, is why no such param exists.
  *
  * The seed is NOT the lever either. #66 and #74 found this lane non-deterministic
  * despite `seed: 42` being pinned, and #81 confirms it: the same request framed
  * on one run and not on the next. Frames varied freely across five seeds in both
- * arms, so there is no lucky seed to pick.
+ * arms, so there is no lucky seed to pick. `guidance`, `num_steps` and the
+ * checkpoint were left alone once the cause turned out to sit upstream of all
+ * three, in this string; they are where to look if anyone ever chases the
+ * residual 1-in-20.
+ *
+ * ── Why "no text" survives the same argument ────────────────────────────────
+ * It is the identical shape to "no border", which the table above shows is a
+ * cue rather than a prohibition — so it was measured too, the same way: 20
+ * samples with the phrase, 20 without. Text appeared once with it and never
+ * without, which at this sample size is no detectable effect either way, so it
+ * stays rather than churn `promptHash` for a change nothing can see.
+ *
+ * The asymmetry with "trading-card" is the real lesson, and it is about the
+ * NOUN rather than the negation: a trading card is an object a diffusion model
+ * has abundant training data for and can draw, so naming it — in any polarity —
+ * puts it in the picture. "Text" is not a thing it can draw a picture OF.
+ * Suspect any phrase here that names something depictable; a phrase that names
+ * a property is comparatively safe.
  *
  * ── What this costs, and why it is affordable ────────────────────────────────
  * `promptHash` (keys.ts, D4) covers this string, so editing it invalidates every
@@ -44,18 +82,29 @@ import type { SeedCard } from "./seed-schema";
  * re-generated and never re-audited. The map rules re-rendering them out of
  * scope, and this respects that.
  *
- * Nor does it shift the incumbent lane's look, which is the thing the binder's
- * coherence actually rests on. Pollinations serves `sana` (#64), and #81 drew
- * all four subjects through both styles there: same painterly semi-realism, same
- * compositions, same failure modes. `sana` never drew the frame and never read
- * the phrase. Every one of the ~360 published cards came from that lane, so the
- * cards this change alters are the ones that were diverging anyway.
+ * Nor does it shift the incumbent lane's look. Pollinations serves `sana` (#64),
+ * and #81 drew all four subjects through both styles there: same painterly
+ * semi-realism, same compositions, same failure modes. `sana` never drew the
+ * frame and never read the phrase, and every one of the ~360 published cards
+ * came from that lane — so this edit does not move the art that is already in
+ * the binder.
+ *
+ * That is a MEASUREMENT, not the coherence verdict. Whether mixing providers
+ * breaks the binder is #77's question and stays open there; all this establishes
+ * is that #81's fix is not one of the things that could break it.
  */
 export const ART_STYLE =
   "vibrant kid-friendly cartoon illustration, bright colors, " +
   "friendly, clean background, no text";
 
-/** Build the full Pollinations prompt for a card (pure). */
+/**
+ * Build the full prompt for a card (pure).
+ *
+ * Every provider gets the same string — the seam varies the adapter, never the
+ * words (#67) — which is what lets the contact sheet group a subject's
+ * candidates into one row, and what makes this constant a shared surface rather
+ * than one lane's tuning knob.
+ */
 export function buildPrompt(card: Pick<SeedCard, "imagePrompt">): string {
   return `${card.imagePrompt}, ${ART_STYLE}`;
 }

--- a/src/features/pool/providers/cloudflare-sdxl.ts
+++ b/src/features/pool/providers/cloudflare-sdxl.ts
@@ -26,13 +26,17 @@
  *
  * ── The frame this lane used to draw, and why the fix is not here (#81) ──────
  * This adapter was where a decorative frame border — a wooden picture frame, a
- * tan mat with a gold rule — got baked into roughly a third of its candidates.
- * It reads like an adapter problem and is not: the cause was the words
- * "trading-card" in `ART_STYLE` (`../prompt.ts`), which SDXL drew literally
- * while Pollinations' `sana` ignored them. The fix is that edit, not a parameter
- * here. #81 measured `negative_prompt` at 5/20 against a 7/20 baseline, so it
- * buys nothing — and every entry in `params` is hashed into review filenames, so
- * a parameter that buys nothing still costs a folder of reviewed images.
+ * tan mat with a gold rule — got baked into most of its candidates. It reads
+ * like an adapter problem and is not: the cause was the words "trading-card" in
+ * `ART_STYLE`, which SDXL drew literally while Pollinations' `sana` ignored
+ * them. The fix is that edit, and `../prompt.ts` carries the measurements.
+ *
+ * What belongs here is why this adapter has no `negative_prompt`. It was
+ * measured, and it is not inert — it roughly halves the frame rate. It is still
+ * not the fix, because deleting two words from the prompt does far better and
+ * addresses the cause. And every entry in `params` is hashed into review
+ * filenames, so adding one invalidates a folder of reviewed images: a partial
+ * fix, at that price, stacked on top of the real one.
  *
  * ── Provenance ───────────────────────────────────────────────────────────────
  * Cloudflare reports no serving-model header, so `model` comes back undefined

--- a/tests/pool.test.ts
+++ b/tests/pool.test.ts
@@ -100,29 +100,30 @@ describe("buildPrompt (U3-BR5)", () => {
   });
 
   /**
-   * #81 — ART_STYLE must not name a physical card, frame or border.
+   * #81 — ART_STYLE must not name the object a card's picture sits inside.
    *
    * The style string used to read "cartoon TRADING-CARD illustration", and
    * `cloudflare-sdxl` drew that literally: a wooden picture frame, a tan mat
-   * with a gold rule, a rounded panel, with the subject inset inside it. #81
-   * measured 7/20 framed against 1/20 once the words came out, and the residual
-   * one is a flat colour margin rather than a decorative frame.
+   * with a gold rule, a rounded panel, with the subject inset inside it. The
+   * measurements, and why a negative prompt is not the fix, are in
+   * `src/features/pool/prompt.ts`.
    *
    * This is a REGRESSION GUARD, not a restatement of the constant. The removed
    * words are the natural way to describe what these images are for, so the
-   * likeliest future edit — someone making the style read better, or adding a
-   * card-ish word to another lane's prompt — is exactly the one that brings the
-   * frames back. It would be invisible: a framed card is a valid 768x768 PNG,
-   * so `finishGeneration` passes it and only a human at checkpoint 2 sees it.
+   * likeliest future edit — someone making the style read better — is exactly
+   * the one that brings the frames back, and it would be invisible: a framed
+   * card is a valid 768x768 PNG, so `finishGeneration` passes it and only a
+   * human at checkpoint 2 sees it.
    *
-   * Naming the border to forbid it does NOT work and must not be the fix — #81
-   * measured "full-bleed edge-to-edge artwork, no border" appended to the style
-   * at 6/20, no better than saying nothing. Diffusion models weight the noun,
-   * not the negation. Neither does `negative_prompt` on the Cloudflare adapter
-   * (5/20 against a 7/20 baseline), which is why no such param was added.
+   * Scope, stated so the gap is deliberate rather than forgotten: this guards
+   * `ART_STYLE` only. The same rule binds a card author writing an
+   * `imagePrompt`, and nothing enforces it there — `seed-schema.ts` takes any
+   * non-empty string. That stays a runbook instruction under Step 3, because a
+   * blocklist over free-text prompts would fail both ways: "a knight holding a
+   * shield" is fine and "a card" never appears literally.
    */
-  it("names no physical card, frame or border — the words SDXL drew literally (#81)", () => {
-    expect(ART_STYLE).not.toMatch(/trading[ -]?card|\bcard\b|\bframe|\bborder|\bmat(te)?\b/i);
+  it("names no card, frame, border or mat — the objects SDXL draws literally (#81)", () => {
+    expect(ART_STYLE).not.toMatch(/\bcards?\b|\bfram(e|es|ed|ing)\b|\bborders?\b|\bmat(te|tes|ted)?\b/i);
   });
 });
 


### PR DESCRIPTION
Closes #84.

`main` already has #81's fix — `ART_STYLE` no longer says "trading-card", and
that string is byte-identical before and after this PR, so **no generated card
changes**. What `main` currently gets wrong is its account of its own
measurement, in the file a future reader will trust.

## How it got that way

#81's fix and its write-up were one commit on `feat/aihorde-hatch-and-runbook`.
That commit's content reached `main` inside #83 (#77's mixing rule), which
touched the same four files and carried it along. It is the **pre-review**
version. A code-review pass and a full re-run of the harness then corrected it,
on the same branch — and that correction never made it to `main`.

## What changes

**A conclusion, not just prose: `negative_prompt` is not inert.** The first run
of 20 read it as having no effect, and `main` says so. Re-running the committed
harness end to end produced a second sample of 20 that flipped it — the param
roughly *halves* the frame rate. It is still rejected, but for a different and
honest reason: a partial fix that leaves frames on a sixth of candidates, does
not address the cause, and still invalidates a folder of reviewed images, since
`params` is hashed into review filenames.

**Severity was understated.** `main` quotes `7/20` as though both instruments
agreed. That is the detector's number, and the detector reads a flat four-edge
band, so it misses ornate frames whose borders are too textured to register. By
eye it was `11/20` — a *majority* of candidates. Both columns are now shown, the
detector column is pooled over both runs (`13/40`), and the by-eye column is
named as the one to quote.

**One canonical copy.** The numbers were restated in four files; re-measuring
meant editing all four. They now live in `prompt.ts`, and the adapter, the
runbook and the test point at it.

**Two runbook fixes.** The authoring rule named `poster, sticker, mat` — nouns
that were never measured — now names only the ones that were. And the frame
observation deleted from #74's failure-class table is restored as history,
marked superseded, rather than quietly removed.

## The harness

`scripts/prototype-81-frames/` (`pnpm prototype:81`), kept per #74's precedent of
keeping the throwaway that produced the evidence. It generates all five arms, the
Pollinations control, and an HTML contact sheet.

It deliberately does **not** carry the pixel detector: that needed a decoder, and
the only one in the tree is `sharp`, which `pnpm-workspace.yaml` pins on the
express grounds that it "is invoked by `next` alone and never by this repo's own
code" — the argument that makes a 0.x MINOR override safe there. A prototype
importing it would quietly retire that argument, for a cross-check that
under-reads every arm anyway. The detector column is labelled in `prompt.ts` as a
one-off that is not in the repo.

## Also measured

"no text" is the identical shape to "no border", which the table shows is a cue
rather than a prohibition — so it was measured rather than assumed: 1 image in 20
with the phrase, 0 without. No detectable effect at that sample size, so it
stays. The asymmetry is the lesson, and it is about the **noun**: a trading card
is something a diffusion model can draw, so naming it in any polarity puts it in
the picture. "Text" is not.

## Verification

`pnpm typecheck`, `pnpm test` (511 passing) and `pnpm build` all green on top of
`main`. The only conflict on rebase was the checkpoint-2 bullet list, where #77's
photograph/3D-render rule and this correction both apply — both are kept.