### PR TITLE
Cloudflare-weight cards ship as-is, and the store gets a budget (#79)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -92,6 +92,30 @@ free provider:
   The already-published pool was swept once against the same floor
   (`pnpm seed --check-images`, `blank-audit.ts`): **390 of 390 weighed, none blank**,
   2026-08-15.
+- **Store budget** — how much of the plan's Blob **storage allowance** the pool has spent,
+  and how many more 30-card themes fit at each lane's declared weight
+  (`src/features/pool/blob-budget.ts`, `pnpm seed --blob-budget`, #79). Reads the
+  STORE via `list()` rather than the pool's own image URLs, because `put()` adds a
+  random suffix: re-publishing a card writes a new object and strands the old one,
+  and the allowance is charged for both (**403 objects for 390 cards, 1.07 MB
+  stranded**, 2026-08-15). Stranded bytes are reported, never deleted. Measured
+  that day: **31.36 MB of 1 GB**, i.e. 415 more Pollinations-weight themes or 39
+  Cloudflare-weight ones. The plan is **Hobby**, so exceeding an allowance is not a
+  bill — it cuts off the store for the rest of the 30-day window, and a card whose
+  optimized variant is not already cached then renders as its `alt` text.
+- **`typicalCardBytes`** — an adapter's declared, *measured* weight for an ordinary
+  768×768 card. Not in `params` and not hashed, for `minIntervalMs`'s reason twice
+  over: it does not change the request, and it is an observation of the response. A
+  lane nobody has weighed leaves it undefined and projects as **UNMEASURED**, the
+  same discipline as a `null` `model`.
+- **Delivered weight vs stored weight** — not the same number, and #79 turned on the
+  difference. Every card surface renders through `next/image`, so a child downloads a
+  re-encoded WebP at the requested width, never the stored bytes. Measured through the
+  production optimizer at `w=512 q=75` (2026-08-15): a 937.9 KB Cloudflare PNG
+  delivered **39.5 KB**, a 147.9 KB JPEG delivered **68.4 KB**, a 41.5 KB Pollinations
+  JPEG delivered **9.6 KB**. Delivered weight tracks picture complexity, not source
+  encoding — so a heavier lane is a *storage* question and not a child-facing
+  performance one.
 - **Contact sheet** — the subject × provider grid built by `pnpm contact-sheet`
   (`src/features/pool/contact-sheet.ts`), **CHECKPOINT 2** of
   `seed/NEW-THEME-RUNBOOK.md`, where a human picks the winner per card.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -102,7 +102,16 @@ free provider:
   that day: **31.36 MB of 1 GB**, i.e. 415 more Pollinations-weight themes or 39
   Cloudflare-weight ones. The plan is **Hobby**, so exceeding an allowance is not a
   bill — it cuts off the store for the rest of the 30-day window, and a card whose
-  optimized variant is not already cached then renders as its `alt` text.
+  optimized variant is not already cached then renders as its `alt` text. Covers
+  **storage only**: image transformations are a deployment meter with no read path
+  from the CLI, and were the tightest of them all at **2,998 of 5,000 per 30 days** —
+  a dated observation, not something the command will notice moving. The ceiling is a
+  **plan** fact, hardcoded, and nothing detects a plan change.
+- **Mixed-weight pool** — since #79 accepted Cloudflare's weight and the map rules
+  re-rendering the ~360 published cards out of scope, the pool is permanently mixed:
+  light Pollinations-era cards alongside ~10× heavier Cloudflare ones. That is a fact
+  about the store's growth **rate** (how fast `--blob-budget` moves) and about nothing
+  a child sees, since delivered weight is decided by the optimizer either way.
 - **`typicalCardBytes`** — an adapter's declared, *measured* weight for an ordinary
   768×768 card. Not in `params` and not hashed, for `minIntervalMs`'s reason twice
   over: it does not change the request, and it is an observation of the response. A
@@ -115,7 +124,13 @@ free provider:
   delivered **39.5 KB**, a 147.9 KB JPEG delivered **68.4 KB**, a 41.5 KB Pollinations
   JPEG delivered **9.6 KB**. Delivered weight tracks picture complexity, not source
   encoding — so a heavier lane is a *storage* question and not a child-facing
-  performance one.
+  performance one. Replicated on a second run, where the inversion held (924.7 KB →
+  32.2 KB against 108.7 KB → 44.2 KB). Reproduce with `pnpm prototype:79 --delivered`
+  (`scripts/prototype-79-weight/`), which also carries `--steer`: Cloudflare SDXL has
+  **no output-format parameter** — `Accept: image/jpeg` and an invented
+  `response_format` are both silently dropped — while
+  `stable-diffusion-xl-lightning` answers **JPEG at 88–107 KB**, unregistered because
+  a model swap is a roster decision (#69), not a file-size one.
 - **Contact sheet** — the subject × provider grid built by `pnpm contact-sheet`
   (`src/features/pool/contact-sheet.ts`), **CHECKPOINT 2** of
   `seed/NEW-THEME-RUNBOOK.md`, where a human picks the winner per card.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "contact-sheet": "tsx --env-file-if-exists=.env.local scripts/contact-sheet/index.ts",
     "reconcile": "tsx --env-file-if-exists=.env.local scripts/reconcile/index.ts",
     "prototype:74": "tsx --env-file-if-exists=.env.local scripts/prototype-74-aihorde/index.ts",
+    "prototype:79": "tsx --env-file-if-exists=.env.local scripts/prototype-79-weight/index.ts",
     "prototype:81": "tsx --env-file-if-exists=.env.local scripts/prototype-81-frames/index.ts"
   },
   "dependencies": {

--- a/scripts/prototype-79-weight/index.ts
+++ b/scripts/prototype-79-weight/index.ts
@@ -1,0 +1,223 @@
+/**
+ * PROTOTYPE — #79. Throwaway. Do not import this from anything.
+ *
+ * The question: Cloudflare SDXL's cards are ~10x heavier than Pollinations'.
+ * Who pays for that? #79 named two payers — the Blob allowance and "a
+ * seven-year-old's connection" — and two possible remedies: re-encode, or ask
+ * Cloudflare for something lighter.
+ *
+ * This is the run behind both answers. The store side needs no prototype
+ * (`pnpm seed --blob-budget` is the shipped command and reads the real numbers);
+ * these are the two measurements that would otherwise be assertions in a commit
+ * body, which is the state #79 was complaining about in the first place.
+ *
+ *   pnpm prototype:79 --delivered    what a BROWSER actually downloads
+ *   pnpm prototype:79 --steer        can Cloudflare be asked for fewer bytes?
+ *
+ * ── --delivered: the source weight is not the delivered weight ───────────────
+ * Every card surface renders through `next/image` (`CardImage` is the only
+ * component that draws card art; there is no raw <img> anywhere), so a browser
+ * downloads a re-encoded WebP at the width it asked for and never the stored
+ * bytes. This uploads one image per lane to Blob under `probe-79/`, asks the
+ * PRODUCTION optimizer for each width the app actually requests, weighs what
+ * comes back, and deletes the probes.
+ *
+ * Measured 2026-08-15, `q=75`, WebP. Two runs, because this lane is not
+ * deterministic (#66) and #81's standing lesson is that a conclusion drawn from
+ * one run of a non-deterministic lane is worth re-drawing:
+ *
+ *                          source      w=128   w=256   w=512   w=1080
+ *   run 1
+ *   cloudflare-sdxl        937.9 KB     4.7     14.4    39.5     73.1
+ *   cloudflare-lightning   147.9 KB     6.6     24.9    68.4    110.7
+ *   pollinations            41.5 KB     1.8      4.1     9.6     16.3
+ *   run 2
+ *   cloudflare-sdxl        924.7 KB     4.1     11.8    32.2     64.9
+ *   cloudflare-lightning   108.7 KB     6.1     17.9    44.2     71.7
+ *   pollinations            44.1 KB     1.9      4.5    10.5     17.5
+ *
+ * The ordering INVERTS, in both runs: an ~8x heavier source delivers ~30%
+ * LIGHTER than the middle one. Delivered weight tracks how busy the picture is,
+ * not how heavy the file was — so the 14x does not survive the optimizer as
+ * bytes OR as a correlation, and the child-facing half of #79 is answered
+ * "nobody pays". Everything reaching a browser is 2-70 KB whichever lane drew
+ * it, against a stored range of 41 KB to 938 KB.
+ *
+ * Read it as three points, not a law. Each lane drew its own picture, so this
+ * compares three subjects as much as three encoders; what it establishes is
+ * that the delivered band is 2-70 KB for all of them and that source weight
+ * does not order it. A stronger design would put the same picture through both
+ * encoders, which no image dependency in this repo can do — which is itself
+ * part of the answer to "where would a re-encode live".
+ *
+ * The widths are not arbitrary: `CardImage` is used at dim 110/200/256/512, and
+ * `next.config.ts` allows imageSizes 128/256/512 + deviceSizes 640/1080, so a
+ * card is transformed at 128, 256, 512 and 1080 and at no other width. That is
+ * the 4 in "a 30-card theme costs at most 30 x 4 = 120 transformations".
+ *
+ * ── --steer: SDXL has no output-format lever; a different model does ─────────
+ * Measured the same day, same prompt, against the live endpoint:
+ *
+ *                                                          run 1     run 2
+ *   stable-diffusion-xl-base-1.0                     PNG   696.1 KB  852.1 KB
+ *   ... + `Accept: image/jpeg`                       PNG   698.7 KB  796.0 KB
+ *   ... + `response_format: "jpeg"` in the body      PNG   744.1 KB  816.5 KB
+ *   stable-diffusion-xl-lightning                    JPEG   88.2 KB  107.1 KB
+ *
+ * The within-run spread across the three sdxl arms (48 KB, 56 KB) is smaller
+ * than the between-run spread on the SAME arm (696 -> 852 KB), which is what
+ * makes "no effect" the reading rather than "a small effect".
+ *
+ * Two things worth knowing. SDXL's schema has no output-format parameter and
+ * the endpoint DROPS keys it does not know rather than refusing them, so an
+ * invented one returns 200 and looks like it worked — the size difference
+ * between those three rows is this lane's ordinary non-determinism (#66), not
+ * an effect. And `-lightning` answers JPEG while its `content-type` header
+ * still says `image/png`, which is one more reason `finishGeneration` sniffs
+ * bytes instead of trusting headers.
+ *
+ * So the lever for "ask Cloudflare for less" exists and it is a MODEL, not a
+ * parameter. It is deliberately not registered: a model swap is a quality
+ * decision belonging to a bake-off and to the roster (#69), and `-lightning` is
+ * a distilled model whose output at these step counts nobody has judged.
+ *
+ * Requires CLOUDFLARE_ACCOUNT_ID + CLOUDFLARE_API_TOKEN, and for `--delivered`
+ * also BLOB_READ_WRITE_TOKEN. `--delivered` writes 3 objects to the real store
+ * and deletes them again; `del()` is free and the probes are namespaced away
+ * from `cards/` so a failed run strands nothing a card could be confused with.
+ */
+import { put, del } from "@vercel/blob";
+import { ART_STYLE } from "@/features/pool/prompt";
+import { readImageSize } from "@/features/pool/image-size";
+import { CARD_SIZE } from "@/features/pool/providers";
+
+/** One subject, drawn by every arm, so the rows differ by encoder not by prompt length. */
+const SUBJECT = "A red panda curled on a mossy branch";
+const PROMPT = `${SUBJECT}, ${ART_STYLE}`;
+
+const PROD = "https://kids-collection.vercel.app";
+
+/**
+ * Every width the app can ask for, and no others — see the header. A width
+ * outside `next.config.ts`'s allowlist is refused by the optimizer, so this
+ * doubles as a check that the allowlist and `CardImage`'s dims still agree.
+ */
+const WIDTHS = [128, 256, 512, 1080];
+
+const SDXL = "@cf/stabilityai/stable-diffusion-xl-base-1.0";
+const LIGHTNING = "@cf/bytedance/stable-diffusion-xl-lightning";
+
+const kb = (n: number) => `${(n / 1024).toFixed(1)} KB`;
+
+async function cloudflare(
+  model: string,
+  extraBody: Record<string, unknown> = {},
+  extraHeaders: Record<string, string> = {},
+): Promise<{ bytes: Uint8Array; contentType: string }> {
+  const account = process.env.CLOUDFLARE_ACCOUNT_ID ?? "";
+  const res = await fetch(`https://api.cloudflare.com/client/v4/accounts/${account}/ai/run/${model}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.CLOUDFLARE_API_TOKEN ?? ""}`,
+      "Content-Type": "application/json",
+      ...extraHeaders,
+    },
+    body: JSON.stringify({
+      prompt: PROMPT,
+      width: CARD_SIZE.width,
+      height: CARD_SIZE.height,
+      num_steps: 20,
+      guidance: 7.5,
+      seed: 42,
+      ...extraBody,
+    }),
+  });
+  return {
+    bytes: new Uint8Array(await res.arrayBuffer()),
+    contentType: res.headers.get("content-type") ?? "(none)",
+  };
+}
+
+async function pollinations(): Promise<Uint8Array> {
+  const url =
+    `https://image.pollinations.ai/prompt/${encodeURIComponent(PROMPT)}` +
+    `?width=${CARD_SIZE.width}&height=${CARD_SIZE.height}&model=flux&seed=42&nologo=true`;
+  const res = await fetch(url);
+  return new Uint8Array(await res.arrayBuffer());
+}
+
+/**
+ * What the SNIFFED format is, against what the response CLAIMED. `-lightning`
+ * returns JPEG under an `image/png` content type, which is the whole reason the
+ * seam reads bytes rather than headers.
+ */
+function describeFormat(bytes: Uint8Array, contentType: string): string {
+  const sniffed = readImageSize(bytes);
+  const actual = sniffed ? sniffed.format : "UNRECOGNISED";
+  return contentType.includes(actual) ? actual : `${actual} (header said ${contentType})`;
+}
+
+async function delivered(): Promise<void> {
+  const arms: Array<{ name: string; bytes: Uint8Array; ext: string; type: string }> = [];
+
+  const sdxl = await cloudflare(SDXL);
+  arms.push({ name: "cloudflare-sdxl", bytes: sdxl.bytes, ext: "png", type: "image/png" });
+  const light = await cloudflare(LIGHTNING);
+  arms.push({ name: "cloudflare-lightning", bytes: light.bytes, ext: "jpg", type: "image/jpeg" });
+  arms.push({ name: "pollinations", bytes: await pollinations(), ext: "jpg", type: "image/jpeg" });
+
+  const uploaded: string[] = [];
+  try {
+    console.log(`\n${"arm".padEnd(22)}${"source".padStart(10)}   ${WIDTHS.map((w) => `w=${w}`.padStart(9)).join("")}`);
+    for (const arm of arms) {
+      // `probe-79/`, never `cards/`: a probe that outlives a crashed run must not
+      // look like an orphaned card to `--blob-budget`.
+      const { url } = await put(`probe-79/${arm.name}.${arm.ext}`, Buffer.from(arm.bytes), {
+        access: "public",
+        contentType: arm.type,
+      });
+      uploaded.push(url);
+
+      const row: string[] = [];
+      for (const w of WIDTHS) {
+        const res = await fetch(`${PROD}/_next/image?url=${encodeURIComponent(url)}&w=${w}&q=75`, {
+          headers: { Accept: "image/webp,image/*" },
+        });
+        // A width outside next.config.ts's allowlist answers 400, which is a
+        // finding about the config rather than about the image.
+        const cell = res.ok ? kb((await res.arrayBuffer()).byteLength) : `HTTP ${res.status}`;
+        row.push(cell.padStart(9));
+      }
+      console.log(`${arm.name.padEnd(22)}${kb(arm.bytes.byteLength).padStart(10)}   ${row.join("")}`);
+    }
+  } finally {
+    // In a finally, because the probes are the only thing this writes and a
+    // half-finished run must not leave them behind charging the allowance.
+    for (const url of uploaded) await del(url);
+    console.log(`\ndeleted ${uploaded.length} probe object(s) from Blob`);
+  }
+}
+
+async function steer(): Promise<void> {
+  const arms: Array<[string, () => Promise<{ bytes: Uint8Array; contentType: string }>]> = [
+    ["sdxl, as shipped", () => cloudflare(SDXL)],
+    ["sdxl + Accept: image/jpeg", () => cloudflare(SDXL, {}, { Accept: "image/jpeg" })],
+    ["sdxl + response_format", () => cloudflare(SDXL, { response_format: "jpeg" })],
+    ["stable-diffusion-xl-lightning", () => cloudflare(LIGHTNING)],
+  ];
+  console.log(`\n${"arm".padEnd(32)}${"bytes".padStart(10)}  format`);
+  for (const [label, run] of arms) {
+    const { bytes, contentType } = await run();
+    console.log(
+      `${label.padEnd(32)}${kb(bytes.byteLength).padStart(10)}  ${describeFormat(bytes, contentType)}`,
+    );
+  }
+  console.log(
+    `\nThe three sdxl rows differ only by this lane's ordinary non-determinism\n` +
+      `(#66) — an unknown key is DROPPED, not refused, so an invented parameter\n` +
+      `returns 200 and looks like it worked.`,
+  );
+}
+
+const mode = process.argv.includes("--steer") ? "steer" : "delivered";
+await (mode === "steer" ? steer() : delivered());

--- a/scripts/seed/index.ts
+++ b/scripts/seed/index.ts
@@ -4,6 +4,9 @@
  *   pnpm seed --check-urls        check every sourceUrl in the seed file, then exit
  *   pnpm seed --check-images      weigh every PUBLISHED card image and report any that
  *                                 is too sparse to be a picture (#78), then exit
+ *   pnpm seed --blob-budget       weigh the whole Blob store against the plan's storage
+ *                                 allowance and project how many themes still fit, per
+ *                                 lane (#79), then exit
  *   pnpm seed --review            generate images for NEW cards to seed/review/,
  *                                 from EVERY registered provider (the bake-off)
  *   pnpm seed --review --providers=pollinations
@@ -107,10 +110,12 @@ import {
   type ProvenanceFile,
   type PublishedCard,
 } from "@/features/pool/provenance";
+import { CARDS_PER_THEME } from "@/features/pool/seed-schema";
 import type { SeedCard, ThemeSeed } from "@/features/pool/seed-schema";
 import {
   CARD_SIZE,
   PROVIDER_IDS,
+  PROVIDERS,
   ProviderSelectionError,
   parseProvidersFlag,
   providerById,
@@ -126,6 +131,12 @@ import {
 } from "@/features/pool/pool-reads";
 import { checkSourceUrls } from "@/features/pool/url-check";
 import { auditPublishedImages } from "@/features/pool/blank-audit";
+import {
+  buildBlobBudget,
+  formatBytes,
+  readStoreObjects,
+  WARN_FRACTION,
+} from "@/features/pool/blob-budget";
 import {
   upsertTheme,
   insertCardIfNew,
@@ -226,6 +237,74 @@ async function main() {
         `   blast-radius guard first.\n`,
     );
     process.exitCode = 1;
+    return;
+  }
+
+  // ── --blob-budget: weigh the whole store against the plan's allowance and say
+  // how many more themes fit, per lane (#79). Standalone; runs and exits.
+  //
+  // Standalone rather than in-band on --sync, which is the opposite of
+  // `comparePoolShape`'s choice and for the opposite reason. A short theme is a
+  // fault of the run that just happened, so it has to be caught inside it. Store
+  // pressure is a slow trend across many runs, and wiring it into --sync would
+  // add a `list()` to every publish and give a publish a new way to fail for a
+  // reason that has nothing to do with the cards being published. The runbook
+  // calls this before a bake-off instead, which is the moment the answer can
+  // still change what you do.
+  //
+  // Reads the STORE, not the pool: `put()` adds a random suffix, so a re-publish
+  // strands the old object and the pool's own URLs cannot see it. Read-only —
+  // stranded bytes are reported and never deleted.
+  if (process.argv.includes("--blob-budget")) {
+    console.log(`Weighing the Blob store…`);
+    const [objects, published] = await Promise.all([
+      readStoreObjects(),
+      readPublishedImages(),
+    ]);
+    const budget = buildBlobBudget({
+      objects,
+      liveUrls: new Set(published.map((p) => p.url)),
+      lanes: PROVIDERS,
+    });
+
+    const pct = (budget.usedFraction * 100).toFixed(1);
+    console.log(
+      `\n   stored     ${formatBytes(budget.store.totalBytes)} of ` +
+        `${formatBytes(budget.ceilingBytes)}  (${pct}%)\n` +
+        `   objects    ${budget.store.count}  for ${published.length} published card(s)\n` +
+        `   per card   mean ${formatBytes(budget.store.meanBytes)}, ` +
+        `median ${formatBytes(budget.store.medianBytes)}, ` +
+        `max ${formatBytes(budget.store.maxBytes)}\n` +
+        `   free       ${formatBytes(budget.freeBytes)}`,
+    );
+
+    if (budget.orphans.count > 0) {
+      console.log(
+        `\n   ${budget.orphans.count} object(s), ${formatBytes(budget.orphans.bytes)}, that no ` +
+          `published card points at.\n` +
+          `   Re-publishing a card writes a NEW object rather than replacing the old\n` +
+          `   one, and the allowance is charged for both. Reported, not deleted: look\n` +
+          `   before removing anything, because a card whose row was pruned and whose\n` +
+          `   bytes were kept looks exactly the same from here.`,
+      );
+    }
+
+    console.log(`\n   Themes of ${CARDS_PER_THEME} cards that still fit, per lane:`);
+    for (const p of budget.projections) {
+      const weight = p.perCardBytes === null ? "UNMEASURED" : `${formatBytes(p.perCardBytes)}/card`;
+      console.log(`     ${p.id.padEnd(18)} ${weight.padEnd(16)} ${p.themes ?? "—"}`);
+    }
+
+    if (budget.overWarnLine) {
+      console.warn(
+        `\n⚠️  past ${(WARN_FRACTION * 100).toFixed(0)}% of the storage allowance.\n` +
+          `   Exceeding it does not produce a bill on this plan — it cuts off access to\n` +
+          `   the store until the 30-day window rolls, so cards whose optimized variant\n` +
+          `   is not already cached render as their alt text. Publish nothing further\n` +
+          `   until this is dealt with.`,
+      );
+      process.exitCode = 1;
+    }
     return;
   }
 

--- a/scripts/seed/index.ts
+++ b/scripts/seed/index.ts
@@ -136,6 +136,7 @@ import {
   formatBytes,
   readStoreObjects,
   WARN_FRACTION,
+  type BlobBudget,
 } from "@/features/pool/blob-budget";
 import {
   upsertTheme,
@@ -176,6 +177,66 @@ type Mode = "review" | "publish" | "sync";
 /** Absolute path of one bake-off candidate. */
 function reviewPath(themeName: string, card: NamedCard, provider: ImageProvider): string {
   return join(REVIEW_DIR, reviewFileName(themeName, card, provider));
+}
+
+/**
+ * Print a store budget (#79). Returns true when the run should exit non-zero,
+ * which is how the runbook's Hard stop is detectable from a script.
+ *
+ * Extracted rather than inlined in `main`, for the reason the neighbouring
+ * commands are: presentation is the bulk of it, and `main` is already the
+ * longest thing here.
+ */
+function reportBlobBudget(budget: BlobBudget, publishedCount: number): boolean {
+  const pct = (budget.usedFraction * 100).toFixed(1);
+  console.log(
+    `\n   stored     ${formatBytes(budget.store.totalBytes)} of ` +
+      `${formatBytes(budget.ceilingBytes)}  (${pct}%)\n` +
+      `   objects    ${budget.store.count}  for ${publishedCount} published card(s)\n` +
+      `   per card   mean ${formatBytes(budget.store.meanBytes)}, ` +
+      `median ${formatBytes(budget.store.medianBytes)}, ` +
+      `max ${formatBytes(budget.store.maxBytes)}\n` +
+      `   free       ${formatBytes(budget.freeBytes)}`,
+  );
+
+  if (budget.orphans.count > 0) {
+    console.log(
+      `\n   ${budget.orphans.count} object(s), ${formatBytes(budget.orphans.bytes)}, that no ` +
+        `published card points at.\n` +
+        `   Re-publishing a card writes a NEW object rather than replacing the old\n` +
+        `   one, and the allowance is charged for both. Reported, not deleted: look\n` +
+        `   before removing anything, because a card whose row was pruned and whose\n` +
+        `   bytes were kept looks exactly the same from here.`,
+    );
+  }
+
+  console.log(`\n   Themes of ${CARDS_PER_THEME} cards that still fit, per lane:`);
+  for (const p of budget.projections) {
+    const weight = p.perCardBytes === null ? "UNMEASURED" : `${formatBytes(p.perCardBytes)}/card`;
+    console.log(`     ${p.id.padEnd(18)} ${weight.padEnd(16)} ${p.themes ?? "—"}`);
+  }
+  // Said every run, not only when it warns: this covers Blob storage and
+  // nothing else, and the meter nearest its cap when #79 measured was one it
+  // cannot see. A report silently scoped to one meter is how the others get
+  // assumed instead of measured.
+  console.log(
+    `\n   Storage only. Image transformations are a deployment meter with no read\n` +
+      `   path from here (2,998 of 5,000 per 30 days on 2026-08-15, the tightest of\n` +
+      `   them) — check the team's usage page for that one. The ceiling above is the\n` +
+      `   Hobby allowance, hardcoded; on a different plan it is wrong.`,
+  );
+
+  if (budget.overWarnLine) {
+    console.warn(
+      `\n⚠️  past ${(WARN_FRACTION * 100).toFixed(0)}% of the storage allowance.\n` +
+        `   Exceeding it does not produce a bill on the Hobby plan — it cuts off access\n` +
+        `   to the store until the 30-day window rolls, so cards whose optimized variant\n` +
+        `   is not already cached render as their alt text. Publish nothing further\n` +
+        `   until this is dealt with.`,
+    );
+    return true;
+  }
+  return false;
 }
 
 async function main() {
@@ -266,45 +327,7 @@ async function main() {
       liveUrls: new Set(published.map((p) => p.url)),
       lanes: PROVIDERS,
     });
-
-    const pct = (budget.usedFraction * 100).toFixed(1);
-    console.log(
-      `\n   stored     ${formatBytes(budget.store.totalBytes)} of ` +
-        `${formatBytes(budget.ceilingBytes)}  (${pct}%)\n` +
-        `   objects    ${budget.store.count}  for ${published.length} published card(s)\n` +
-        `   per card   mean ${formatBytes(budget.store.meanBytes)}, ` +
-        `median ${formatBytes(budget.store.medianBytes)}, ` +
-        `max ${formatBytes(budget.store.maxBytes)}\n` +
-        `   free       ${formatBytes(budget.freeBytes)}`,
-    );
-
-    if (budget.orphans.count > 0) {
-      console.log(
-        `\n   ${budget.orphans.count} object(s), ${formatBytes(budget.orphans.bytes)}, that no ` +
-          `published card points at.\n` +
-          `   Re-publishing a card writes a NEW object rather than replacing the old\n` +
-          `   one, and the allowance is charged for both. Reported, not deleted: look\n` +
-          `   before removing anything, because a card whose row was pruned and whose\n` +
-          `   bytes were kept looks exactly the same from here.`,
-      );
-    }
-
-    console.log(`\n   Themes of ${CARDS_PER_THEME} cards that still fit, per lane:`);
-    for (const p of budget.projections) {
-      const weight = p.perCardBytes === null ? "UNMEASURED" : `${formatBytes(p.perCardBytes)}/card`;
-      console.log(`     ${p.id.padEnd(18)} ${weight.padEnd(16)} ${p.themes ?? "—"}`);
-    }
-
-    if (budget.overWarnLine) {
-      console.warn(
-        `\n⚠️  past ${(WARN_FRACTION * 100).toFixed(0)}% of the storage allowance.\n` +
-          `   Exceeding it does not produce a bill on this plan — it cuts off access to\n` +
-          `   the store until the 30-day window rolls, so cards whose optimized variant\n` +
-          `   is not already cached render as their alt text. Publish nothing further\n` +
-          `   until this is dealt with.`,
-      );
-      process.exitCode = 1;
-    }
+    if (reportBlobBudget(budget, published.length)) process.exitCode = 1;
     return;
   }
 

--- a/seed/NEW-THEME-RUNBOOK.md
+++ b/seed/NEW-THEME-RUNBOOK.md
@@ -217,17 +217,28 @@ entries — that reshuffles what the children already know.
 
 ```bash
 pnpm seed --check-urls     # schema runs first; then every sourceUrl in the file must return 200
-pnpm seed --blob-budget    # is there room in Blob for another 30 cards? (#79)
 ```
 
 Schema failure → fix the JSON. A 404 → find a URL that resolves, or change the subject; **never** delete
 the field or point at a search page. Re-run until clean. This is network-only and touches no database.
 
-`--blob-budget` is read-only and prints how much of the plan's storage allowance the pool has spent, plus
-how many more 30-card themes fit **at each lane's measured weight**. Run it here rather than after
-publishing, because it is only useful while you can still act on it. On 2026-08-15 it read *31.36 MB of
-1.00 GB, 415 more Pollinations themes or 39 Cloudflare ones* — so the honest summary is **there is room,
-and the lanes differ by an order of magnitude in how fast it goes**. If it warns, stop: see *Hard stops*.
+Then, separately — this one **does** read the database and needs `DATABASE_URL` and
+`BLOB_READ_WRITE_TOKEN`:
+
+```bash
+pnpm seed --blob-budget    # is there room in Blob for another 30 cards? (#79)
+```
+
+Read-only. It prints how much of the plan's storage allowance the pool has spent, plus how many more
+30-card themes fit **at each lane's measured weight**. Run it here rather than after publishing, because
+it is only useful while you can still act on it. On 2026-08-15 it read *31.36 MB of 1.00 GB, 415 more
+Pollinations themes or 39 Cloudflare ones* — so the honest summary is **there is room, and the lanes
+differ by an order of magnitude in how fast it goes**. If it warns, stop: see *Hard stops*.
+
+Two things it does **not** cover, so you know what it is not telling you. It watches Blob **storage**
+only; image transformations are a deployment meter with no read path from the CLI, and on 2026-08-15 that
+was the meter nearest its cap (2,998 of 5,000 per 30 days) — check the team's usage page for that one. And
+its ceiling is the **Hobby** allowance hardcoded; if the plan has changed since, the number is wrong.
 
 ## Step 6 — Commit, then generate the art
 

--- a/seed/NEW-THEME-RUNBOOK.md
+++ b/seed/NEW-THEME-RUNBOOK.md
@@ -217,10 +217,17 @@ entries — that reshuffles what the children already know.
 
 ```bash
 pnpm seed --check-urls     # schema runs first; then every sourceUrl in the file must return 200
+pnpm seed --blob-budget    # is there room in Blob for another 30 cards? (#79)
 ```
 
 Schema failure → fix the JSON. A 404 → find a URL that resolves, or change the subject; **never** delete
 the field or point at a search page. Re-run until clean. This is network-only and touches no database.
+
+`--blob-budget` is read-only and prints how much of the plan's storage allowance the pool has spent, plus
+how many more 30-card themes fit **at each lane's measured weight**. Run it here rather than after
+publishing, because it is only useful while you can still act on it. On 2026-08-15 it read *31.36 MB of
+1.00 GB, 415 more Pollinations themes or 39 Cloudflare ones* — so the honest summary is **there is room,
+and the lanes differ by an order of magnitude in how fast it goes**. If it warns, stop: see *Hard stops*.
 
 ## Step 6 — Commit, then generate the art
 
@@ -317,6 +324,24 @@ in the style that drew them (#64), so picking it buys nothing back. That is abou
 pick, not about which lanes run — the lane roster is #69's, and unchanged.
 
 Legendaries get no special rule. If two of them tie, say so at the checkpoint; do not settle it yourself.
+
+### Does a lane's file size change the pick?
+
+**No. Pick on the picture (#79).** Cloudflare SDXL returns ~826 KB PNGs against Pollinations' ~78 KB
+JPEGs, and that 10× is real in the Blob store and nowhere else that matters:
+
+- **The child never receives it.** Every card surface renders through `next/image`, so what a browser
+  downloads is a re-encoded WebP at the width it asked for, and *the ordering inverts*. Measured through
+  the production optimizer on 2026-08-15, at `w=512 q=75`: a 937.9 KB Cloudflare PNG delivered **39.5 KB**,
+  a 147.9 KB JPEG delivered **68.4 KB**, a 41.5 KB Pollinations JPEG delivered **9.6 KB**. Delivered weight
+  tracks how busy the *picture* is, not how heavy the source file was.
+- **Image transformations don't care either.** They are billed per cache miss, so a 30-card theme costs at
+  most 30 × 4 requested widths = 120 of them whichever lane drew it.
+- **Storage is the one meter it moves**, and `--blob-budget` in Step 5 is where you find out whether that
+  matters this run. At the last reading it did not.
+
+So there is nothing to trade off at the checkpoint. If `--blob-budget` ever says otherwise, that is a
+decision about *how many more themes to publish*, not about which candidate is the better drawing.
 
 ### Which lever: pick another provider, or change the words?
 
@@ -515,6 +540,7 @@ Abort the run and report. Do not improvise past any of these.
 | Schema failure you cannot resolve without dropping below 30 cards or off the pyramid | The theme is not viable as scoped. That is a human call. |
 | A `sourceUrl` you cannot make resolve for a subject you consider essential | Ditto. |
 | An image still failing after 2 re-prompt rounds on every provider | Take it to the checkpoint, named. |
+| `--blob-budget` warns that the store is past 80% of its allowance | Publish nothing further. Exceeding it produces no bill on this plan — it **cuts off access to the Blob store** until the 30-day window rolls, and a card whose optimized variant is not already cached then renders as its alt text. Report it: the levers are a plan change or removing bytes, and both are human calls. |
 | `DATABASE_URL` / `BLOB_READ_WRITE_TOKEN` missing | Report it; do not go hunting for credentials. |
 
 ## Never

--- a/src/features/pool/blob-budget.ts
+++ b/src/features/pool/blob-budget.ts
@@ -31,12 +31,28 @@
  * ceiling below is where it becomes urgent. The meter actually near its cap is
  * **image transformations at 60%**, and that one is indifferent to how heavy a
  * source image is: it is billed per cache MISS, so a 30-card theme costs at most
- * 30 x 4 requested widths = 120 transformations whichever lane drew it.
+ * 30 x 4 requested widths = 120 transformations whichever lane drew it. (Four,
+ * because `CardImage` renders at dim 110/200/256/512 and `next.config.ts` allows
+ * imageSizes 128/256/512 plus deviceSizes 640/1080, so 128/256/512/1080 are the
+ * only widths a card is ever asked for.)
+ *
+ * **This command does not watch that meter, and cannot.** It is a deployment
+ * fact rather than a store fact, with no read path from here — Vercel's usage
+ * API is dashboard-only. So the 60% figure is a dated observation, not something
+ * this will notice moving, and the place to check it is the team's usage page.
+ * Said out loud because a report that covers one meter well is exactly how the
+ * other one gets assumed instead of measured, which is what #79 was about.
+ *
+ * ── This number is a PLAN fact, and nothing here detects a plan change ───────
+ * The ceiling below is Hobby's. On Pro it becomes 5 GB with paid overage above
+ * it, at which point exceeding it is a bill rather than an outage and the 80%
+ * warning is measuring the wrong thing. Nothing in this process can see the
+ * plan, so the constant carries its date and this paragraph carries the caveat.
  *
  * ── Why this reads the STORE and not the pool ────────────────────────────────
  * `readPublishedImages` would be the cheaper source, and it under-reports.
  * `put()` adds a random suffix, so re-publishing a card writes a NEW object and
- * strands the old one: 403 objects against 390 cards, 1.02 MB of bytes nothing
+ * strands the old one: 403 objects against 390 cards, 1.07 MB of bytes nothing
  * points at, still charged. `list()` is the only view that sees them, so the
  * report reconciles the two and names the difference rather than hiding it.
  *
@@ -50,6 +66,16 @@
  * Decimal, because Vercel's dashboard is: it prints 31,363,297 bytes as
  * "31.36 MB / 1 GB". Using binary units here would put this report and the page
  * it has to be reconciled against 5% apart for no reason.
+ *
+ * ── Why the I/O is in here rather than in a sibling ─────────────────────────
+ * The repo's standing split is pure module + I/O module (`blank-frame.ts` /
+ * `blank-audit.ts`), and `pool-reads.ts` states the reason: importing the `db`
+ * singleton pulls `env.databaseUrl` in at MODULE LOAD, which fails in Vitest.
+ * That reason does not reach `@vercel/blob` — `list` reads its token when
+ * called, so importing it costs a test nothing, and the tests here construct no
+ * store at all. `readStoreObjects` takes an injectable `listImpl` for the same
+ * reason `auditPublishedImages` takes a `fetchImpl`, which is what actually
+ * buys the testability the split was for.
  */
 import { list } from "@vercel/blob";
 import { CARDS_PER_THEME } from "./seed-schema";
@@ -152,6 +178,9 @@ export function summariseWeights(sizes: readonly number[]): WeightSummary {
     count: sorted.length,
     totalBytes,
     meanBytes: Math.round(totalBytes / sorted.length),
+    // Lower median on an even count, rather than the mean of the middle two: it
+    // is a weight some real card actually has, and this report exists to be
+    // reconciled against individual objects.
     medianBytes: sorted[Math.floor((sorted.length - 1) / 2)],
     maxBytes: sorted[sorted.length - 1],
   };

--- a/src/features/pool/blob-budget.ts
+++ b/src/features/pool/blob-budget.ts
@@ -1,0 +1,237 @@
+/**
+ * How much of the Blob allowance has the pool spent, and how many themes are
+ * left? (#79)
+ *
+ * #79 asked whether Cloudflare SDXL's 14x-heavier cards are affordable, and
+ * observed that nobody had looked at current Blob usage against its allowance —
+ * "that number should come first: it may make this urgent or moot". This is the
+ * command that produces the number, made repeatable rather than a one-off
+ * dashboard visit, because the answer changes every time a theme publishes.
+ *
+ * ── What was measured, 2026-08-15 ────────────────────────────────────────────
+ * Team `selwyn-yeows-projects`, plan **Hobby** — which is the first correction
+ * #79 needed. The ticket assumed a card on file, so that "storage and bandwidth
+ * growth converts directly into money". It does not: Hobby is not billed for
+ * overage at all. Exceeding the Blob allowance **cuts off access to the store**
+ * until the 30-day window rolls, and exceeding the image-optimization allowance
+ * returns 402 for images not already cached, which renders as the `alt` text.
+ * So the currency here is a broken binder, not a bill — which is worse, and is
+ * why this is a command rather than a note.
+ *
+ *   meter                        used            Hobby allowance
+ *   Blob storage                 31.36 MB        1 GB          <- what this reports
+ *   Blob data transfer          102.32 MB        10 GB / 30d
+ *   Blob simple operations       1,833           10,000 / 30d
+ *   Blob advanced operations       215           2,000 / 30d
+ *   Image transformations        2,998           5,000 / 30d
+ *   Image cache reads            5,992           300,000 / 30d
+ *   Image cache writes          14,439           100,000 / 30d
+ *
+ * Storage is at 3% — so the weight question is real but not urgent, and the
+ * ceiling below is where it becomes urgent. The meter actually near its cap is
+ * **image transformations at 60%**, and that one is indifferent to how heavy a
+ * source image is: it is billed per cache MISS, so a 30-card theme costs at most
+ * 30 x 4 requested widths = 120 transformations whichever lane drew it.
+ *
+ * ── Why this reads the STORE and not the pool ────────────────────────────────
+ * `readPublishedImages` would be the cheaper source, and it under-reports.
+ * `put()` adds a random suffix, so re-publishing a card writes a NEW object and
+ * strands the old one: 403 objects against 390 cards, 1.02 MB of bytes nothing
+ * points at, still charged. `list()` is the only view that sees them, so the
+ * report reconciles the two and names the difference rather than hiding it.
+ *
+ * Reporting stranded bytes is where this stops — it never deletes. `del()` is
+ * free and irreversible, and the operator's response to a reported orphan should
+ * be to look at it, for the reason `url-check.ts` records: a checker whose
+ * findings are acted on automatically is a checker that can destroy good data on
+ * a bad measurement.
+ *
+ * ── Units ────────────────────────────────────────────────────────────────────
+ * Decimal, because Vercel's dashboard is: it prints 31,363,297 bytes as
+ * "31.36 MB / 1 GB". Using binary units here would put this report and the page
+ * it has to be reconciled against 5% apart for no reason.
+ */
+import { list } from "@vercel/blob";
+import { CARDS_PER_THEME } from "./seed-schema";
+
+/**
+ * Vercel's Hobby allowance for Blob storage size, in decimal bytes.
+ *
+ * Read off the team's own usage page (2026-08-15) rather than the docs, which
+ * price the meter "Regional" and never state the Hobby number. It is a plan
+ * fact, not a project one, so it changes when the plan changes — the day this
+ * team goes Pro it becomes 5 GB with paid overage above, and the failure mode
+ * stops being an outage and starts being a bill.
+ */
+export const BLOB_STORAGE_CEILING_BYTES = 1_000_000_000;
+
+/**
+ * Where the report stops being reassuring, as a fraction of the ceiling.
+ *
+ * 80% leaves ~200 MB, which is eight Cloudflare-weight themes — enough warning
+ * to act during a run rather than after the one that failed. A line at the
+ * ceiling itself would only ever describe an outage that had already happened.
+ */
+export const WARN_FRACTION = 0.8;
+
+/**
+ * Bytes as Vercel's dashboard prints them — decimal, two decimals, so a figure
+ * from this report can be read straight across to the usage page.
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes >= 1_000_000_000) return `${(bytes / 1_000_000_000).toFixed(2)} GB`;
+  if (bytes >= 1_000_000) return `${(bytes / 1_000_000).toFixed(2)} MB`;
+  if (bytes >= 1_000) return `${(bytes / 1_000).toFixed(2)} KB`;
+  return `${bytes} B`;
+}
+
+/** One object in the Blob store, as `list()` reports it. */
+export interface StoredObject {
+  pathname: string;
+  url: string;
+  size: number;
+}
+
+/** The shape of a set of weights — a mean alone hides the distribution. */
+export interface WeightSummary {
+  count: number;
+  totalBytes: number;
+  meanBytes: number;
+  medianBytes: number;
+  maxBytes: number;
+}
+
+/**
+ * How many more themes one lane's output fits in the remaining space.
+ *
+ * `null` where the lane declares no measured weight. Same discipline as
+ * `provenance.model`: a fact nobody has witnessed is reported as absent, never
+ * back-filled from a neighbouring lane's number.
+ */
+export interface LaneProjection {
+  id: string;
+  perCardBytes: number | null;
+  themes: number | null;
+}
+
+export interface BlobBudget {
+  /** Every object in the store, orphans included — this is what is charged. */
+  store: WeightSummary;
+  /** Objects no published card points at. Reported, never deleted. */
+  orphans: { count: number; bytes: number };
+  ceilingBytes: number;
+  freeBytes: number;
+  usedFraction: number;
+  overWarnLine: boolean;
+  projections: LaneProjection[];
+}
+
+/** A lane, as far as this module needs to know it. */
+export interface WeighedLane {
+  id: string;
+  typicalCardBytes?: number;
+}
+
+export interface BlobBudgetInput {
+  objects: readonly StoredObject[];
+  /** `imageUrl` of every published card — what makes an object non-orphaned. */
+  liveUrls: ReadonlySet<string>;
+  lanes: readonly WeighedLane[];
+  cardsPerTheme?: number;
+  ceilingBytes?: number;
+}
+
+/** Count, total, mean, median and max of a set of encoded sizes. Pure. */
+export function summariseWeights(sizes: readonly number[]): WeightSummary {
+  if (sizes.length === 0) {
+    return { count: 0, totalBytes: 0, meanBytes: 0, medianBytes: 0, maxBytes: 0 };
+  }
+  const sorted = [...sizes].sort((a, b) => a - b);
+  const totalBytes = sorted.reduce((n, s) => n + s, 0);
+  return {
+    count: sorted.length,
+    totalBytes,
+    meanBytes: Math.round(totalBytes / sorted.length),
+    medianBytes: sorted[Math.floor((sorted.length - 1) / 2)],
+    maxBytes: sorted[sorted.length - 1],
+  };
+}
+
+/**
+ * Whole themes that fit in `freeBytes` at a given per-card weight.
+ *
+ * Whole, because a 30-card publish is the unit: a run that fills the store at
+ * card 17 has left a short theme, which `comparePoolShape` reports as a
+ * publishing fault and a child sees as an unreachable set-completion.
+ */
+export function themesThatFit(
+  freeBytes: number,
+  perCardBytes: number,
+  cardsPerTheme: number = CARDS_PER_THEME,
+): number {
+  const perTheme = perCardBytes * cardsPerTheme;
+  if (perTheme <= 0 || freeBytes <= 0) return 0;
+  return Math.floor(freeBytes / perTheme);
+}
+
+/** Weigh the store against the allowance and project each lane's headroom. Pure. */
+export function buildBlobBudget(input: BlobBudgetInput): BlobBudget {
+  const ceilingBytes = input.ceilingBytes ?? BLOB_STORAGE_CEILING_BYTES;
+  const cardsPerTheme = input.cardsPerTheme ?? CARDS_PER_THEME;
+
+  const store = summariseWeights(input.objects.map((o) => o.size));
+  const stranded = input.objects.filter((o) => !input.liveUrls.has(o.url));
+
+  // Floored at zero: past the ceiling the useful statement is "no room", and a
+  // negative would print as a negative theme count.
+  const freeBytes = Math.max(0, ceilingBytes - store.totalBytes);
+  const usedFraction = ceilingBytes > 0 ? store.totalBytes / ceilingBytes : 0;
+
+  return {
+    store,
+    orphans: { count: stranded.length, bytes: stranded.reduce((n, o) => n + o.size, 0) },
+    ceilingBytes,
+    freeBytes,
+    usedFraction,
+    overWarnLine: usedFraction > WARN_FRACTION,
+    projections: input.lanes.map((lane) => ({
+      id: lane.id,
+      perCardBytes: lane.typicalCardBytes ?? null,
+      themes:
+        lane.typicalCardBytes === undefined
+          ? null
+          : themesThatFit(freeBytes, lane.typicalCardBytes, cardsPerTheme),
+    })),
+  };
+}
+
+/** One page of `list()`, as much of it as this module reads. */
+export interface StorePage {
+  blobs: readonly StoredObject[];
+  cursor?: string;
+}
+
+export type ListImpl = (opts: { limit: number; cursor?: string }) => Promise<StorePage>;
+
+/**
+ * Every object in the store, following the cursor.
+ *
+ * Paginated rather than single-page: 403 objects against a 1000-object page
+ * means a single read is right today and silently truncating on the run that
+ * matters — and a truncated read under-reports usage, which is the one direction
+ * this report must never be wrong in.
+ *
+ * `list()` is an advanced operation, so this costs one per page against an
+ * allowance of 2,000 per 30 days. Cheap enough to run before every bake-off,
+ * which is what the runbook now asks for.
+ */
+export async function readStoreObjects(listImpl: ListImpl = list): Promise<StoredObject[]> {
+  const objects: StoredObject[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = await listImpl({ limit: 1000, cursor });
+    objects.push(...page.blobs.map((b) => ({ pathname: b.pathname, url: b.url, size: b.size })));
+    cursor = page.cursor;
+  } while (cursor);
+  return objects;
+}

--- a/src/features/pool/image.ts
+++ b/src/features/pool/image.ts
@@ -27,6 +27,22 @@ import { contentTypeFor, readImageSize } from "./image-size";
  *
  * Sniffing rather than trusting a caller-supplied type is deliberate: the bytes
  * are the only thing that cannot be wrong.
+ *
+ * ── No re-encoding here, and it is not only about FR8 (#79) ──────────────────
+ * Cloudflare SDXL's cards are ~10x heavier than Pollinations', and the obvious
+ * remedy is to JPEG-encode on the way past. It does not happen here, and the
+ * first reason is the rule: publish ships the bytes a parent APPROVED, so
+ * re-encoding at this line hands a child bytes no one reviewed. Re-encoding at
+ * REVIEW time would keep the rule intact and is the better change if one is ever
+ * needed.
+ *
+ * The second reason is that none is needed yet, which is the measurement rather
+ * than the principle. `blob-budget.ts` weighed the store against its allowance:
+ * 3% spent, 39 more Cloudflare-weight themes of room. And the child was never
+ * downloading these bytes anyway — every card renders through `next/image`, so a
+ * 937.9 KB PNG reaches a browser as a 39.5 KB WebP. An encoder would be a new
+ * dependency (#67 kept this seam dependency-free) bought to fix a number nobody
+ * is paying.
  */
 export async function uploadImage(
   key: string,

--- a/src/features/pool/providers/ai-horde.ts
+++ b/src/features/pool/providers/ai-horde.ts
@@ -243,6 +243,12 @@ export function aiHorde(opts: AiHordeOptions = {}): ImageProvider {
     // See the pacing note: the limit is per-IP across the whole API.
     minIntervalMs: 1_200,
     concurrency: 1,
+    // No `typicalCardBytes`, deliberately (#79). It would be a WebP number, and
+    // the twelve images this hatch has ever delivered came from one model on one
+    // day at one worker's encoder settings — too thin to project a store budget
+    // from, and getting a real sample means another 30-45 minute queue wait that
+    // #74 showed is as likely to be dropped as answered. `blob-budget.ts` reports
+    // it as UNMEASURED, which is the true statement.
     requiredEnv: ["AIHORDE_API_KEY"],
     isConfigured: () => Boolean(process.env.AIHORDE_API_KEY),
 

--- a/src/features/pool/providers/cloudflare-sdxl.ts
+++ b/src/features/pool/providers/cloudflare-sdxl.ts
@@ -38,6 +38,32 @@
  * filenames, so adding one invalidates a folder of reviewed images: a partial
  * fix, at that price, stacked on top of the real one.
  *
+ * ── Weight: ~826 KB a card, and why it ships anyway (#79) ───────────────────
+ * This lane returns PNG at roughly 10x Pollinations' JPEG — 826 KB against the
+ * published pool's measured 77.8 KB mean. #79 asked who pays for that, on two
+ * counts, and measurement answered both.
+ *
+ * The CHILD does not. Every card surface renders through `next/image`, so a
+ * browser downloads a re-encoded WebP at the width it asked for and never the
+ * stored bytes. Through the production optimizer at `w=512 q=75`, 2026-08-15:
+ * a 937.9 KB PNG from here delivered 39.5 KB, a 147.9 KB JPEG delivered 68.4 KB,
+ * a 41.5 KB Pollinations JPEG delivered 9.6 KB. The ordering INVERTS — delivered
+ * weight tracks how busy the picture is, not how heavy the source was.
+ *
+ * The STORE does, and `blob-budget.ts` says by how much: 39 more themes from
+ * this lane against 415 from Pollinations, out of the same 968 MB. That is a
+ * real difference and not yet a constraint, so nothing here re-encodes.
+ *
+ * There is also no cheaper thing to ask THIS model for. Measured against the
+ * live endpoint on the same day: `Accept: image/jpeg` is ignored (PNG back), and
+ * an invented `response_format: "jpeg"` is ignored too — SDXL's schema has no
+ * output-format parameter and the endpoint drops what it does not know rather
+ * than refusing it, so an unrecognised key looks like it worked. The lever that
+ * DOES exist is a different model: `@cf/bytedance/stable-diffusion-xl-lightning`
+ * answers **JPEG** at 88-148 KB from the identical request. It is not registered
+ * here, because a model swap is a quality decision that belongs to a bake-off
+ * and to the roster (#69), not to a file-size ticket.
+ *
  * ── Provenance ───────────────────────────────────────────────────────────────
  * Cloudflare reports no serving-model header, so `model` comes back undefined
  * and the sidecar records only what was requested. That is an honest gap, and
@@ -67,6 +93,9 @@ export function cloudflareSdxl(opts: HttpAdapterOptions = {}): ImageProvider {
     },
     minIntervalMs: 100,
     concurrency: 4,
+    // #66's six-subject average; corroborated 2026-08-15 at 712-938 KB across
+    // four fresh generations. See the weight note above for why this stays.
+    typicalCardBytes: 826_000,
     requiredEnv: ["CLOUDFLARE_ACCOUNT_ID", "CLOUDFLARE_API_TOKEN"],
     isConfigured: () =>
       Boolean(process.env.CLOUDFLARE_ACCOUNT_ID && process.env.CLOUDFLARE_API_TOKEN),

--- a/src/features/pool/providers/pollinations.ts
+++ b/src/features/pool/providers/pollinations.ts
@@ -95,8 +95,16 @@ export function pollinations(opts: HttpAdapterOptions = {}): ImageProvider {
     minIntervalMs: 15_000,
     concurrency: 1,
     // The published pool's own mean: 390 cards, every one of them drawn by this
-    // lane, weighed in Blob 2026-08-15 (median 77.2 KB, max 136.3 KB). A better
-    // witness than any fresh sample, because it is the whole population.
+    // lane, weighed in Blob 2026-08-15 (median 77.2 KB, max 136.3 KB).
+    //
+    // A population rather than a sample, which is its strength and its catch.
+    // #64 caught this host swapping models underneath a fixed prompt, so those
+    // 390 cards span at least two of them and this is the mean of an era rather
+    // than of what the lane returns today — fresh generations on the same day
+    // came back at 41.5 and 44.1 KB, and #79's own figure was 57 KB. Kept as the
+    // HEAVIEST of those numbers on purpose: a headroom projection that
+    // over-estimates per-card weight under-estimates how many themes fit, which
+    // is the safe direction to be wrong in.
     typicalCardBytes: 77_800,
     // Nothing to configure: the anonymous tier needs no credential, and the
     // credentialled one is behind a paywall this map may not cross (#72).

--- a/src/features/pool/providers/pollinations.ts
+++ b/src/features/pool/providers/pollinations.ts
@@ -94,6 +94,10 @@ export function pollinations(opts: HttpAdapterOptions = {}): ImageProvider {
     // A serial cap with an upsell attached, not a tunable rate — see above.
     minIntervalMs: 15_000,
     concurrency: 1,
+    // The published pool's own mean: 390 cards, every one of them drawn by this
+    // lane, weighed in Blob 2026-08-15 (median 77.2 KB, max 136.3 KB). A better
+    // witness than any fresh sample, because it is the whole population.
+    typicalCardBytes: 77_800,
     // Nothing to configure: the anonymous tier needs no credential, and the
     // credentialled one is behind a paywall this map may not cross (#72).
     requiredEnv: [],

--- a/src/features/pool/providers/provider.ts
+++ b/src/features/pool/providers/provider.ts
@@ -110,6 +110,23 @@ export interface ImageProvider {
   readonly minIntervalMs: number;
   /** Workers in this provider's lane. Not hashed. */
   readonly concurrency: number;
+  /**
+   * Encoded bytes an ordinary 768x768 card from this lane weighs. Not hashed,
+   * for `minIntervalMs`'s reason twice over: it does not change the request, and
+   * it is an OBSERVATION of the response rather than an instruction to it.
+   *
+   * Declared here so `blob-budget.ts` projects the store's remaining headroom
+   * from the roster rather than from a table that has to be edited alongside it
+   * (#79). Every adapter that declares one records the measurement and its date
+   * in its own header; a lane nobody has weighed leaves it undefined and is
+   * reported as UNMEASURED, never given a neighbouring lane's number.
+   *
+   * Approximate by construction — a diffusion model's output size varies with
+   * subject complexity by roughly a factor of two either way — so it is only
+   * ever used for an order-of-magnitude projection, never for a check that
+   * refuses anything.
+   */
+  readonly typicalCardBytes?: number;
   /** True when this provider's credentials are present in the environment. */
   isConfigured(): boolean;
   /** Env vars a caller must set to configure it — used by the startup error. */

--- a/tests/blob-budget.test.ts
+++ b/tests/blob-budget.test.ts
@@ -9,8 +9,9 @@ import {
   themesThatFit,
   type StoredObject,
 } from "@/features/pool/blob-budget";
-
-const CARDS_PER_THEME = 30;
+// The real one, not a local 30: a projection asserted against a copy of the
+// constant would keep passing after the pyramid changed underneath it.
+import { CARDS_PER_THEME } from "@/features/pool/seed-schema";
 
 /** A store object the way `list()` reports one. */
 function obj(pathname: string, size: number, suffix = "x"): StoredObject {

--- a/tests/blob-budget.test.ts
+++ b/tests/blob-budget.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  BLOB_STORAGE_CEILING_BYTES,
+  WARN_FRACTION,
+  buildBlobBudget,
+  formatBytes,
+  readStoreObjects,
+  summariseWeights,
+  themesThatFit,
+  type StoredObject,
+} from "@/features/pool/blob-budget";
+
+const CARDS_PER_THEME = 30;
+
+/** A store object the way `list()` reports one. */
+function obj(pathname: string, size: number, suffix = "x"): StoredObject {
+  return { pathname, size, url: `https://store.example/${pathname}-${suffix}` };
+}
+
+describe("weight summary", () => {
+  it("reports the shape of a set of weights, not just their total", () => {
+    // A mean alone hides the distribution, and the distribution is the thing that
+    // decides whether a projection is worth trusting.
+    const s = summariseWeights([10, 20, 30, 40, 900]);
+    expect(s.count).toBe(5);
+    expect(s.totalBytes).toBe(1000);
+    expect(s.meanBytes).toBe(200);
+    expect(s.medianBytes).toBe(30);
+    expect(s.maxBytes).toBe(900);
+  });
+
+  it("summarises an empty pool without dividing by zero", () => {
+    expect(summariseWeights([])).toEqual({
+      count: 0,
+      totalBytes: 0,
+      meanBytes: 0,
+      medianBytes: 0,
+      maxBytes: 0,
+    });
+  });
+});
+
+describe("byte formatting", () => {
+  it("uses DECIMAL units, so a figure reads across to Vercel's usage page", () => {
+    // The store held 31,363,297 bytes on 2026-08-15 and the dashboard printed
+    // "31.36 MB / 1 GB". Binary units would print 29.91 and invite an argument
+    // about a 5% discrepancy that does not exist.
+    expect(formatBytes(31_363_297)).toBe("31.36 MB");
+    expect(formatBytes(BLOB_STORAGE_CEILING_BYTES)).toBe("1.00 GB");
+  });
+});
+
+describe("how many more themes fit", () => {
+  it("counts WHOLE themes — half a theme is not a theme you can publish", () => {
+    // 2.5 themes' worth of room is two themes and a refusal, because a whole
+    // theme is the publish unit and a run that stops at card 17 has failed.
+    expect(themesThatFit(2_500, 100, 10)).toBe(2);
+  });
+
+  it("is zero when the next theme does not fit, never negative", () => {
+    expect(themesThatFit(100, 826_000, CARDS_PER_THEME)).toBe(0);
+    expect(themesThatFit(-1, 826_000, CARDS_PER_THEME)).toBe(0);
+  });
+
+  it("separates the two lanes by the factor #79 is about", () => {
+    // The measured per-card weights: the published pool's own mean against
+    // Cloudflare SDXL's. Same free space, an order of magnitude apart in themes.
+    const free = 968_600_000;
+    expect(themesThatFit(free, 77_800, CARDS_PER_THEME)).toBeGreaterThan(400);
+    expect(themesThatFit(free, 826_000, CARDS_PER_THEME)).toBeLessThan(45);
+  });
+});
+
+describe("blob budget", () => {
+  const lanes = [
+    { id: "pollinations", typicalCardBytes: 77_800 },
+    { id: "cloudflare-sdxl", typicalCardBytes: 826_000 },
+  ];
+
+  it("measures the STORE, so bytes no card points at are still bytes stored", () => {
+    // The reason this reads `list()` rather than summing the DB's image URLs:
+    // a re-publish leaves the old object behind, and the allowance is charged for
+    // it either way. Summing what the pool references would under-report.
+    const budget = buildBlobBudget({
+      objects: [obj("cards/a.jpg", 100), obj("cards/a.jpg", 400, "old"), obj("cards/b.jpg", 500)],
+      liveUrls: new Set(["https://store.example/cards/a.jpg-x", "https://store.example/cards/b.jpg-x"]),
+      lanes,
+      cardsPerTheme: CARDS_PER_THEME,
+    });
+    expect(budget.store.count).toBe(3);
+    expect(budget.store.totalBytes).toBe(1000);
+    expect(budget.orphans).toEqual({ count: 1, bytes: 400 });
+  });
+
+  it("projects a lane's remaining themes from its own declared weight", () => {
+    const budget = buildBlobBudget({
+      objects: [obj("cards/a.jpg", 31_363_297)],
+      liveUrls: new Set(["https://store.example/cards/a.jpg-x"]),
+      lanes,
+      cardsPerTheme: CARDS_PER_THEME,
+    });
+    const sdxl = budget.projections.find((p) => p.id === "cloudflare-sdxl")!;
+    expect(sdxl.perCardBytes).toBe(826_000);
+    expect(sdxl.themes).toBe(themesThatFit(budget.freeBytes, 826_000, CARDS_PER_THEME));
+  });
+
+  it("says UNMEASURED for a lane that declares no weight, rather than guessing one", () => {
+    // Same discipline as `provenance.model`: a provider that witnesses nothing
+    // gets a null, never a number back-filled from something adjacent.
+    const budget = buildBlobBudget({
+      objects: [obj("cards/a.jpg", 100)],
+      liveUrls: new Set(),
+      lanes: [{ id: "ai-horde" }],
+      cardsPerTheme: CARDS_PER_THEME,
+    });
+    expect(budget.projections).toEqual([{ id: "ai-horde", perCardBytes: null, themes: null }]);
+  });
+
+  it("raises the warning line before the ceiling, not at it", () => {
+    // A report that only speaks up once the store is full is a report about an
+    // outage. The whole point is to be told during the run BEFORE the one that
+    // fails.
+    const nearly = Math.ceil(BLOB_STORAGE_CEILING_BYTES * WARN_FRACTION) + 1;
+    const budget = buildBlobBudget({
+      objects: [obj("cards/a.jpg", nearly)],
+      liveUrls: new Set(),
+      lanes,
+      cardsPerTheme: CARDS_PER_THEME,
+    });
+    expect(budget.overWarnLine).toBe(true);
+    expect(budget.usedFraction).toBeGreaterThan(WARN_FRACTION);
+    expect(budget.freeBytes).toBe(BLOB_STORAGE_CEILING_BYTES - nearly);
+  });
+
+  it("does not report negative free space once the ceiling is passed", () => {
+    const budget = buildBlobBudget({
+      objects: [obj("cards/a.jpg", BLOB_STORAGE_CEILING_BYTES * 2)],
+      liveUrls: new Set(),
+      lanes,
+      cardsPerTheme: CARDS_PER_THEME,
+    });
+    expect(budget.freeBytes).toBe(0);
+    expect(budget.projections.every((p) => p.themes === 0)).toBe(true);
+  });
+});
+
+describe("reading the store", () => {
+  it("follows the cursor, because one page is not the store", () => {
+    // 403 objects today against a 1000-object page, so a single-page read would
+    // have been right by luck and wrong on the run that mattered.
+    const pages = [
+      { blobs: [{ pathname: "a", url: "u/a", size: 1 }], cursor: "next" },
+      { blobs: [{ pathname: "b", url: "u/b", size: 2 }], cursor: undefined },
+    ];
+    let n = 0;
+    return readStoreObjects(async () => pages[n++]).then((objects) => {
+      expect(objects).toEqual([
+        { pathname: "a", url: "u/a", size: 1 },
+        { pathname: "b", url: "u/b", size: 2 },
+      ]);
+      expect(n).toBe(2);
+    });
+  });
+});

--- a/tests/contracts/image-provider-contract.ts
+++ b/tests/contracts/image-provider-contract.ts
@@ -138,17 +138,24 @@ export function runImageProviderContract(label: string, makeProvider: MakeProvid
 
     it("declares a card weight that is a picture's weight, or none at all (#79)", () => {
       // `typicalCardBytes` feeds `blob-budget.ts`'s projection, so a wrong one
-      // silently mis-states how many themes are left. The two ends worth pinning
-      // are the ones that would make it nonsense rather than merely stale: a
-      // weight BELOW the blank-frame floor describes an image with no subject in
-      // it, and one above 16 MB is past what Vercel will even cache. Undefined
-      // stays legal — an unweighed lane reports UNMEASURED, which is true.
+      // silently mis-states how many themes are left. Both ends are DERIVED
+      // rather than picked, because the useful assertion is "this is the weight
+      // of an encoded card" and not "this is the number someone typed":
+      //
+      //   below — the blank-frame floor. Under it, the declared weight
+      //   describes an image the seam would itself refuse as carrying no
+      //   subject (#78).
+      //   above — the card's own pixels at 4 bytes each, i.e. uncompressed
+      //   RGBA. Every codec here exists to beat that, so a weight above it is
+      //   not a compressed image of anything.
+      //
+      // Undefined stays legal — an unweighed lane reports UNMEASURED, which is
+      // a true statement rather than a gap to be filled.
       const { typicalCardBytes } = makeProvider();
       if (typicalCardBytes === undefined) return;
-      expect(typicalCardBytes).toBeGreaterThan(
-        MIN_BYTES_PER_PIXEL * CARD_SIZE.width * CARD_SIZE.height,
-      );
-      expect(typicalCardBytes).toBeLessThan(16_000_000);
+      const pixels = CARD_SIZE.width * CARD_SIZE.height;
+      expect(typicalCardBytes).toBeGreaterThan(MIN_BYTES_PER_PIXEL * pixels);
+      expect(typicalCardBytes).toBeLessThan(pixels * 4);
     });
   });
 }

--- a/tests/contracts/image-provider-contract.ts
+++ b/tests/contracts/image-provider-contract.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { readImageSize } from "@/features/pool/image-size";
-import { looksBlank } from "@/features/pool/blank-frame";
+import { MIN_BYTES_PER_PIXEL, looksBlank } from "@/features/pool/blank-frame";
 import {
   CARD_SIZE,
   ProviderRetryable,
@@ -134,6 +134,21 @@ export function runImageProviderContract(label: string, makeProvider: MakeProvid
       const provider = makeProvider();
       expect(provider.minIntervalMs).toBeGreaterThanOrEqual(0);
       expect(provider.concurrency).toBeGreaterThanOrEqual(1);
+    });
+
+    it("declares a card weight that is a picture's weight, or none at all (#79)", () => {
+      // `typicalCardBytes` feeds `blob-budget.ts`'s projection, so a wrong one
+      // silently mis-states how many themes are left. The two ends worth pinning
+      // are the ones that would make it nonsense rather than merely stale: a
+      // weight BELOW the blank-frame floor describes an image with no subject in
+      // it, and one above 16 MB is past what Vercel will even cache. Undefined
+      // stays legal — an unweighed lane reports UNMEASURED, which is true.
+      const { typicalCardBytes } = makeProvider();
+      if (typicalCardBytes === undefined) return;
+      expect(typicalCardBytes).toBeGreaterThan(
+        MIN_BYTES_PER_PIXEL * CARD_SIZE.width * CARD_SIZE.height,
+      );
+      expect(typicalCardBytes).toBeLessThan(16_000_000);
     });
   });
 }


### PR DESCRIPTION
Resolves #79. Part of #61.

**Ship Cloudflare-weight cards as-is. Re-encode nothing.** Both of the ticket's premises turned out to be false, and measuring them is what settles it. Full gist on the [issue](https://github.com/nywleswoey/kids-collection/issues/79#issuecomment-5301627929).

## The two premises, corrected

**"an account that *does* have a payment method, so growth converts directly into money."** The team is on **Hobby**. Overage is not billed at all — it **cuts off access to the store** until the 30-day window rolls, and a card whose optimized variant is not already cached renders as its `alt` text. A broken binder, not a bill.

**"~830 KB per card face, on whatever connection a seven-year-old happens to be on."** The child was never downloading these bytes. Every card surface renders through `next/image` (`CardImage` is the only component that draws card art; no raw `<img>` anywhere). Through the **production** optimizer at `q=75`, two runs:

| | source | w=512 delivered |
|---|---|---|
| `cloudflare-sdxl` | 937.9 / 924.7 KB PNG | **39.5 / 32.2 KB** |
| `stable-diffusion-xl-lightning` | 147.9 / 108.7 KB JPEG | 68.4 / 44.2 KB |
| `pollinations` | 41.5 / 44.1 KB JPEG | 9.6 / 10.5 KB |

**The ordering inverts, both runs** — an ~8× heavier source delivers ~30% *lighter*. Delivered weight tracks how busy the picture is, not how heavy the file was, so the 14× survives the optimizer neither as bytes nor as the correlation the worry rested on.

## Is a limit being approached? Yes — not the one the ticket named

Measured 2026-08-15: Blob storage **31.36 MB / 1 GB (3.1%)**, data transfer 1.0%, advanced ops 11%. The meter near its cap is **image transformations, 2,998 / 5,000 (60%)** — and that one is *indifferent to source weight*, being billed per cache MISS: a 30-card theme costs at most 30 × 4 requested widths = 120 whichever lane drew it.

**Ceiling: 968 MB free ⇒ ~39 more all-Cloudflare themes, or ~415 Pollinations-weight ones.** At 80% the command exits non-zero and the runbook's *Hard stops* row says publish nothing further and report.

## "Ask Cloudflare for less" — closed by measurement

`Accept: image/jpeg` and an invented `response_format` are both **silently dropped** (SDXL has no output-format parameter; the endpoint ignores unknown keys, so a wrong one returns 200 looking successful). The lever that exists is a **model**: `@cf/bytedance/stable-diffusion-xl-lightning` answers **JPEG at 88–107 KB** — while its `content-type` still claims `image/png`, one more reason `finishGeneration` sniffs bytes. **Not registered**: a model swap is a quality decision belonging to a bake-off and to the roster (#69).

## What's in the diff

- **`pnpm seed --blob-budget`** (`src/features/pool/blob-budget.ts`) — read-only. Reads the **store** via `list()`, not the pool's image URLs, which found **403 objects for 390 cards — 13 stranded, 1.07 MB**: `put()` adds a random suffix, so re-publishing writes a *new* object and the allowance is charged for both. Reported, never deleted. Standalone rather than in-band on `--sync` — the opposite of `comparePoolShape`'s choice, for the opposite reason.
- **`typicalCardBytes`** on the provider port — outside `params` and unhashed, for `minIntervalMs`'s reason twice over: it does not change the request, and it is an observation of the response. AI Horde declares none and reports **UNMEASURED**, the same discipline as a `null` `model`.
- **`pnpm prototype:79 --delivered | --steer`** — the evidence above, reproducible, on this map's precedent (`prototype-81-frames`, `prototype-74-aihorde`).
- Runbook Step 5 (pre-flight), Step 7 (weight does **not** change the pick), Hard stops; `CONTEXT.md`; a contract-suite bound on any declared weight, derived from the blank-frame floor and uncompressed RGBA rather than typed.
- `image.ts` records why a re-encode is not there, rule first: publishing re-encoded bytes hands a child bytes no one approved (Inc24 FR8). At **review** time it would keep the rule intact — and would cost an image dependency this repo does not have and #67 deliberately kept out.

## Notes for review

- The third commit is the two-axis review's own findings applied, including the one both axes reached: the settling measurement lived only in prose, so it is now a prototype that reproduces it.
- ⚠️ `pollinations`' declared 77.8 KB is the published pool's *mean*, and #64 established that pool spans at least two models — so it is the mean of an era, not of today's output (fresh samples: 41.5 / 44.1 KB). Kept as the heaviest candidate: over-estimating per-card weight under-estimates how many themes fit, the safe direction.
- `--blob-budget` covers **storage only**, and says so on every run. Image transformations cannot be read from the CLI, and the ceiling is a hardcoded *plan* fact nothing detects a change to.

Load-bearing invariants untouched: `reviewKey` unchanged, publish still ships the reviewed bytes, 768×768 unchanged, no `--allow-*` flag involved. `pnpm typecheck` clean; **565 tests pass** (11 new).
