### PR TITLE
Outer Space: 30 astronomy cards

### DIFF
--- a/seed/cards.json
+++ b/seed/cards.json
@@ -3011,6 +3011,221 @@
           "sourceUrl": "https://en.wikipedia.org/wiki/Tsar_Cannon"
         }
       ]
+    },
+    {
+      "name": "Outer Space",
+      "cards": [
+        {
+          "name": "The Moon",
+          "rarity": "common",
+          "eduText": "The Moon always shows us the same side, because it spins once every time it circles the Earth.",
+          "imagePrompt": "one large grey moon seen close up, its pale surface covered with round craters, on a plain dark blue background",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Moon"
+        },
+        {
+          "name": "Mars",
+          "rarity": "common",
+          "eduText": "Mars looks red because its dust is full of rust, the same stuff that turns old nails orange.",
+          "imagePrompt": "a single huge red-orange planet rising above a dark rocky horizon in the foreground, a small pale ice cap at its top, deep blue sky with a few small stars",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Mars"
+        },
+        {
+          "name": "Venus",
+          "rarity": "common",
+          "eduText": "Venus spins the other way round, so there the Sun rises in the west and sets in the east.",
+          "imagePrompt": "a single round pale yellow planet wrapped in swirling cream clouds, floating against a deep blue starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Venus"
+        },
+        {
+          "name": "Mercury",
+          "rarity": "common",
+          "eduText": "Mercury is the quickest planet, racing all the way around the Sun in just eighty-eight days.",
+          "imagePrompt": "a single small round brownish-grey planet covered in craters, floating against a deep blue starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Mercury_(planet)"
+        },
+        {
+          "name": "Asteroid",
+          "rarity": "common",
+          "eduText": "Most asteroids circle in a wide ring between Mars and Jupiter, far apart from one another.",
+          "imagePrompt": "a single lumpy grey potato-shaped space rock, side view, floating against a deep blue starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Asteroid"
+        },
+        {
+          "name": "Meteorite",
+          "rarity": "common",
+          "eduText": "A meteorite is a piece of space rock that survived the fall and landed, so you can hold one.",
+          "imagePrompt": "a single knobbly dark space rock with a shiny black crust, lying on green grass under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Meteorite"
+        },
+        {
+          "name": "Shooting Star",
+          "rarity": "common",
+          "eduText": "A shooting star is not a star at all, only a speck of space dust glowing high in the air.",
+          "imagePrompt": "a single bright white streak of light with a long glowing tail crossing a deep blue starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Meteoroid"
+        },
+        {
+          "name": "Moon Crater",
+          "rarity": "common",
+          "eduText": "Craters keep their shape for billions of years, as the Moon has no wind or rain to wear them away.",
+          "imagePrompt": "one round bowl-shaped hollow with a raised rocky rim in pale grey dusty ground, seen at a low angle from nearby, bright daylight",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Impact_crater"
+        },
+        {
+          "name": "Solar Eclipse",
+          "rarity": "common",
+          "eduText": "In a total eclipse the Moon covers the Sun so neatly that the Sun's faint outer glow appears.",
+          "imagePrompt": "a dark round disc covering a bright sun with a glowing white ring around it, in a deep blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Solar_eclipse"
+        },
+        {
+          "name": "Northern Lights",
+          "rarity": "common",
+          "eduText": "The lights glow when tiny specks from the Sun bump into the air high above the North Pole.",
+          "imagePrompt": "wide green and purple curtains of light glowing in a deep blue night sky above snowy white hills",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Aurora"
+        },
+        {
+          "name": "Astronaut",
+          "rarity": "common",
+          "eduText": "An astronaut's suit is really a tiny spaceship, carrying its own air, water and cooling system.",
+          "imagePrompt": "a single cheerful astronaut in a white spacesuit standing on pale grey rocky ground, deep blue starry sky behind",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Astronaut"
+        },
+        {
+          "name": "Mars Rover",
+          "rarity": "common",
+          "eduText": "Rovers drive themselves, because a radio message from Earth takes many minutes to reach them.",
+          "imagePrompt": "a single six-wheeled rover with a tall camera mast, side view, parked on red rocky ground under a pink sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Mars_rover"
+        },
+        {
+          "name": "Satellite",
+          "rarity": "common",
+          "eduText": "Satellites stay up by moving forwards so fast that they keep missing the Earth as they fall.",
+          "imagePrompt": "a single boxy silver satellite with two flat blue solar wings, side view, against a deep blue starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Satellite"
+        },
+        {
+          "name": "Telescope",
+          "rarity": "common",
+          "eduText": "A telescope does not really magnify, it gathers light, so it shows things too faint for our eyes.",
+          "imagePrompt": "a single white telescope tube on a three-legged wooden tripod, side view, on green grass under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Telescope"
+        },
+        {
+          "name": "Observatory",
+          "rarity": "common",
+          "eduText": "Observatories are built on high mountains, above most of the clouds and the wobbly warm air.",
+          "imagePrompt": "a single white domed observatory building with an open slit, on a green hilltop under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Observatory"
+        },
+        {
+          "name": "Uranus",
+          "rarity": "rare",
+          "eduText": "Uranus rolls around the Sun on its side, so each of its seasons lasts about twenty-one years.",
+          "imagePrompt": "a single smooth pale blue-green planet with faint thin sideways rings, against a deep blue starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Uranus"
+        },
+        {
+          "name": "Neptune",
+          "rarity": "rare",
+          "eduText": "Neptune has the fastest winds in the solar system, quicker than any storm here on Earth.",
+          "imagePrompt": "a single deep blue planet with wispy white clouds, floating against a pale lilac starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Neptune"
+        },
+        {
+          "name": "Pluto",
+          "rarity": "rare",
+          "eduText": "Pluto has a huge pale heart shape on its surface, made of frozen nitrogen ice.",
+          "imagePrompt": "a single round tan and cream dwarf planet with a large pale heart-shaped patch, against a deep blue starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Pluto"
+        },
+        {
+          "name": "Europa",
+          "rarity": "rare",
+          "eduText": "Europa's icy shell is cracked all over, and a salty ocean is thought to slosh about underneath.",
+          "imagePrompt": "a single pale white icy moon rising above a dark rocky horizon in the foreground, its smooth surface marked with thin rust-red lines, deep blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Europa_(moon)"
+        },
+        {
+          "name": "Titan",
+          "rarity": "rare",
+          "eduText": "Titan has rivers, rain and lakes, but they are made of freezing cold methane instead of water.",
+          "imagePrompt": "a single hazy orange moon with a soft golden glow around it, floating against a deep blue starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Titan_(moon)"
+        },
+        {
+          "name": "Olympus Mons",
+          "rarity": "rare",
+          "eduText": "Olympus Mons is so enormously wide that standing on it, the slope would look almost flat.",
+          "imagePrompt": "a single huge wide reddish volcano mountain with gentle slopes, side view, on a red rocky plain under a pink sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Olympus_Mons"
+        },
+        {
+          "name": "Orion Nebula",
+          "rarity": "rare",
+          "eduText": "The Orion Nebula is a giant cloud of gas and dust where brand new stars are being born.",
+          "imagePrompt": "a wide soft pink and teal glowing mist spread sideways across a dark starry sky, with a few bright stars shining inside it",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Orion_Nebula"
+        },
+        {
+          "name": "Andromeda Galaxy",
+          "rarity": "rare",
+          "eduText": "Andromeda is our nearest big galaxy, and it is slowly drifting towards us for a far-off meeting.",
+          "imagePrompt": "a single spiral galaxy with bright swirling arms seen at a tilted angle, against a deep blue starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Andromeda_Galaxy"
+        },
+        {
+          "name": "Earth",
+          "rarity": "epic",
+          "eduText": "Earth is the only planet we know of with liquid water on its surface, and it covers most of it.",
+          "imagePrompt": "a single round planet with blue oceans, green continents and swirling white clouds, against a deep blue starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Earth"
+        },
+        {
+          "name": "Jupiter",
+          "rarity": "epic",
+          "eduText": "Jupiter's Great Red Spot is a storm so wide that the whole of the Earth could fit inside it.",
+          "imagePrompt": "a single large planet with cream and orange stripes and one big red oval spot, against a deep blue starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Jupiter"
+        },
+        {
+          "name": "Saturn",
+          "rarity": "epic",
+          "eduText": "Saturn's rings are made of countless chunks of ice, some as small as dust and some as big as a house.",
+          "imagePrompt": "a single pale golden planet with one wide flat ring tilted around its middle, rising above a dark rocky horizon in the foreground, deep blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Saturn"
+        },
+        {
+          "name": "Black Hole",
+          "rarity": "epic",
+          "eduText": "A black hole pulls so strongly that even light cannot travel quickly enough to get away from it.",
+          "imagePrompt": "a round pitch-black ball with one thin glowing orange ring of light circling around it, on a plain dark blue background",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Black_hole"
+        },
+        {
+          "name": "Halley's Comet",
+          "rarity": "epic",
+          "eduText": "Halley's Comet sweeps past the Earth about every seventy-six years, so most people see it once.",
+          "imagePrompt": "a single icy blue-white comet with a long glowing tail, side view, crossing a deep blue starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Halley%27s_Comet"
+        },
+        {
+          "name": "The Sun",
+          "rarity": "legendary",
+          "eduText": "The Sun holds more than ninety-nine parts out of a hundred of everything in the solar system.",
+          "imagePrompt": "a single bright yellow-orange sun with a glowing golden rim, against a deep blue starry sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Sun"
+        },
+        {
+          "name": "Milky Way",
+          "rarity": "legendary",
+          "eduText": "Our galaxy is so wide that light, the fastest thing there is, takes 100,000 years to cross it.",
+          "imagePrompt": "a broad glowing band of pale starlight arching across a dark blue night sky above low rolling green hills",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Milky_Way"
+        }
+      ]
     }
   ]
 }

