### PR TITLE
Land Machines: 30 road, rail and site machines

### DIFF
--- a/seed/cards.json
+++ b/seed/cards.json
@@ -3254,7 +3254,7 @@
         {
           "name": "School Bus",
           "rarity": "common",
-          "eduText": "School buses are the same bright yellow everywhere, because that colour is the easiest to spot early.",
+          "eduText": "School buses in the United States are the same bright yellow, because that colour is the easiest to spot early.",
           "imagePrompt": "a single bright yellow school bus, side view, parked on a grey road under a blue sky",
           "sourceUrl": "https://en.wikipedia.org/wiki/School_bus",
           "provider": "pollinations"
@@ -3450,7 +3450,7 @@
         {
           "name": "Bagger 288",
           "rarity": "legendary",
-          "eduText": "Bagger 288 is the heaviest vehicle on Earth, and it crawls so slowly you can easily walk past it.",
+          "eduText": "Bagger 288 is one of the heaviest vehicles on Earth, and it crawls so slowly you can easily walk past it.",
           "imagePrompt": "a single enormous bucket-wheel excavator with a giant round wheel of buckets, side view, on brown earth under a blue sky",
           "sourceUrl": "https://en.wikipedia.org/wiki/Bagger_288",
           "provider": "pollinations"

--- a/seed/cards.json
+++ b/seed/cards.json
@@ -3241,7 +3241,8 @@
           "rarity": "common",
           "eduText": "Fire engines carry their own water tank, so they can start work before hooking up to a hydrant.",
           "imagePrompt": "a single red fire engine with ladders along its roof, side view, parked on green grass under a blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Fire_engine"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Fire_engine",
+          "provider": "pollinations"
         },
         {
           "name": "Ambulance",
@@ -3255,7 +3256,8 @@
           "rarity": "common",
           "eduText": "School buses are the same bright yellow everywhere, because that colour is the easiest to spot early.",
           "imagePrompt": "a single bright yellow school bus, side view, parked on a grey road under a blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/School_bus"
+          "sourceUrl": "https://en.wikipedia.org/wiki/School_bus",
+          "provider": "pollinations"
         },
         {
           "name": "Bulldozer",
@@ -3297,7 +3299,8 @@
           "rarity": "common",
           "eduText": "A crane lowers strong legs called outriggers, spreading its feet wide so it cannot topple over.",
           "imagePrompt": "a single yellow mobile crane with a long boom raised, side view, on a grey gravel yard under a blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Mobile_crane"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Mobile_crane",
+          "provider": "pollinations"
         },
         {
           "name": "Garbage Truck",
@@ -3325,21 +3328,24 @@
           "rarity": "common",
           "eduText": "Four fat low-pressure tyres let a quad bike float over sand and mud that would trap a car.",
           "imagePrompt": "a single red quad bike with four fat tyres, side view, on brown dirt under a blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/All-terrain_vehicle"
+          "sourceUrl": "https://en.wikipedia.org/wiki/All-terrain_vehicle",
+          "provider": "pollinations"
         },
         {
           "name": "Go-Kart",
           "rarity": "common",
           "eduText": "A go-kart has no springs at all, so every bump in the track travels straight up to the driver.",
           "imagePrompt": "a single small blue go-kart with four little wheels, side view, on a grey racetrack under a blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Go-kart"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Go-kart",
+          "provider": "pollinations"
         },
         {
           "name": "Taxi",
           "rarity": "common",
           "eduText": "Taxi comes from taximeter, the little clock on board that counts the fare up as you ride along.",
           "imagePrompt": "a single yellow taxi car with a small sign on its roof, side view, parked on a grey road under a blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Taxi"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Taxi",
+          "provider": "pollinations"
         },
         {
           "name": "Tram",
@@ -3402,7 +3408,8 @@
           "rarity": "epic",
           "eduText": "A steam engine boils water to make steam, and it is the pushing steam that turns the wheels.",
           "imagePrompt": "a single black steam locomotive with large red wheels and a tall chimney, side view, on railway tracks under a blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Steam_locomotive"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Steam_locomotive",
+          "provider": "pollinations"
         },
         {
           "name": "Bullet Train",
@@ -3416,7 +3423,8 @@
           "rarity": "epic",
           "eduText": "Its wings push down instead of up, pressing the car onto the track hard enough to grip a ceiling.",
           "imagePrompt": "a single red formula one racing car with wide front and rear wings, side view, on a grey racetrack under a blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Formula_One_car"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Formula_One_car",
+          "provider": "pollinations"
         },
         {
           "name": "Monster Truck",
@@ -3444,9 +3452,11 @@
           "rarity": "legendary",
           "eduText": "Bagger 288 is the heaviest vehicle on Earth, and it crawls so slowly you can easily walk past it.",
           "imagePrompt": "a single enormous bucket-wheel excavator with a giant round wheel of buckets, side view, on brown earth under a blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Bagger_288"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Bagger_288",
+          "provider": "pollinations"
         }
-      ]
+      ],
+      "provider": "cloudflare-sdxl"
     }
   ]
 }

