### PR TITLE
Move two CI traps out of a closed issue and beside the code they constrain (#95)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,27 @@
 #
 # This file only *supplies* checks. What makes them binding is branch protection
 # on `main`, which is a repository setting rather than anything committed here.
-# Until that is switched on, this workflow reports and nothing more.
+# It has been on since 2026-08-09: repository ruleset `main protection`, active,
+# requiring a pull request and exactly two status checks — `fast-gate` and
+# `pg-gate`, the two job ids below.
+#
+# Those two are the ONLY checks that may ever be required, and the constraint
+# runs in both directions: renaming a job detaches the rule from its check (see
+# the note on the job ids below), and adding a third check to the ruleset is a
+# claim that the check can go red.
+#
+# In particular, `Vercel Preview Comments` must NEVER become a required check.
+# It is not merely redundant — it cannot fail. #23 broke each gate on purpose,
+# one breakage per commit, and Preview Comments reported `success` on ALL SIX of
+# those deliberately-broken commits: a failing unit assertion, a failing
+# property, a type error, a module-scope throw that broke the production build,
+# a failing `*.pg.test.ts`, and an `include` glob pointed at a dead suffix. It
+# reports on whether Vercel managed to post a comment, not on whether anything
+# in the tree works. Requiring it would add a required check that is green by
+# construction — "something checked" standing in for nothing having been
+# checked, which is the precise lie this whole file exists to stop, wearing a
+# green tick instead of a missing one. Fuller writeup lives in
+# `Product-Definition/technical-environment.md`, *Enforcement status*.
 #
 # No secrets, deliberately. The repository is public, and every gate below still
 # passes with the environment completely empty. There are exactly two `env:`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
+    "//": "⚠️ Never add --passWithNoTests to test, test:pg or test:providers. Vitest failing a zero-file run is load-bearing: a suite that passes while running nothing is indistinguishable from a real green. Full reasoning and evidence in vitest.config.ts.",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:pg": "vitest run --config vitest.pg.config.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,24 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    // ⚠️ `--passWithNoTests` must NEVER be added — not here as
+    // `passWithNoTests: true`, and not to the `test`, `test:pg` or
+    // `test:providers` scripts in package.json. Vitest's default is to FAIL a
+    // run that matches no files, and that default is load-bearing rather than
+    // incidental: #23 broke every gate on purpose to prove the harness honest,
+    // and one of the six breakages was pointing an `include` glob at a dead
+    // suffix, which duly reddened the check with `No test files found`. With
+    // the flag set, that same run goes green having executed nothing.
+    //
+    // This is not a hypothetical failure mode. `numRuns: NaN` already produced
+    // 321 passing tests that checked nothing — fast-check ran each property
+    // zero times and reported a pass — which is why tests/setup.ts now throws
+    // on a malformed FC_NUM_RUNS rather than falling back to a default.
+    //
+    // A suite that passes while running nothing is indistinguishable from a
+    // real green, and it is strictly worse than having no CI: it converts
+    // "nobody checked" into "something checked", which is a claim someone will
+    // rely on. That is the failure #23 and #25 exist to prevent.
     include: ["tests/**/*.test.ts"],
     // Property-search depth only; see tests/setup.ts. Nothing here needs a
     // database — that is vitest.pg.config.ts's job.

--- a/vitest.live.config.ts
+++ b/vitest.live.config.ts
@@ -25,6 +25,10 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    // ⚠️ Never add `--passWithNoTests`/`passWithNoTests: true` here either.
+    // Not a CI gate, but the same lie: this runner's whole point is that it
+    // reports what it skipped instead of passing on an empty set. Reasoning in
+    // vitest.config.ts.
     include: ["tests-live/**/*.live.test.ts"],
     setupFiles: ["./tests-live/setup.ts"],
     // A single 768x768 generation can take 30s on a loaded free tier, and a

--- a/vitest.pg.config.ts
+++ b/vitest.pg.config.ts
@@ -17,6 +17,8 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    // ⚠️ Never add `--passWithNoTests`/`passWithNoTests: true` here either —
+    // this glob backs a *required* check. Reasoning in vitest.config.ts.
     include: ["tests-pg/**/*.pg.test.ts"],
     setupFiles: ["./tests-pg/setup.ts"],
     fileParallelism: false, // shared DB → run files serially


### PR DESCRIPTION
Closes #95.

#45's *Cautions, not tasks* section carried two prohibitions whose only home outside that issue was one paragraph in `Product-Definition/technical-environment.md` — which nobody editing `package.json` or `ci.yml` has reason to open. Both now sit beside the thing they govern, carrying the evidence rather than just the prohibition.

## `--passWithNoTests` must never be added

Vitest failing a zero-file run is load-bearing, not incidental. One of #23's six deliberate breakages was an `include` glob pointed at a dead suffix, and it reddened the check with `No test files found`. Re-verified on this tree:

| run | exit |
|---|---|
| `vitest run 'tests/**/*.nosuchsuffix.ts'` | `1` — `No test files found` |
| same, `--passWithNoTests` | `0`, having executed nothing |

Nor is the failure hypothetical: `numRuns: NaN` already produced **321 passing tests that checked nothing**, which is why `tests/setup.ts` throws on a malformed `FC_NUM_RUNS` instead of falling back.

Recorded at:
- `vitest.config.ts` — the full reasoning, on the `include` glob that makes an empty match possible
- `vitest.pg.config.ts` — pointer; its glob backs a *required* check
- `vitest.live.config.ts` — pointer; not a gate, but the runner's whole point is reporting what it skipped rather than passing on an empty set
- `package.json` — a `//` key on the scripts block. JSON has no comments and this is the documented convention, and the scripts are where the flag would actually be typed. It shows up in `pnpm run`, which is fine.

## `Vercel Preview Comments` must never become a required check

It reported `success` on **all six** of #23's deliberately-broken commits — failing unit assertion, failing property, type error, module-scope throw that broke the production build, failing `*.pg.test.ts`, and the empty glob above. It reports on whether Vercel managed to post a comment, not on whether anything in the tree works, so requiring it adds a check that is green by construction. Recorded in `ci.yml`'s header beside the branch-protection notes, naming all six breakages.

## One stale line corrected

The paragraph #95 sent me to still said *"Until that is switched on, this workflow reports and nothing more."* Branch protection has been on since 2026-08-09 — ruleset `main protection`, `enforcement: active`, requiring a pull request and exactly the two checks `fast-gate` and `pg-gate`. Checked against the API, not the doc. That is the #46 failure mode this issue exists to fight, sitting in the very paragraph it pointed at.

## Note on the issue's premise

#95 says both traps are "recorded nowhere in the repo". Not quite — they were at `Product-Definition/technical-environment.md:462,487`. The premise holds anyway, so the placement is unchanged and the comments cross-reference that fuller writeup rather than duplicating it.

## Verification

Comments only; no behaviour changes.

- `pnpm typecheck` clean
- `pnpm test` — 67 files, 565 tests, green
- `ci.yml` parses with both job ids intact
- `package.json` parses; `pnpm run` lists the note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified branch protection requirements and validation checks.
  - Documented that empty test suites must fail rather than pass silently.
  - Clarified expected behavior for empty provider test runs and required database checks.
- **Tests**
  - Reinforced test configuration guidance to prevent false-positive results when no tests are discovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->