### PR TITLE
Refuse a blank frame at the provider seam (#78)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -80,6 +80,18 @@ free provider:
   response *named* and is **`null`** where a provider names nothing (Cloudflare), never
   back-filled from the `params.model` that was *asked for*; its `reviewed` flag is FR9's
   durable receipt, false only on the `--allow-unreviewed` path.
+- **Blank frame** — a response that is a well-formed image of *nothing*: a real,
+  exactly-768×768, correctly-formatted frame carrying no subject (Cloudflare SDXL
+  returned a pure black PNG for ~40% of attempts on the one prompt where it was
+  measured, and never on the others tried, #78). Detected at
+  the seam as an information-density floor — encoded **bytes per pixel**, no decoder
+  — in `src/features/pool/blank-frame.ts`, which holds the threshold and the
+  measurements that set it. Refused by `finishGeneration` as `ProviderRetryable`,
+  because another attempt is a real remedy; a lane that keeps blanking exhausts the
+  ordinary retry ladder and is counted by the circuit breaker like any other failure.
+  The already-published pool was swept once against the same floor
+  (`pnpm seed --check-images`, `blank-audit.ts`): **390 of 390 weighed, none blank**,
+  2026-08-15.
 - **Contact sheet** — the subject × provider grid built by `pnpm contact-sheet`
   (`src/features/pool/contact-sheet.ts`), **CHECKPOINT 2** of
   `seed/NEW-THEME-RUNBOOK.md`, where a human picks the winner per card.

--- a/scripts/seed/index.ts
+++ b/scripts/seed/index.ts
@@ -2,6 +2,8 @@
  * Offline seed CLI — builds the card pool. NOT in the request path.
  *
  *   pnpm seed --check-urls        check every sourceUrl in the seed file, then exit
+ *   pnpm seed --check-images      weigh every PUBLISHED card image and report any that
+ *                                 is too sparse to be a picture (#78), then exit
  *   pnpm seed --review            generate images for NEW cards to seed/review/,
  *                                 from EVERY registered provider (the bake-off)
  *   pnpm seed --review --providers=pollinations
@@ -117,8 +119,13 @@ import {
 } from "@/features/pool/providers";
 import { planInserts, cardKey } from "@/features/pool/publish-plan";
 import { comparePoolShape } from "@/features/pool/completeness";
-import { listPublishedCardKeys, readPublishedShape } from "@/features/pool/pool-reads";
+import {
+  listPublishedCardKeys,
+  readPublishedImages,
+  readPublishedShape,
+} from "@/features/pool/pool-reads";
 import { checkSourceUrls } from "@/features/pool/url-check";
+import { auditPublishedImages } from "@/features/pool/blank-audit";
 import {
   upsertTheme,
   insertCardIfNew,
@@ -166,6 +173,62 @@ async function main() {
     : process.argv.includes("--publish")
       ? "publish"
       : "review";
+
+  // ── --check-images: weigh every PUBLISHED card's art and report anything too
+  // sparse to be a picture (#78). Standalone; runs and exits.
+  //
+  // The seam refuses a blank frame at generation time, which protects everything
+  // published from here on and nothing published before — a card already in the
+  // pool is never re-generated and never re-audited. This is the only pass over
+  // those bytes, so it is a command rather than a one-off script.
+  //
+  // Ahead of `loadSeed`, unlike --check-urls: this reads the DATABASE and touches
+  // no seed data, so failing it on an unrelated authoring error in cards.json
+  // would refuse to answer a question about the live pool for no reason.
+  if (process.argv.includes("--check-images")) {
+    const published = await readPublishedImages();
+    console.log(`Weighing ${published.length} published card image(s)…`);
+    const report = await auditPublishedImages(published, { size: CARD_SIZE });
+
+    // Printed FIRST, because everything below is a statement about the images
+    // that were actually weighed, and this says which ones were not.
+    if (report.unreadable.length > 0) {
+      console.warn(`\n⚠️  ${report.unreadable.length} image(s) could not be weighed:\n`);
+      for (const u of report.unreadable) {
+        console.warn(`   ${u.theme} / ${u.card} — ${u.reason}\n        ${u.url}`);
+      }
+      console.warn(
+        `\n   That is a fact about the request, NOT about the art. Nothing here needs\n` +
+          `   republishing on this evidence — but nothing here has been cleared either.`,
+      );
+    }
+    const weighed = report.checked - report.unreadable.length;
+    if (report.suspects.length === 0) {
+      // Never "all clear" over images nobody weighed — that is an all-clear
+      // earned by not looking, which is the shape of the bug this issue is about.
+      console.log(`✓ no blank frames among the ${weighed} image(s) weighed (of ${report.checked}).`);
+      if (report.unreadable.length > 0) process.exitCode = 1;
+      return;
+    }
+    console.error(
+      `\n⛔ ${report.suspects.length} of ${weighed} weighed image(s) look blank:\n`,
+    );
+    for (const s of report.suspects) {
+      console.error(
+        `   ${s.theme} / ${s.card} — ${s.byteLength} bytes ` +
+          `(${s.bytesPerPixel.toFixed(4)} B/px)\n        ${s.url}`,
+      );
+    }
+    console.error(
+      `\n   Look at each one before acting: this weighs bytes, it does not decode\n` +
+        `   pixels. Republishing a card means removing it from the pool and running\n` +
+        `   --review then --sync, which destroys its collection rows — read the\n` +
+        `   blast-radius guard first.\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
   const seed = loadSeed(SEED_PATH); // fail-fast validation (FR2–FR5)
 
   // ── --check-urls: standalone, network-only, DB-free. Runs and exits (FR11).

--- a/seed/NEW-THEME-RUNBOOK.md
+++ b/seed/NEW-THEME-RUNBOOK.md
@@ -15,7 +15,7 @@ This file supersedes the old `seed/AUTHORING_PROMPT.md`. It is the only card-aut
 | **Input** | A theme name. Nothing else. Any extra steer from the human (e.g. "lean historical") overrides this document's defaults where they conflict. |
 | **Output** | 30 published cards, images reviewed, the winning provider recorded in `seed/cards.json`, committed on a branch, a PR open. |
 | **Human checkpoints** | Exactly **two**: the 30-name list (Step 3), and the image contact sheet (Step 7). Still two — the bake-off did **not** add a third; it changed what the second one *is*, from approve/reject to **choose among N candidates**. Stop dead at both — do not proceed on silence, and never answer them yourself. |
-| **Blast radius** | `pnpm seed --sync` writes to the **production** Neon DB and Blob store that the children play against. `--check-urls` and `--review` do not write to it. |
+| **Blast radius** | `pnpm seed --sync` writes to the **production** Neon DB and Blob store that the children play against. `--check-urls`, `--check-images` and `--review` do not write to it. |
 | **Session** | One theme per run. Do not batch two themes. |
 
 ## Rules the schema enforces
@@ -184,7 +184,7 @@ Wording levers, in the order worth trying — these apply to every provider:
 So: **keep every superseded `imagePrompt` in the session** until the theme ships — that is the only
 recovery mechanism that spans all three. On a non-deterministic lane, deleting a candidate and re-running
 is a **re-roll**: you get a different picture and you cannot get the old one back. That is occasionally the
-right move (it is how you clear a blank frame, below); it is never reversible.
+right move (it is how you clear a near-empty frame, below); it is never reversible.
 
 Even on Pollinations the trick is bounded: the provider can change the model behind a prompt without notice,
 and has (#64) — a request for `flux` is served by `sana` today — so a prompt that drew one picture in July
@@ -284,10 +284,15 @@ Rule out a candidate on:
   binder. This is the one style question settled on sight; **every other one is a pick, not a rejection.**
   It bites the Pollinations lane hardest — `sana` leans semi-real, per the table in Step 4.
 - **A blank frame.** Cloudflare can return a *pure black* 768×768 PNG for a perfectly innocuous prompt —
-  ~40% of attempts on one measured prompt. It is a valid PNG at exactly the right size, so the seam accepts
-  it and it lands looking like a real candidate; the tell is file size, ~2 KB against a normal 750–900 KB.
-  Known and open as **#78**. The fix is a re-roll, not a re-prompt: delete that one file and re-run
-  `--review`. Retrying cleared it both times it was tried.
+  ~40% of attempts on one measured prompt. It is a valid PNG at exactly the right size, so it used to reach
+  `seed/review/` looking like a real candidate, with file size (~2 KB against a normal 750–900 KB) the only
+  tell. **Closed by #78**: the seam now measures encoded bytes per pixel and refuses anything below
+  0.02 B/px as retryable, so the lane simply draws again and the blank never lands. A card that blanks every
+  attempt fails the ladder, prints a `✗` line naming it during the run, and counts as a failure in that
+  lane's summary — so it reaches you as a *missing* candidate, never a black one.
+  You may still meet a frame that is nearly empty but textured enough to clear the floor: that is a re-roll,
+  not a re-prompt (delete that one file, re-run `--review`), and it is the one judgement the guard leaves to
+  you. See `src/features/pool/blank-frame.ts` for what the floor is measured against.
 
 Then, for each row, write down one of three outcomes: **a recommended provider with a one-line reason**,
 **a genuine tie** (say so — the human may have a taste preference), or **nothing usable**. Only the third
@@ -324,7 +329,8 @@ re-prompting fixes the wrong words.**
 | Every candidate is the same subject drawn in a style you dislike | **Pick**, or accept. Style is a property of the lane, not of your wording — see the per-provider table in Step 4 |
 | Every candidate misreads the *subject* — wrong object, fused parts, duplicated weapon | **Re-prompt.** Apply Step 4's wording levers |
 | Every candidate fails and the subject is a small held object | **The escape hatch**, below. Re-prompting this class has never fixed it on either lane |
-| One candidate is blank/black, the rest are fine | **Re-roll** that one file (#78). Not a re-prompt round |
+| One candidate is nearly empty, the rest are fine | **Re-roll** that one file. Not a re-prompt round. An outright *black* frame no longer reaches you — the seam refuses it and the lane redraws (#78) |
+| One cell is missing from the sheet entirely | Not a judgement call: that lane failed the card and printed a `✗` line naming it. Re-run `--review` |
 
 **To re-prompt, edit the `imagePrompt`** — deleting files is not enough on the Pollinations lane, which
 returns the same bytes for the same prompt (#64), so a delete-and-rerun there regenerates the picture you
@@ -410,7 +416,8 @@ chooser needs and nothing more:
 - your **recommendation per row** — provider and a one-line reason — and which rows you think are ties;
 - every card you re-prompted, and how many rounds it took;
 - every card **nothing drew acceptably**, named as such;
-- anything you are unsure about, including any cell you suspect is a blank frame (#78).
+- anything you are unsure about, including any cell that looks nearly empty (an outright blank one
+  cannot reach you any more — #78).
 
 Then **stop and wait for an explicit approval.** The human holds the kid-safety veto and the taste call;
 your screening only removes their grind, it does not replace them. This is the **second and last**
@@ -455,6 +462,15 @@ pnpm seed --sync           # publishes the REVIEWED bytes -> Blob -> DB insert; 
 
 `--sync` is delta-only: it inserts new cards, updates text on existing ones, and republishes nothing it
 does not have to. It refuses to insert any card lacking a reviewed image from its resolved provider.
+
+Optionally, once the theme is in:
+
+```bash
+pnpm seed --check-images   # weigh every PUBLISHED card's art; reports any blank frame (#78)
+```
+
+Read-only, no writes, and it covers the whole pool rather than your theme — a published card is never
+re-generated and never re-audited by any other command, so this is the only pass over those bytes.
 
 **The fail-safe, stated so nobody works around it:** a theme with **no pick recorded publishes nothing.**
 `--sync` reports each such card as *"no provider chosen (bake-off not judged)"* and exits without writing.

--- a/src/features/pool/blank-audit.ts
+++ b/src/features/pool/blank-audit.ts
@@ -1,0 +1,149 @@
+/**
+ * Does any card ALREADY IN THE POOL carry a blank frame? (#78)
+ *
+ * `finishGeneration` now refuses a blank at the seam, which protects every card
+ * generated from here on. It says nothing about the ~360 cards already published:
+ * `planInserts` only ever plans cards absent from the database, so a published
+ * card is never re-generated and never re-audited (`prompt.ts` says so out loud),
+ * and its bytes sit in Blob where no seed run will look at them again.
+ *
+ * #78 asked the question directly — "does anything already published carry one?
+ * worth one pass over the pool before assuming not" — and the honest answer needs
+ * a measurement rather than the argument that Pollinations has never been seen to
+ * do it. This is that pass, made repeatable rather than one-off: any future
+ * publish through `--allow-unreviewed`, or from a provider yet to be registered,
+ * deserves the same look.
+ *
+ * ── What the pass found, 2026-08-15 ──────────────────────────────────────────
+ * 390 published images, 390 weighed, ZERO below the floor and zero unreadable.
+ * So the pool as it stands carries no blank frame, and the ~360-card Pollinations
+ * era escaped the failure that #78 measured on Cloudflare SDXL. That is now a
+ * measurement rather than an assumption — and the reason to keep this command is
+ * that it will stop being true the moment a lane that blanks publishes anything.
+ *
+ * ── Why a HEAD, and why it is not trusted to work ────────────────────────────
+ * The check is a byte count against a pixel count (`blank-frame.ts`), so a
+ * `content-length` is the whole measurement — 360 cards at 360 tiny requests
+ * rather than ~70 MB of downloads.
+ *
+ * A HEAD that does not yield one is not taken as an answer, in either of its two
+ * shapes: no usable length, or a host that refuses the method outright (a CDN
+ * answering 403/405 to HEAD is ordinary). Both fall back to reading the body,
+ * because a check that silently skips what it cannot weigh reports "all clear"
+ * for the wrong reason — and reports it about the whole pool at once.
+ *
+ * No retry ladder, unlike `url-check.ts` ("none of them optional" there). That
+ * one hammers Wikipedia, which throttles; this reads one origin holding the
+ * project's own blobs. If that assumption ever breaks it shows up as entries in
+ * `unreadable`, which is a visible non-answer rather than a false all-clear.
+ *
+ * Every card in the pool is 768x768 (`CARD_SIZE`, the map's invariant), so the
+ * size is passed in rather than sniffed: this weighs bytes, and downloading each
+ * image to read a header it already knows the answer to would defeat the point.
+ *
+ * ── An unreadable image is not a blank one ───────────────────────────────────
+ * `url-check.ts` learned this at cost: its first build reported ~100 Wikipedia
+ * "failures" that were all 429s, and the operator's response to a reported
+ * failure is to go and EDIT good data. Same discipline here — a 403, a timeout or
+ * a missing blob is reported in its own list, never as a card to republish.
+ */
+import { belowDensityFloor, bytesPerPixel } from "./blank-frame";
+import { cardKey } from "./publish-plan";
+import type { ImageSizeRequest } from "./providers/provider";
+
+export type FetchImpl = typeof fetch;
+
+/** One published card's art, as the pool records it. */
+export interface PublishedImage {
+  theme: string;
+  card: string;
+  url: string;
+}
+
+/** A published image too sparse for its size to be a drawing of anything. */
+export interface BlankSuspect extends PublishedImage {
+  byteLength: number;
+  bytesPerPixel: number;
+}
+
+/** A published image the audit could not weigh — NOT a finding about the art. */
+export interface UnreadableImage extends PublishedImage {
+  reason: string;
+}
+
+export interface ImageAuditReport {
+  checked: number;
+  suspects: BlankSuspect[];
+  unreadable: UnreadableImage[];
+}
+
+export interface AuditOptions {
+  /** Pixel dimensions every card is published at. */
+  size: ImageSizeRequest;
+  fetchImpl?: FetchImpl;
+}
+
+/** Requests in flight. The pool is this project's own blobs, so it is polite. */
+const CONCURRENCY = 8;
+
+/** Weigh every published image and report the ones that cannot be pictures. */
+export async function auditPublishedImages(
+  images: readonly PublishedImage[],
+  opts: AuditOptions,
+): Promise<ImageAuditReport> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const suspects: BlankSuspect[] = [];
+  const unreadable: UnreadableImage[] = [];
+
+  /** Encoded size of one image, or the reason it could not be established. */
+  async function weigh(url: string): Promise<number | string> {
+    try {
+      const head = await fetchImpl(url, { method: "HEAD" });
+      if (head.ok) {
+        const declared = Number(head.headers.get("content-length"));
+        if (Number.isFinite(declared) && declared > 0) return declared;
+      }
+      // Either no usable length or a host that will not answer HEAD: read the
+      // bytes rather than skip the card.
+      const body = await fetchImpl(url);
+      if (!body.ok) return `GET ${body.status}`;
+      return (await body.arrayBuffer()).byteLength;
+    } catch (err) {
+      return String(err);
+    }
+  }
+
+  const queue = [...images];
+  const workers = Array.from({ length: Math.min(CONCURRENCY, queue.length) }, async () => {
+    while (queue.length) {
+      const image = queue.shift()!;
+      const weight = await weigh(image.url);
+      if (typeof weight !== "number") {
+        unreadable.push({ ...image, reason: weight });
+        continue;
+      }
+      if (belowDensityFloor(weight, opts.size)) {
+        suspects.push({
+          ...image,
+          byteLength: weight,
+          bytesPerPixel: bytesPerPixel(weight, opts.size),
+        });
+      }
+    }
+  });
+  await Promise.all(workers);
+
+  // Stable, pool-order output: workers finish out of order, and a report that
+  // reshuffles between runs is hard to diff. Keyed with `cardKey` rather than a
+  // separator of this module's own choosing, for the reason `publish-plan.ts`
+  // gives: any printable one lets ("A-B", "C") and ("A", "B-C") collide.
+  const order = new Map(images.map((i, n) => [cardKey(i.theme, i.card), n]));
+  const byPoolOrder = <T extends PublishedImage>(a: T, b: T) =>
+    (order.get(cardKey(a.theme, a.card)) ?? 0) - (order.get(cardKey(b.theme, b.card)) ?? 0);
+
+  return {
+    checked: images.length,
+    suspects: suspects.sort(byPoolOrder),
+    unreadable: unreadable.sort(byPoolOrder),
+  };
+}

--- a/src/features/pool/blank-frame.ts
+++ b/src/features/pool/blank-frame.ts
@@ -1,0 +1,115 @@
+/**
+ * Is an encoded image a drawing of ANYTHING? Pure, no I/O, no dependency (#78).
+ *
+ * `finishGeneration` proves an image is well-formed. It does not prove it is a
+ * picture. #78 caught Cloudflare SDXL answering HTTP 200 with a pure black
+ * 768x768 PNG for an entirely innocuous prompt: a real PNG, exactly the size the
+ * map's invariant demands, non-empty, in the declared format — so it was written
+ * to `seed/review/` under a normal candidate filename, with a normal sidecar, and
+ * counted as a drawn cell on the contact sheet. The only thing that flagged it
+ * was a human noticing the file was 400x smaller than its neighbours.
+ *
+ * Not rare, and not Cloudflare's documented NSFW filter (that answers error 3030,
+ * and #66 confirmed it never fired): 2 blanks in 5 attempts on one shipped prompt
+ * against 0 in 9 across every other prompt tried, with HTTP 200 and no signal.
+ *
+ * ── Why bytes-per-pixel and not pixel variance ───────────────────────────────
+ * The class being caught is "a frame carrying no subject" — uniform or nearly
+ * so, of any colour. The direct test is pixel variance, and it costs a decoder
+ * for PNG, JPEG and WebP; `readImageSize` next door is a header reader by design
+ * and this repo carries no image dependency at all.
+ *
+ * The proxy used instead is what every codec has in common: a uniform frame
+ * carries almost no information, so it compresses to almost nothing whatever the
+ * encoding. Encoded bytes divided by pixel count measures exactly that, needs no
+ * decoder, and — the reason it is worth preferring even if a decoder were free —
+ * it applies to a format nobody has written a decoder for yet, so a future
+ * adapter inherits the guard on the day it is registered.
+ *
+ * Be honest about what that means: this measures the ENCODING, not the pixels.
+ * It cannot say whether the blank is black, white or beige, and it does not
+ * claim to. A variance test would swap one threshold for another, not remove the
+ * need for one.
+ *
+ * ── The floor, and the measurements that set it ──────────────────────────────
+ * All at 768x768, measured 2026-08-15 while resolving #78. The Pollinations rows
+ * are live generations; the Cloudflare rows are #78's own observations.
+ *
+ *   what                                                   encoded    bytes/px
+ *   all-black PNG — the failure (`solidPng` reproduces it)   1.8 KB      0.003
+ *   "a completely flat solid mid-grey field"                30.2 KB      0.051
+ *   "a single small red dot on plain white, minimalist"      27.1 KB      0.046
+ *   an ordinary card prompt (Pollinations, JPEG)             70.1 KB      0.119
+ *   an ordinary card (Cloudflare SDXL, PNG)                750-900 KB  1.27-1.53
+ *
+ * The floor is 0.02 bytes/pixel — about 11.8 KB for a card. It sits ~7x above
+ * the failure and ~2.3x below the sparsest legitimate image that could be
+ * obtained from a live lane on purpose.
+ *
+ * That second margin is the one #78 worried about ("a threshold too eager
+ * rejects a legitimately minimal illustration"), and the measurement is the
+ * answer: you cannot prompt a diffusion model into a blank frame. Asking in
+ * plain words for a flat grey field returns 30 KB of texture anyway. The sparse
+ * end of legitimate output is not adjacent to blank — it is an order of
+ * magnitude away, and the floor sits in the gap.
+ *
+ * ── What it deliberately does not catch ──────────────────────────────────────
+ * A picture of the wrong subject, a badly drawn one, a framed one, a photoreal
+ * one. Those are judgements about content, they are CHECKPOINT 2's job
+ * (`seed/NEW-THEME-RUNBOOK.md`) and a human's, and the provider contract says so
+ * explicitly: "deliberately NOT here: anything about content, style or subject
+ * fidelity."
+ *
+ * ── What would invalidate the number ─────────────────────────────────────────
+ * A new adapter in a far more efficient format — AVIF, or lossless WebP at a low
+ * effort setting — could put an ordinary card nearer the floor than a JPEG does.
+ * Re-measure that adapter's ordinary output before registering it. A change of
+ * card SIZE needs nothing: the floor is per-pixel precisely so it follows the
+ * frame.
+ */
+import type { ImageSizeRequest } from "./providers/provider";
+
+/**
+ * Encoded bytes per pixel below which an image is judged to carry no subject.
+ * See the header for the measurements this sits between.
+ */
+export const MIN_BYTES_PER_PIXEL = 0.02;
+
+/**
+ * Encoded size over pixel count — the density the floor is set against.
+ *
+ * Takes a LENGTH rather than the bytes, because that is all it needs and it is
+ * all `blank-audit.ts` has: a `content-length` from a HEAD against Blob, with
+ * the image itself never downloaded.
+ */
+export function bytesPerPixel(byteLength: number, size: ImageSizeRequest): number {
+  const pixels = size.width * size.height;
+  return pixels > 0 ? byteLength / pixels : 0;
+}
+
+/**
+ * The comparison itself, over a length — the ONE place the floor is applied.
+ *
+ * `blank-audit.ts` weighs published images it never downloads, so it cannot hold
+ * bytes and must ask the question this way. Both callers going through here is
+ * what keeps the threshold a single fact rather than two that can drift.
+ *
+ * A frame with no pixels is not judged blank: a zero or negative size is a
+ * caller's bug rather than a provider's, and `finishGeneration` has already
+ * refused anything whose measured size is not the card's.
+ */
+export function belowDensityFloor(byteLength: number, size: ImageSizeRequest): boolean {
+  if (size.width * size.height <= 0) return false;
+  return bytesPerPixel(byteLength, size) < MIN_BYTES_PER_PIXEL;
+}
+
+/**
+ * True when the bytes are too sparse to be a drawing of anything.
+ *
+ * What the SEAM asks, and it takes the bytes rather than their length so that a
+ * later decision to decode pixels for real changes this file and nothing else.
+ * The audit's question stays length-only either way: it never has the bytes.
+ */
+export function looksBlank(bytes: Uint8Array, size: ImageSizeRequest): boolean {
+  return belowDensityFloor(bytes.byteLength, size);
+}

--- a/src/features/pool/pool-reads.ts
+++ b/src/features/pool/pool-reads.ts
@@ -6,9 +6,12 @@
  * them pulls in `env.databaseUrl` at module load, which fails in Vitest. Same
  * split as Inc23's `backup/count-report.ts` (pure) vs `scripts/backup/verify.ts`.
  *
- * Both queries are strictly reads. `--review` calls the first one and writes
- * nothing at all — which is why neither uses `upsertTheme`, whose lookup would
- * have inserted a row.
+ * Every query here is strictly a read. `--review` calls the first one and writes
+ * nothing at all — which is why none of them uses `upsertTheme`, whose lookup
+ * would have inserted a row.
+ *
+ * `readPublishedImages` is the odd one out and says so: it serves `--check-images`
+ * (#78), which audits art already in the pool rather than planning anything.
  */
 import { count, eq } from "drizzle-orm";
 import { db } from "@/db";
@@ -29,6 +32,23 @@ export async function listPublishedCardKeys(): Promise<Set<string>> {
     .from(cards)
     .innerJoin(themes, eq(themes.id, cards.themeId));
   return new Set(rows.map((r) => cardKey(r.theme, r.card)));
+}
+
+/**
+ * Every published card's art, as `(theme, card, imageUrl)` in display order.
+ *
+ * Read-only, and the only consumer is `--check-images` (#78): a published card's
+ * bytes are never looked at again by any other seed path.
+ */
+export async function readPublishedImages(): Promise<
+  Array<{ theme: string; card: string; url: string }>
+> {
+  const rows = await db
+    .select({ theme: themes.name, card: cards.name, url: cards.imageUrl })
+    .from(cards)
+    .innerJoin(themes, eq(themes.id, cards.themeId))
+    .orderBy(themes.sortOrder, cards.name);
+  return rows.map((r) => ({ theme: r.theme, card: r.card, url: r.url }));
 }
 
 /** Per-theme, per-rarity published counts. One grouped query. */

--- a/src/features/pool/providers/fake.ts
+++ b/src/features/pool/providers/fake.ts
@@ -61,7 +61,7 @@ export function fakeProvider(opts: FakeProviderOptions = {}): FakeProvider {
       calls.push(prompt);
       const step = script[n++];
       if (step instanceof Error) throw step;
-      return { bytes: solidPng(size.width, size.height), format: "png", model: opts.model };
+      return { bytes: picturePng(size.width, size.height), format: "png", model: opts.model };
     },
   };
 }
@@ -71,9 +71,49 @@ export function fakeProvider(opts: FakeProviderOptions = {}): FakeProvider {
  * scanlines, one IEND. `node:zlib` is already in the runtime, so this adds no
  * dependency — which matters, because the alternative was checking a binary
  * fixture into the repo for every size a test wants.
+ *
+ * Zeroed scanlines are an ALL-BLACK frame, which is the exact artefact #78 is
+ * about: at 768x768 this encodes to ~1.7 KB, against the 1.8 KB Cloudflare SDXL
+ * actually returned. So this is no longer a stand-in for a card — it is the
+ * fixture for the failure, and `picturePng` is what a provider is supposed to
+ * return.
  */
 export function solidPng(width: number, height: number): Uint8Array {
-  const raw = Buffer.alloc(height * (1 + width * 3)); // filter byte + RGB per row
+  return encodePng(width, height, Buffer.alloc(height * (1 + width * 3)));
+}
+
+/**
+ * A PNG with the information density of an actual drawing (#78).
+ *
+ * The seam now refuses a frame that carries no subject, measured as encoded
+ * bytes per pixel, so a fake emitting `solidPng` would emit precisely the thing
+ * every real adapter is now required to reject — and every seed-runner test
+ * would be pushing bytes through the port that no lane could ever produce.
+ *
+ * A diagonal gradient plus a low-amplitude dither, which is not a picture of
+ * anything but compresses like one: ~0.78 bytes/pixel at 768x768, against
+ * 1.27-1.53 for a real Cloudflare card and 0.02 for the floor. The dither is
+ * what buys that — a clean gradient compresses almost as far as a flat frame.
+ */
+export function picturePng(width: number, height: number): Uint8Array {
+  const raw = Buffer.alloc(height * (1 + width * 3));
+  let p = 0;
+  let noise = 1;
+  for (let y = 0; y < height; y++) {
+    raw[p++] = 0; // filter: none
+    for (let x = 0; x < width; x++) {
+      noise = (Math.imul(noise, 1664525) + 1013904223) >>> 0;
+      const dither = noise & 3;
+      raw[p++] = ((x >> 1) + dither) & 0xff;
+      raw[p++] = ((y >> 1) + dither) & 0xff;
+      raw[p++] = (128 + dither) & 0xff;
+    }
+  }
+  return encodePng(width, height, raw);
+}
+
+/** Wrap already-filtered scanlines as a truecolour 8-bit PNG. */
+function encodePng(width: number, height: number, raw: Buffer): Uint8Array {
   const ihdr = Buffer.alloc(13);
   ihdr.writeUInt32BE(width, 0);
   ihdr.writeUInt32BE(height, 4);

--- a/src/features/pool/providers/http.ts
+++ b/src/features/pool/providers/http.ts
@@ -7,6 +7,7 @@
  * private constructor argument, so the contract suite can drive a real adapter
  * from recorded fixtures while the seed runner injects a whole fake *provider*.
  */
+import { MIN_BYTES_PER_PIXEL, bytesPerPixel, looksBlank } from "../blank-frame";
 import { readImageSize } from "../image-size";
 import {
   ProviderRetryable,
@@ -71,8 +72,8 @@ export async function readBytes(
 
 /**
  * Turn raw bytes into a `GeneratedImage`, refusing anything that is not a usable
- * card. Every adapter ends here, which is what makes these two checks uniform
- * rather than something each adapter's author had to remember.
+ * card. Every adapter ends here, which is what makes these checks uniform rather
+ * than something each adapter's author had to remember.
  *
  * The format sniff also catches the sneakiest failure: a provider returning an
  * HTML or JSON error page with HTTP 200. That has a non-zero length, so the
@@ -82,6 +83,12 @@ export async function readBytes(
  * The size check enforces the map's 768x768 invariant at runtime, and is not
  * hypothetical: `flux-1-schnell` has no `width`/`height` parameter at all, so an
  * adapter written against it returns a plausible image of the wrong size.
+ *
+ * The blank check (#78) is the one that judges the picture rather than the
+ * envelope. Everything above proves an image is WELL-FORMED, and a pure black
+ * 768x768 PNG is well-formed — Cloudflare SDXL returned one for ~40% of attempts
+ * on a shipped prompt, and it reached `seed/review/` looking like a candidate.
+ * `../blank-frame.ts` holds the threshold and the measurements behind it.
  */
 export function finishGeneration(
   provider: Pick<ImageProvider, "id" | "format">,
@@ -114,6 +121,22 @@ export function finishGeneration(
     throw new Error(
       `${provider.id}: declares format "${provider.format}" but returned ${measured.format}. ` +
         `Fix the adapter's \`format\` — review filenames are named from it.`,
+    );
+  }
+  // Last, because it is the only check here that judges the PICTURE rather than
+  // the envelope, and the checks above give sharper messages when they apply.
+  //
+  // Retryable, on measurement rather than principle: #78 saw ~40% of attempts on
+  // one prompt come back blank and attempt 2 succeed both times it was tried, so
+  // another attempt is a real remedy where the 4xx above is not. A lane that
+  // blanks persistently is not retried forever — `withRetry` exhausts the same
+  // SEED_RETRIES ladder every other transient failure gets, and what escapes is
+  // the `ProviderFailedTerminally` the circuit breaker counts.
+  if (looksBlank(bytes, size)) {
+    throw new ProviderRetryable(
+      `${provider.id}: returned a blank frame — ${bytes.byteLength} bytes for ` +
+        `${size.width}x${size.height} is ${bytesPerPixel(bytes.byteLength, size).toFixed(4)} bytes/pixel, ` +
+        `below the ${MIN_BYTES_PER_PIXEL} floor, so it carries no subject`,
     );
   }
   return { bytes, format: measured.format, model };

--- a/tests-live/providers.live.test.ts
+++ b/tests-live/providers.live.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { runImageProviderContract } from "../tests/contracts/image-provider-contract";
 import { readImageSize } from "@/features/pool/image-size";
+import { looksBlank } from "@/features/pool/blank-frame";
 import { buildPrompt } from "@/features/pool/prompt";
 import { CARD_SIZE, PROVIDERS } from "@/features/pool/providers";
 
@@ -102,7 +103,9 @@ for (const provider of configured) {
       );
       const measured = readImageSize(image.bytes);
       expect(measured).toMatchObject({ width: 768, height: 768 });
-      expect(image.bytes.byteLength).toBeGreaterThan(1024);
+      // Not a byte-count floor: #78's blank frame was 1.8 KB and would have
+      // cleared one. Density, at the same threshold the seam enforces.
+      expect(looksBlank(image.bytes, CARD_SIZE)).toBe(false);
     });
 
     it("reports which model actually served the request, where it can", async () => {

--- a/tests/blank-audit.test.ts
+++ b/tests/blank-audit.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { auditPublishedImages } from "@/features/pool/blank-audit";
+
+const CARD = { width: 768, height: 768 };
+
+/** A HEAD response the way Blob answers one: no body, a content-length. */
+function head(byteLength: number): Response {
+  return new Response(null, {
+    status: 200,
+    headers: { "content-length": String(byteLength) },
+  });
+}
+
+const images = [{ theme: "Warriors", card: "Swiss Guard", url: "https://blob.example/a.png" }];
+
+describe("published blank-frame audit (#78)", () => {
+  it("reports a published card whose image is too sparse to be a picture", async () => {
+    const report = await auditPublishedImages(images, {
+      size: CARD,
+      fetchImpl: async () => head(1_800), // the blank Cloudflare returned
+    });
+    expect(report.checked).toBe(1);
+    expect(report.suspects).toHaveLength(1);
+    expect(report.suspects[0]).toMatchObject({ card: "Swiss Guard", byteLength: 1_800 });
+    expect(report.unreadable).toEqual([]);
+  });
+
+  it("leaves an ordinary card alone", async () => {
+    // 70 KB — a measured Pollinations card at 768x768.
+    const report = await auditPublishedImages(images, {
+      size: CARD,
+      fetchImpl: async () => head(70_139),
+    });
+    expect(report.suspects).toEqual([]);
+  });
+
+  it("reports an image it could not weigh as unreadable, never as blank", async () => {
+    // `url-check.ts` learned this the hard way: a checker that cries wolf is
+    // worse than no checker, because the operator's response to a reported blank
+    // is to delete and republish a card that was fine.
+    const report = await auditPublishedImages(images, {
+      size: CARD,
+      fetchImpl: async () => new Response(null, { status: 403 }),
+    });
+    expect(report.suspects).toEqual([]);
+    expect(report.unreadable).toHaveLength(1);
+    expect(report.unreadable[0].reason).toMatch(/403/);
+  });
+
+  it("falls back to the body when the host refuses HEAD, rather than giving up", async () => {
+    // A CDN answering 405 to HEAD would otherwise put the ENTIRE pool into
+    // `unreadable` and print "0 suspects" beside it — an all-clear earned by not
+    // looking, which is the failure mode this whole issue is about.
+    const report = await auditPublishedImages(images, {
+      size: CARD,
+      fetchImpl: async (_url, init) =>
+        init?.method === "HEAD"
+          ? new Response(null, { status: 405 })
+          : new Response(new Uint8Array(1_800) as unknown as BodyInit, { status: 200 }),
+    });
+    expect(report.unreadable).toEqual([]);
+    expect(report.suspects).toHaveLength(1);
+  });
+
+  it("falls back to reading the body when the response carries no length", async () => {
+    let gets = 0;
+    const report = await auditPublishedImages(images, {
+      size: CARD,
+      fetchImpl: async (_url, init) => {
+        if (init?.method === "HEAD") return new Response(null, { status: 200 });
+        gets++;
+        return new Response(new Uint8Array(1_800) as unknown as BodyInit, { status: 200 });
+      },
+    });
+    expect(gets).toBe(1);
+    expect(report.suspects).toHaveLength(1);
+    expect(report.suspects[0].byteLength).toBe(1_800);
+  });
+});

--- a/tests/blank-frame.test.ts
+++ b/tests/blank-frame.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { picturePng, solidPng } from "@/features/pool/providers/fake";
+import {
+  MIN_BYTES_PER_PIXEL,
+  bytesPerPixel,
+  looksBlank,
+} from "@/features/pool/blank-frame";
+
+const CARD = { width: 768, height: 768 };
+
+describe("blank-frame detector (#78)", () => {
+  it("reads a flat 768x768 PNG as blank — the shape Cloudflare actually returned", () => {
+    // `solidPng` encodes zeroed scanlines, i.e. an all-black frame, and lands at
+    // ~1.7 KB. #78 measured Cloudflare SDXL's blank at 1.8 KB: the same artefact.
+    expect(looksBlank(solidPng(CARD.width, CARD.height), CARD)).toBe(true);
+  });
+
+  it("does not read a picture-dense image as blank", () => {
+    expect(looksBlank(picturePng(CARD.width, CARD.height), CARD)).toBe(false);
+  });
+
+  it("judges density rather than file size, so the floor follows the frame", () => {
+    // 6 KB is a plausible small illustration at 256x256 (0.092 B/px) and nothing
+    // at all spread over a card (0.010 B/px). A flat byte-count floor would have
+    // to pick one of those and be wrong about the other.
+    const bytes = new Uint8Array(6_000);
+    expect(looksBlank(bytes, { width: 256, height: 256 })).toBe(false);
+    expect(looksBlank(bytes, CARD)).toBe(true);
+  });
+
+  it("keeps the floor inside the band #78 measured, with room on both sides", () => {
+    // The threshold is a judgement call, so this is the guard that stops it
+    // drifting silently: it pins the floor between the two ends of the measured
+    // evidence rather than pinning the number itself (which would assert only
+    // that someone typed it twice).
+    //
+    // Below — the failure: an all-black 768x768 frame, which is what Cloudflare
+    // SDXL returned and what `solidPng` encodes.
+    const blank = bytesPerPixel(solidPng(CARD.width, CARD.height).byteLength, CARD);
+    // Above — the sparsest LEGITIMATE image measurable on a live lane. Asking
+    // Pollinations for "a completely flat solid mid-grey field" still comes back
+    // at 30 KB, and "a single small red dot on a plain white background" at
+    // 27 KB, because a diffusion model draws texture even when told not to.
+    const sparsestLegitimate = 27_077 / (CARD.width * CARD.height);
+
+    expect(MIN_BYTES_PER_PIXEL).toBeGreaterThan(blank * 3);
+    expect(MIN_BYTES_PER_PIXEL).toBeLessThan(sparsestLegitimate / 2);
+  });
+});

--- a/tests/contracts/image-provider-contract.ts
+++ b/tests/contracts/image-provider-contract.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { readImageSize } from "@/features/pool/image-size";
+import { looksBlank } from "@/features/pool/blank-frame";
 import {
   CARD_SIZE,
   ProviderRetryable,
@@ -30,9 +31,22 @@ import {
  *   4. `paramHash(params)` is stable across processes and independent of key
  *      order. If it were not, a run would invalidate every review file on disk
  *      and demand a full re-review for no reason.
+ *   5. The image is a picture of SOMETHING (#78). Well-formed is not drawn: a
+ *      pure black 768x768 PNG satisfies 1 and 2 completely, and Cloudflare SDXL
+ *      returned one for ~40% of attempts on a shipped prompt.
  *
  * Deliberately NOT here: anything about content, style or subject fidelity.
- * That is the bake-off's job (#66) and a human's judgement, not a test's.
+ * That is the bake-off's job (#66) and a human's judgement, not a test's. Item 5
+ * is the narrow exception, and only because "carries no subject at all" is
+ * measurable without opinion.
+ *
+ * Item 5 lands in both halves, split by what each half can force. The structural
+ * half asserts a healthy provider's output is dense enough to be a drawing —
+ * which is what stops the fake emitting the pathology. FORCING a blank needs a
+ * transport to serve one, so the REFUSAL is asserted in the wire half. Every
+ * adapter funnels through `finishGeneration`, so an adapter that is not
+ * HTTP-shaped still inherits the guard; what it would not inherit is this proof
+ * of it, and that is worth knowing when one is written.
  *
  * ── Two halves, because the fake has no wire ─────────────────────────────────
  * Everything structural applies to every provider including the in-memory fake —
@@ -76,6 +90,15 @@ export function runImageProviderContract(label: string, makeProvider: MakeProvid
         expect(image.format).toBe(provider.format);
         expect(readImageSize(image.bytes)!.format).toBe(image.format);
       });
+    });
+
+    it("returns a frame dense enough to carry a subject (#78)", async () => {
+      // Well-formed is not the same as drawn. A provider can answer 200 with a
+      // real, exactly-768x768 image of nothing at all, and every other assertion
+      // here passes. This one is why the fake draws a picture rather than the
+      // all-black frame it used to.
+      const image = await makeProvider().generate("a friendly panda", CARD_SIZE);
+      expect(looksBlank(image.bytes, CARD_SIZE)).toBe(false);
     });
 
     it("declares a non-empty, slug-shaped id", () => {
@@ -130,6 +153,11 @@ export interface ContractFixtures {
   wrongSize(): Response;
   /** HTTP 200 with a correctly-sized image in a format the adapter does not declare. */
   wrongFormat(): Response;
+  /**
+   * HTTP 200 with a real, correctly-sized, correctly-formatted image that is a
+   * picture of nothing — the all-black frame #78 measured on Cloudflare SDXL.
+   */
+  blank(): Response;
 }
 
 /** Fresh HTTP adapter per call, wired to the supplied responder. */
@@ -164,6 +192,20 @@ export function runHttpProviderContract(
       // uploadImage sniffs the bytes — so only this catches it.
       const provider = makeProvider(fixtures.wrongFormat);
       await expect(provider.generate("x", CARD_SIZE)).rejects.toThrow(/declares format/);
+    });
+
+    it("refuses a blank frame, and treats it as worth another attempt (#78)", async () => {
+      // The one failure that passes every OTHER check in this list: a real PNG,
+      // exactly 768x768, non-empty, in the declared format — and a picture of
+      // nothing. Measured at ~40% of attempts on one shipped prompt, where
+      // attempt 2 succeeded both times it was tried, so the remedy is another
+      // attempt rather than failing the card. A lane that keeps blanking still
+      // exhausts the ladder and is reported: `withRetry` turns the last one into
+      // `ProviderFailedTerminally` and the breaker counts it like any other.
+      const provider = makeProvider(fixtures.blank);
+      const err = await provider.generate("x", CARD_SIZE).catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(ProviderRetryable);
+      expect(String(err)).toMatch(/blank/i);
     });
 
     it("throws ProviderRetryable on 429, so a rate limit is not a dead lane", async () => {

--- a/tests/image-provider.test.ts
+++ b/tests/image-provider.test.ts
@@ -4,7 +4,7 @@ import {
   runImageProviderContract,
   type ContractFixtures,
 } from "./contracts/image-provider-contract";
-import { fakeProvider, solidPng } from "@/features/pool/providers/fake";
+import { fakeProvider, picturePng, solidPng } from "@/features/pool/providers/fake";
 import { pollinations } from "@/features/pool/providers/pollinations";
 import { cloudflareSdxl } from "@/features/pool/providers/cloudflare-sdxl";
 import { aiHorde } from "@/features/pool/providers/ai-horde";
@@ -70,8 +70,32 @@ function imageResponse(bytes: Uint8Array): Response {
   return new Response(bytes as unknown as BodyInit, { status: 200 });
 }
 
+/**
+ * A synthetic image is a header and nothing else — a few dozen bytes — and the
+ * seam now measures whether the bytes are dense enough to be a drawing (#78).
+ * So the ones standing in for a REAL response are padded to what a real card of
+ * that size weighs: 0.15 B/px, between Pollinations' measured 0.119 for a card
+ * and the 0.78 the fake's `picturePng` reaches.
+ *
+ * Trailing bytes are safe: `readImageSize` returns at the JPEG frame header and
+ * at the WebP chunk header, both inside the first 32 bytes, and nothing anywhere
+ * decodes a picture.
+ */
+function padToCardWeight(bytes: Uint8Array, width: number, height: number): Uint8Array {
+  const target = Math.round(width * height * 0.15);
+  if (bytes.byteLength >= target) return bytes;
+  const out = new Uint8Array(target);
+  out.set(bytes);
+  return out;
+}
+
+function drawn(synthetic: (w: number, h: number) => Uint8Array) {
+  return (w: number, h: number) => padToCardWeight(synthetic(w, h), w, h);
+}
+
 function makeFixtures(
   image: (w: number, h: number) => Uint8Array,
+  blankImage: (w: number, h: number) => Uint8Array,
   otherFormat: (w: number, h: number) => Uint8Array,
 ): ContractFixtures {
   return {
@@ -79,6 +103,8 @@ function makeFixtures(
     wrongSize: () => imageResponse(image(512, 512)),
     // Right size, right everything — except the encoding the adapter promises.
     wrongFormat: () => imageResponse(otherFormat(CARD_SIZE.width, CARD_SIZE.height)),
+    // Right size, right format, right everything — and a picture of nothing.
+    blank: () => imageResponse(blankImage(CARD_SIZE.width, CARD_SIZE.height)),
     notAnImage: () =>
       new Response("<html><body>upstream error</body></html>", {
         status: 200,
@@ -97,9 +123,13 @@ function makeFixtures(
   };
 }
 
-const jpegFixtures = makeFixtures(syntheticJpeg, solidPng);
-const pngFixtures = makeFixtures(solidPng, syntheticJpeg);
-const webpFixtures = makeFixtures(syntheticWebp, solidPng);
+/** The synthetic headers at the weight of a real card — see `padToCardWeight`. */
+const cardJpeg = drawn(syntheticJpeg);
+const cardWebp = drawn(syntheticWebp);
+
+const jpegFixtures = makeFixtures(cardJpeg, syntheticJpeg, picturePng);
+const pngFixtures = makeFixtures(picturePng, solidPng, drawn(syntheticJpeg));
+const webpFixtures = makeFixtures(cardWebp, syntheticWebp, picturePng);
 
 /**
  * AI Horde needs four round-trips where the others need one, so the shared
@@ -195,7 +225,7 @@ describe("pollinations adapter", () => {
     process.env.POLLINATIONS_TOKEN = "t";
     const provider = pollinations({
       fetchImpl: async () =>
-        new Response(syntheticJpeg(768, 768) as unknown as BodyInit, {
+        new Response(cardJpeg(768, 768) as unknown as BodyInit, {
           status: 200,
           headers: { "x-model-used": "sana" },
         }),
@@ -213,7 +243,7 @@ describe("pollinations adapter", () => {
     const provider = pollinations({
       fetchImpl: async (url) => {
         seen = String(url);
-        return imageResponse(syntheticJpeg(768, 768));
+        return imageResponse(cardJpeg(768, 768));
       },
     });
     await provider.generate("a panda", CARD_SIZE);
@@ -237,7 +267,7 @@ describe("pollinations adapter", () => {
     const provider = pollinations({
       fetchImpl: async (_input, init) => {
         sentAuth = (init?.headers as Record<string, string> | undefined)?.Authorization;
-        return imageResponse(syntheticJpeg(768, 768));
+        return imageResponse(cardJpeg(768, 768));
       },
     });
     return provider.generate("x", CARD_SIZE).then(() => {
@@ -269,7 +299,7 @@ describe("cloudflare-sdxl adapter", () => {
       fetchImpl: async (input, init) => {
         url = String(input);
         body = JSON.parse(String(init?.body));
-        return imageResponse(solidPng(768, 768));
+        return imageResponse(picturePng(768, 768));
       },
     });
     await provider.generate("a panda", CARD_SIZE);
@@ -283,7 +313,7 @@ describe("cloudflare-sdxl adapter", () => {
     process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
     process.env.CLOUDFLARE_API_TOKEN = "tok";
     const provider = cloudflareSdxl({
-      fetchImpl: async () => imageResponse(solidPng(768, 768)),
+      fetchImpl: async () => imageResponse(picturePng(768, 768)),
     });
     expect((await provider.generate("x", CARD_SIZE)).model).toBeUndefined();
   });
@@ -304,7 +334,7 @@ describe("ai-horde adapter (#74)", () => {
     process.env = { ...saved };
   });
 
-  const okWebp = () => imageResponse(syntheticWebp(768, 768));
+  const okWebp = () => imageResponse(cardWebp(768, 768));
 
   /** Run one generation and hand back the body the adapter POSTed to /generate/async. */
   async function capturedSubmit(): Promise<Record<string, unknown>> {


### PR DESCRIPTION
Closes #78.

`finishGeneration` proved an image was well-formed, not that it was an image of anything. Cloudflare SDXL answers HTTP 200 with a pure black 768×768 PNG for ~40% of attempts on one shipped prompt — a real PNG, exactly the right size, non-empty, in the declared format — so it landed in `seed/review/` under a normal candidate filename, with a normal sidecar, and counted as a drawn cell on the contact sheet.

## The check

Encoded **bytes per pixel**, not pixel variance. A uniform frame carries no information in any codec, so this catches the class with no decoder — and therefore applies to a format nobody has written one for yet, which is what makes a future adapter inherit the guard on the day it is registered. `src/features/pool/blank-frame.ts` is explicit that this measures the *encoding*, not the pixels.

## The threshold, and the measurements that set it

All at 768×768 — the Pollinations rows generated live while resolving this:

| | B/px |
|---|---|
| all-black PNG (the failure) | 0.003 |
| "a completely flat solid mid-grey field" | 0.051 |
| "a single small red dot on plain white, minimalist" | 0.046 |
| ordinary card prompt (Pollinations, JPEG) | 0.119 |
| ordinary card (Cloudflare SDXL, PNG) | 1.27–1.53 |

Floor: **0.02 B/px** — ~7× above the failure, ~2.3× below the sparsest legitimate output. The "too eager rejects a minimal illustration" worry does not bite, and the measurement is why: **you cannot prompt a diffusion model into a blank frame.** Asking in plain words for a flat grey field still returns 30 KB of texture. A test pins the floor inside that band rather than asserting the number twice.

## Retryable, on measurement

Attempt 2 succeeded both times it was tried, so another attempt is a real remedy. No new machinery: `withRetry` exhausts the same `SEED_RETRIES` ladder, and a lane that keeps blanking produces `ProviderFailedTerminally` for the circuit breaker to count like any other failure.

## Also here

- **Contract suite** — a `blank()` fixture per format. Refusal asserted in the wire half (forcing a blank needs a transport), density in the structural half. The split is documented where a future adapter author will read it.
- **The fake stopped emitting the pathology.** `fakeProvider` returned `solidPng` — an all-black frame, i.e. exactly what the seam now rejects — so every seed-runner test was pushing bytes through the port that no real lane could produce. It now draws `picturePng`.
- **`pnpm seed --check-images`** — weighs already-published art, which no other command revisits. Read-only; an image it cannot weigh is reported as *unweighed*, never as clear.

## The pool pass

#78 asked whether anything already published carries one. Swept: **390 of 390 weighed, none blank.** The Pollinations era escaped the failure — now measured rather than assumed.

## Not covered

Fixtures only. `pnpm test:providers` has not run since the density assertion joined the live contract, and nothing has watched the guard reject a *real* blank end-to-end — both need provider keys, which CI deliberately does not have.