--- a/seed/cards.json
+++ b/seed/cards.json
@@ -3232,6 +3232,221 @@
         }
       ],
       "provider": "cloudflare-sdxl"
+    },
+    {
+      "name": "Land Machines",
+      "cards": [
+        {
+          "name": "Fire Engine",
+          "rarity": "common",
+          "eduText": "Fire engines carry their own water tank, so they can start work before hooking up to a hydrant.",
+          "imagePrompt": "a single red fire engine with ladders along its roof, side view, parked on green grass under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Fire_engine"
+        },
+        {
+          "name": "Ambulance",
+          "rarity": "common",
+          "eduText": "The word AMBULANCE is often painted backwards on the front, so drivers read it in their mirror.",
+          "imagePrompt": "a single white ambulance with orange stripes along its side, side view, parked on a grey road under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Ambulance"
+        },
+        {
+          "name": "School Bus",
+          "rarity": "common",
+          "eduText": "School buses are the same bright yellow everywhere, because that colour is the easiest to spot early.",
+          "imagePrompt": "a single bright yellow school bus, side view, parked on a grey road under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/School_bus"
+        },
+        {
+          "name": "Bulldozer",
+          "rarity": "common",
+          "eduText": "A bulldozer spreads its weight over wide tracks, so it can shove heavy soil without sinking in.",
+          "imagePrompt": "a single yellow bulldozer with a wide front blade and metal tracks, side view, on brown earth under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Bulldozer"
+        },
+        {
+          "name": "Excavator",
+          "rarity": "common",
+          "eduText": "An excavator's arm copies your own: it has a shoulder, an elbow, and a wrist that curls the bucket.",
+          "imagePrompt": "a single orange excavator with a long digging arm and bucket, side view, on brown earth under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Excavator"
+        },
+        {
+          "name": "Tractor",
+          "rarity": "common",
+          "eduText": "A tractor's back wheels are huge so they grip soft mud, while the small front pair does the steering.",
+          "imagePrompt": "a single green tractor with very large rear wheels, side view, parked on green grass under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Tractor"
+        },
+        {
+          "name": "Cement Mixer",
+          "rarity": "common",
+          "eduText": "The drum turns for the whole journey, because concrete sets hard if it is ever left standing still.",
+          "imagePrompt": "a single white cement mixer truck with a large drum on its back, side view, on a grey road under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Concrete_mixer"
+        },
+        {
+          "name": "Dump Truck",
+          "rarity": "common",
+          "eduText": "A dump truck tips its whole body up on a hidden ram, and lets gravity slide the load out.",
+          "imagePrompt": "a single yellow dump truck with its tipping body raised, side view, on brown earth under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Dump_truck"
+        },
+        {
+          "name": "Mobile Crane",
+          "rarity": "common",
+          "eduText": "A crane lowers strong legs called outriggers, spreading its feet wide so it cannot topple over.",
+          "imagePrompt": "a single yellow mobile crane with a long boom raised, side view, on a grey gravel yard under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Mobile_crane"
+        },
+        {
+          "name": "Garbage Truck",
+          "rarity": "common",
+          "eduText": "A moving wall inside squashes the rubbish down, so one truck can swallow about three loads.",
+          "imagePrompt": "a single green garbage truck with a lifting arm at the back, side view, on a grey road under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Garbage_truck"
+        },
+        {
+          "name": "Motorcycle",
+          "rarity": "common",
+          "eduText": "A motorcycle stays upright because its spinning wheels resist being tipped, like a rolling coin.",
+          "imagePrompt": "a single red motorcycle, side view, parked on a grey road under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Motorcycle"
+        },
+        {
+          "name": "Bicycle",
+          "rarity": "common",
+          "eduText": "A bicycle is the most efficient machine ever built for turning muscle into distance travelled.",
+          "imagePrompt": "a single blue bicycle, side view, standing on green grass under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Bicycle"
+        },
+        {
+          "name": "Quad Bike",
+          "rarity": "common",
+          "eduText": "Four fat low-pressure tyres let a quad bike float over sand and mud that would trap a car.",
+          "imagePrompt": "a single red quad bike with four fat tyres, side view, on brown dirt under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/All-terrain_vehicle"
+        },
+        {
+          "name": "Go-Kart",
+          "rarity": "common",
+          "eduText": "A go-kart has no springs at all, so every bump in the track travels straight up to the driver.",
+          "imagePrompt": "a single small blue go-kart with four little wheels, side view, on a grey racetrack under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Go-kart"
+        },
+        {
+          "name": "Taxi",
+          "rarity": "common",
+          "eduText": "Taxi comes from taximeter, the little clock on board that counts the fare up as you ride along.",
+          "imagePrompt": "a single yellow taxi car with a small sign on its roof, side view, parked on a grey road under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Taxi"
+        },
+        {
+          "name": "Tram",
+          "rarity": "rare",
+          "eduText": "Trams run on rails set flush into the street, so they always follow exactly the same path.",
+          "imagePrompt": "a single red and cream tram on street rails, side view, on a grey city street under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Tram"
+        },
+        {
+          "name": "Combine Harvester",
+          "rarity": "rare",
+          "eduText": "A combine does three jobs at once: it cuts the crop, shakes the grain loose, and drops the straw.",
+          "imagePrompt": "a single green combine harvester with a wide cutting header at the front, side view, in a golden wheat field under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Combine_harvester"
+        },
+        {
+          "name": "Snowplough",
+          "rarity": "rare",
+          "eduText": "A plough blade is set at an angle, so the snow curls off to one side instead of piling up ahead.",
+          "imagePrompt": "a single orange snowplough truck with a wide angled blade at the front, side view, on white snowy ground under a pale blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Snowplow"
+        },
+        {
+          "name": "Road Roller",
+          "rarity": "rare",
+          "eduText": "A road roller squeezes the tiny air pockets out of fresh tarmac, and that is what makes it last.",
+          "imagePrompt": "a single yellow road roller with a wide smooth drum at the front, side view, on a grey road under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Road_roller"
+        },
+        {
+          "name": "Forklift",
+          "rarity": "rare",
+          "eduText": "A forklift carries a heavy weight in its tail, balancing the load out front like a see-saw.",
+          "imagePrompt": "a single orange forklift truck with two metal forks at the front, side view, on a grey concrete yard under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Forklift"
+        },
+        {
+          "name": "Tow Truck",
+          "rarity": "rare",
+          "eduText": "A tow truck lifts just two wheels clear of the ground, and lets the other two roll along behind.",
+          "imagePrompt": "a single blue tow truck with a lifting arm at the back, side view, on a grey road under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Tow_truck"
+        },
+        {
+          "name": "Ice Resurfacer",
+          "rarity": "rare",
+          "eduText": "It shaves a thin layer off the ice and lays warm water down, which freezes into a smooth new top.",
+          "imagePrompt": "a single blue ice resurfacing machine, side view, on a pale white ice rink in bright daylight",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Ice_resurfacer"
+        },
+        {
+          "name": "Tuk-Tuk",
+          "rarity": "rare",
+          "eduText": "A tuk-tuk is named after the put-put sound of its little engine, and it runs on just three wheels.",
+          "imagePrompt": "a single green and yellow three-wheeled tuk-tuk, side view, parked on a grey street under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Auto_rickshaw"
+        },
+        {
+          "name": "Steam Locomotive",
+          "rarity": "epic",
+          "eduText": "A steam engine boils water to make steam, and it is the pushing steam that turns the wheels.",
+          "imagePrompt": "a single black steam locomotive with large red wheels and a tall chimney, side view, on railway tracks under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Steam_locomotive"
+        },
+        {
+          "name": "Bullet Train",
+          "rarity": "epic",
+          "eduText": "Its long nose was shaped like a kingfisher's beak, to stop the bang as it leaves a tunnel.",
+          "imagePrompt": "a single white and blue bullet train with a long pointed nose, side view, on railway tracks under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Shinkansen"
+        },
+        {
+          "name": "Formula One Car",
+          "rarity": "epic",
+          "eduText": "Its wings push down instead of up, pressing the car onto the track hard enough to grip a ceiling.",
+          "imagePrompt": "a single red formula one racing car with wide front and rear wings, side view, on a grey racetrack under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Formula_One_car"
+        },
+        {
+          "name": "Monster Truck",
+          "rarity": "epic",
+          "eduText": "Each tyre stands taller than a grown-up, and one alone weighs about as much as a small car.",
+          "imagePrompt": "a single blue monster truck with four enormous tyres, side view, on brown dirt under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Monster_truck"
+        },
+        {
+          "name": "Tunnel Boring Machine",
+          "rarity": "epic",
+          "eduText": "It builds the tunnel wall behind itself as it chews forward, so it never has to reverse out.",
+          "imagePrompt": "a single huge tunnel boring machine with a round cutting wheel at the front, side view, on grey gravel under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Tunnel_boring_machine"
+        },
+        {
+          "name": "Stephenson's Rocket",
+          "rarity": "legendary",
+          "eduText": "Rocket won a contest in 1829, and set the pattern that every steam locomotive followed after it.",
+          "imagePrompt": "a single early steam locomotive with a tall thin chimney and a yellow barrel body, side view, on railway tracks under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Stephenson%27s_Rocket"
+        },
+        {
+          "name": "Bagger 288",
+          "rarity": "legendary",
+          "eduText": "Bagger 288 is the heaviest vehicle on Earth, and it crawls so slowly you can easily walk past it.",
+          "imagePrompt": "a single enormous bucket-wheel excavator with a giant round wheel of buckets, side view, on brown earth under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Bagger_288"
+        }
+      ]
     }
   ]
 }