--- a/seed/cards.json
+++ b/seed/cards.json
@@ -3034,7 +3034,8 @@
           "rarity": "common",
           "eduText": "Venus spins the other way round, so there the Sun rises in the west and sets in the east.",
           "imagePrompt": "a single round pale yellow planet wrapped in swirling cream clouds, floating against a deep blue starry sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Venus"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Venus",
+          "provider": "pollinations"
         },
         {
           "name": "Mercury",
@@ -3065,11 +3066,11 @@
           "sourceUrl": "https://en.wikipedia.org/wiki/Meteoroid"
         },
         {
-          "name": "Moon Crater",
+          "name": "Space Helmet",
           "rarity": "common",
-          "eduText": "Craters keep their shape for billions of years, as the Moon has no wind or rain to wear them away.",
-          "imagePrompt": "one round bowl-shaped hollow with a raised rocky rim in pale grey dusty ground, seen at a low angle from nearby, bright daylight",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Impact_crater"
+          "eduText": "An astronaut visor carries a whisper-thin layer of real gold, to keep the Sun's fierce glare out.",
+          "imagePrompt": "a single white space helmet with a shiny gold visor, side view, lying on green grass under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Space_helmet"
         },
         {
           "name": "Solar Eclipse",
@@ -3139,7 +3140,8 @@
           "rarity": "rare",
           "eduText": "Pluto has a huge pale heart shape on its surface, made of frozen nitrogen ice.",
           "imagePrompt": "a single round tan and cream dwarf planet with a large pale heart-shaped patch, against a deep blue starry sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Pluto"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Pluto",
+          "provider": "pollinations"
         },
         {
           "name": "Europa",
@@ -3153,7 +3155,8 @@
           "rarity": "rare",
           "eduText": "Titan has rivers, rain and lakes, but they are made of freezing cold methane instead of water.",
           "imagePrompt": "a single hazy orange moon with a soft golden glow around it, floating against a deep blue starry sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Titan_(moon)"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Titan_(moon)",
+          "provider": "pollinations"
         },
         {
           "name": "Olympus Mons",
@@ -3174,7 +3177,8 @@
           "rarity": "rare",
           "eduText": "Andromeda is our nearest big galaxy, and it is slowly drifting towards us for a far-off meeting.",
           "imagePrompt": "a single spiral galaxy with bright swirling arms seen at a tilted angle, against a deep blue starry sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Andromeda_Galaxy"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Andromeda_Galaxy",
+          "provider": "pollinations"
         },
         {
           "name": "Earth",
@@ -3216,7 +3220,8 @@
           "rarity": "legendary",
           "eduText": "The Sun holds more than ninety-nine parts out of a hundred of everything in the solar system.",
           "imagePrompt": "a single bright yellow-orange sun with a glowing golden rim, against a deep blue starry sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Sun"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Sun",
+          "provider": "pollinations"
         },
         {
           "name": "Milky Way",
@@ -3225,7 +3230,8 @@
           "imagePrompt": "a broad glowing band of pale starlight arching across a dark blue night sky above low rolling green hills",
           "sourceUrl": "https://en.wikipedia.org/wiki/Milky_Way"
         }