--- a/seed/provenance.json
+++ b/seed/provenance.json
@@ -392,6 +392,389 @@
         "reviewed": true
       }
     },
+    "Land Machines": {
+      "Ambulance": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-ambulance-423d83fc-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Bagger 288": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "land-machines-bagger-288-dffdf6c4-pollinations-dff2",
+        "reviewed": true
+      },
+      "Bicycle": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-bicycle-9253f806-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Bulldozer": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-bulldozer-e792914f-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Bullet Train": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-bullet-train-02b71644-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Cement Mixer": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-cement-mixer-6a0d864b-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Combine Harvester": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-combine-harvester-4d273431-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Dump Truck": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-dump-truck-eee24a28-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Excavator": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-excavator-6bcab395-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Fire Engine": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "land-machines-fire-engine-1d0dd826-pollinations-dff2",
+        "reviewed": true
+      },
+      "Forklift": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-forklift-41a26910-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Formula One Car": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "land-machines-formula-one-car-561308a0-pollinations-dff2",
+        "reviewed": true
+      },
+      "Garbage Truck": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-garbage-truck-cd6b097b-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Go-Kart": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "land-machines-go-kart-f32c3396-pollinations-dff2",
+        "reviewed": true
+      },
+      "Ice Resurfacer": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-ice-resurfacer-4ef9426e-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Mobile Crane": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "land-machines-mobile-crane-577e8aa6-pollinations-dff2",
+        "reviewed": true
+      },
+      "Monster Truck": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-monster-truck-1c76dc58-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Motorcycle": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-motorcycle-2dad4588-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Quad Bike": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "land-machines-quad-bike-999b27c9-pollinations-dff2",
+        "reviewed": true
+      },
+      "Road Roller": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-road-roller-16407883-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "School Bus": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "land-machines-school-bus-4b1b8292-pollinations-dff2",
+        "reviewed": true
+      },
+      "Snowplough": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-snowplough-74acf556-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Steam Locomotive": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "land-machines-steam-locomotive-3ad66896-pollinations-dff2",
+        "reviewed": true
+      },
+      "Stephenson's Rocket": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-stephenson-s-rocket-e8dbd9ff-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Taxi": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "land-machines-taxi-8ebd5b4a-pollinations-dff2",
+        "reviewed": true
+      },
+      "Tow Truck": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-tow-truck-41e382a4-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Tractor": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-tractor-459996d3-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Tram": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-tram-d0e098a7-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Tuk-Tuk": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-tuk-tuk-ac7ccb49-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Tunnel Boring Machine": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "land-machines-tunnel-boring-machine-cf1303e2-cloudflare-sdxl-2211",
+        "reviewed": true
+      }
+    },
     "Outer Space": {
       "Andromeda Galaxy": {
         "provider": "pollinations",


### PR DESCRIPTION
Adds **Land Machines**, the 16th theme, authored per `seed/NEW-THEME-RUNBOOK.md`. It completes
the machines trio alongside *Flying Machines* and *Ocean Machines*.

30 cards on the exact pyramid (15 common / 8 rare / 5 epic / 2 legendary), spread across rail,
construction, farm, emergency, city transport, industrial, sport and winter machines. **No
military subjects** — *Artillery* and *Warriors* already carry those, so the cap was left unused
rather than spent.

Legendaries take the oldest/biggest split the pool uses elsewhere: **Stephenson's Rocket** (the
first) and **Bagger 288** (the largest land vehicle ever built).

## Bake-off

Both lanes drew all 30 with zero failures, and **no card needed a re-prompt round** — a first for
this runbook. Single machines photographed side-on in daylight are the shape both providers draw
most reliably, which is exactly what Step 4 predicts.

`cloudflare-sdxl` won 21 rows and is the theme default. Nine cards are overridden to
`pollinations`, each for a concrete defect rather than taste:

- duplicated subject — Fire Engine (two trucks plus a scissor lift), Formula One Car (two cars)
- text baked into the image — School Bus ("SCHOO BUS"), Taxi ("TAXI")
- wrong subject — Go-Kart (a toddler's plastic ride-on)
- extra figure — Quad Bike (added a child rider; every other card is machine-only)
- anthropomorphised — Steam Locomotive (a face close enough to Thomas to avoid on principle)
- weaker drawing — Mobile Crane, Bagger 288

Two Cloudflare cells came back framed (Excavator, Dump Truck) and were **re-rolled** per #81, not
re-prompted; both came back clean and won their rows.

## Checks

- schema green, all 480 `sourceUrl`s return 200
- `--blob-budget` at 6.9% of 1.00 GB before publish
- `--sync`: 30 inserted, 0 failed, 0 pruned; completeness reports all 16 themes published in full
- `seed/provenance.json`: 30 entries, 21 cloudflare-sdxl + 9 pollinations, none `reviewed: false`

https://claude.ai/code/session_01BYtX31xMTCSuxKP84ihtpe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the **Land Machines** theme with 30 educational cards covering emergency vehicles, construction equipment, agricultural machinery, personal transport, rail vehicles, racing vehicles, and industrial machines.
  * Included card rarities, educational descriptions, images, source references, and generation details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->