-      ]
+      ],
+      "provider": "cloudflare-sdxl"
     }
   ]
 }

--- a/seed/provenance.json
+++ b/seed/provenance.json
@@ -391,6 +391,393 @@
         "reviewKey": "artillery-tsar-cannon-364908d7-cloudflare-sdxl-2211",
         "reviewed": true
       }
+    },
+    "Outer Space": {
+      "Andromeda Galaxy": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "outer-space-andromeda-galaxy-2c0b4aed-pollinations-dff2",
+        "reviewed": true
+      },
+      "Asteroid": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-asteroid-d320ec95-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Astronaut": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-astronaut-effc46b9-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Black Hole": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-black-hole-8d804ce8-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Earth": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-earth-bcde1810-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Europa": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-europa-2c755175-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Halley's Comet": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-halley-s-comet-9db25c3c-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Jupiter": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-jupiter-2ca00865-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Mars": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-mars-cf4afb0e-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Mars Rover": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-mars-rover-4432b059-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Mercury": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-mercury-c0192916-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Meteorite": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-meteorite-856cc292-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Milky Way": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-milky-way-7dabb5a3-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Neptune": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-neptune-fab37c67-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Northern Lights": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-northern-lights-ebf59986-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Observatory": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-observatory-98dcdbd6-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Olympus Mons": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-olympus-mons-57204c89-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Orion Nebula": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-orion-nebula-8b884e54-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Pluto": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "outer-space-pluto-99e1d8c7-pollinations-dff2",
+        "reviewed": true
+      },
+      "Satellite": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-satellite-897e4221-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Saturn": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-saturn-8e9e524f-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Shooting Star": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-shooting-star-f04f0d7c-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Solar Eclipse": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-solar-eclipse-8f5093fb-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Space Helmet": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-space-helmet-3fd678f1-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Telescope": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-telescope-333e988b-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "The Moon": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-the-moon-9f87262b-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "The Sun": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "outer-space-the-sun-3213ae55-pollinations-dff2",
+        "reviewed": true
+      },
+      "Titan": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "outer-space-titan-79096ebe-pollinations-dff2",
+        "reviewed": true
+      },
+      "Uranus": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "outer-space-uranus-2f02ce57-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Venus": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "outer-space-venus-5ef3acea-pollinations-dff2",
+        "reviewed": true
+      }
     }
   }
 }


### PR DESCRIPTION
Adds **Outer Space**, the 15th theme, authored per `seed/NEW-THEME-RUNBOOK.md`.

30 cards on the exact pyramid (15 common / 8 rare / 5 epic / 2 legendary). The theme is
deliberately **astronomy only** — *Flying Machines* already holds Saturn V, Space Shuttle,
Voyager 1, Hubble and the ISS, so spacecraft stay out and planets, moons, small bodies,
deep sky, sky events and stargazing tools carry the set.

## Bake-off

Both lanes drew all 30; neither failed a card. `cloudflare-sdxl` won 25 rows and is the
theme default, with 5 cards overridden to `pollinations` where it drew the subject more
faithfully (Venus, Pluto, Titan, Andromeda Galaxy, The Sun).

Pollinations lost most rows on subject accuracy rather than taste — it drew a red pickup
truck for Mars Rover, a missile for Satellite, a cat beside the Telescope, two overlapping
comets for Halley's, and a photoreal suit for Astronaut.

## Re-prompting

Eight cards had nothing usable on either lane in round 0 and were re-prompted. Cloudflare's
recurring failure was **tiling a round subject across the sky** (a field of ~12 moons, ~25
Mars spheres); anchoring each subject against a horizon fixed most of it.

- Fixed in round 1: The Moon, Orion Nebula (which had come back as a pink mushroom cloud), Black Hole, Milky Way
- Fixed in round 2: Mars, Europa, Saturn
- **Moon Crater** failed both lanes across both rounds — the final pair drew a literal
  ceramic bowl — and the subject was swapped for **Space Helmet** on the maintainer's call.

Two Cloudflare cells were re-rolled rather than re-prompted after coming back framed
(Pluto, The Sun, per #81); neither re-roll beat the Pollinations candidate.

## Checks

- schema green, all 450 `sourceUrl`s return 200
- `--blob-budget` at 5.2% of 1.00 GB before publish
- `--sync`: 30 inserted, 0 failed, 0 pruned; completeness reports all 15 themes published in full
- `seed/provenance.json`: 30 entries, 25 cloudflare-sdxl + 5 pollinations, none `reviewed: false`

https://claude.ai/code/session_01BYtX31xMTCSuxKP84ihtpe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **Outer Space** card theme with 30 educational cards covering celestial bodies, space phenomena, exploration equipment, and astronomy concepts.
  * Cards include educational content, rarity levels, imagery, and source references.
  * Added provenance information for generated card artwork and content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->