### PR TITLE
feat(binder): enter categories as places, keep the place in the URL, and tier the swap board

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,6 +37,11 @@ same way. Domain nouns come from the app; architecture nouns from `/codebase-des
 - **Sacrifice** — burn N copies of a card for a rarity-pick ticket (same tier or one
   up, 50/50).
 - **Trade** — atomic two-sided duplicate swap between two children.
+- **Swap tier** — what a trade is worth to whoever **receives** the card, and how both
+  swap-board columns are ordered (#109): **new** (they own none) → **one-away** (they
+  hold `SACRIFICE_MIN - 1`, so this copy makes it burnable) → **rest**. Mirrored — each
+  column is tiered against the *other* party's shelf. Never about acquisition recency:
+  `collections` has no timestamp.
 - **Offer** — an HMAC-signed, expiring token pinning the exact cards/rarity the server
   chose, so a claim can't be swapped for an un-offered card (pull eggs, quiz answers).
 - **Gate** — the admin passcode gate; issues a short-lived signed cookie.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,6 +30,11 @@ same way. Domain nouns come from the app; architecture nouns from `/codebase-des
   `docs/DATA-PRESERVATION-0009.md`.
 - **Collection** — a child's owned cards, one row per `(child, card)` with a `count`
   (`collections` table, `CHECK(count >= 1)`).
+- **Place** — where the binder is: the category picker (the hub), one category, or the
+  burn pile (#107, #108). The three are mutually exclusive, so a place is one value
+  rather than a category selection plus a mode flag, and it lives in the URL as `?at=`
+  so a tapped card can come back to it. Rarity is deliberately **not** a place — it is
+  a lens applied inside one and resets on entry (`src/features/binder/binder-place.ts`).
 - **Pull** — spending a token to draw a rarity-weighted card. May branch into an
   **easter egg**: a signed pick-1-of-N **offer** the child claims later.
 - **Ticket** — a spendable column on `children`: normal `pullTokens`, special egg

--- a/Product-Definition/vision-document.md
+++ b/Product-Definition/vision-document.md
@@ -99,7 +99,8 @@ Grounded in the repository as of 2026-08-03 — 14 feature modules under `src/fe
 - **Ticket economy** — normal `pullTokens`, special egg tickets (✨ epic / 🍀 lucky), and per-rarity pick
   tickets. The single currency the whole reward loop runs on.
 - **Binder / Galaxy** — per-child collection grouped by theme, duplicate counts `xN`, locked silhouettes
-  for unowned cards, rarity and category filters, per-theme completion progress.
+  for unowned cards, a grid of category tiles the child *enters* one at a time (with a rarity filter
+  inside, and the burn pile as its own destination), per-theme completion progress.
 - **Card rendering & effects** — holographic foil, 3D tilt/parallax, rarity-scaled intensity, pack-open
   reveal, roulette.
 - **Sound** — SFX and BGM, rarity fanfares, dedicated easter-egg cue.
@@ -275,9 +276,10 @@ Next.js App Router + TypeScript + Tailwind application on Vercel, with Neon Post
   gap where an edited prompt could republish an image reviewed against a prompt that no longer exists.
   `--sync` also refuses to insert a card with no reviewed image without `--allow-unreviewed`.
 - **`SACRIFICE_COST` / `SACRIFICE_MIN` stay a single source of truth.** `SACRIFICE_COST = 3`,
-  `SACRIFICE_MIN = 4` in `src/features/pull/sacrifice.ts`, consumed by both the card detail page and the
-  galaxy filter, with a property-based test asserting the equivalence. The values are correct as-is; the
-  invariant is that they are never hardcoded anywhere else.
+  `SACRIFICE_MIN = 4` in `src/features/pull/sacrifice.ts`, consumed by every surface that offers or
+  advertises a sacrifice (listed on the constant itself), with a property-based test asserting the
+  equivalence. The values are correct as-is; the invariant is that they are never hardcoded anywhere
+  else.
 - **A pool reset must never delete `collections`.** `cards.theme_id` and `collections.card_id` are both
   `ON DELETE CASCADE`, so deleting the pool destroys every child's cards regardless of what the function
   names. `resetPool()` therefore refuses outright while any collection row exists, and has **no override

--- a/app/play/binder/[cardId]/page.tsx
+++ b/app/play/binder/[cardId]/page.tsx
@@ -5,17 +5,24 @@ import { binderService } from "@/features/binder/service.prod";
 import { Card } from "@/features/card/Card";
 import { SacrificePanel } from "@/features/pull/SacrificePanel";
 import { SACRIFICE_MIN } from "@/features/pull/sacrifice";
+import { backHref } from "@/features/binder/binder-place";
 
 export default async function CardDetailPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ cardId: string }>;
+  searchParams: Promise<{ from?: string | string[] }>;
 }) {
   const child = await requireActivePlayer();
 
-  const { cardId } = await params;
+  const [{ cardId }, { from }] = await Promise.all([params, searchParams]);
   const detail = await binderService.getCardDetail(child.id, cardId);
   if (!detail) notFound(); // owned-only (U5-BR4/SEC-2)
+
+  // Back to the place the child tapped this card from — the burn pile is a
+  // loop, so returning to the hub cost a re-entry on every card (#108).
+  const back = backHref(from, detail.card.themeId);
 
   return (
     <main
@@ -29,7 +36,7 @@ export default async function CardDetailPage({
       {detail.count >= SACRIFICE_MIN ? (
         <SacrificePanel cardId={detail.card.id} count={detail.count} />
       ) : null}
-      <Link href="/play/binder" className="btn btn--ghost text-sm">
+      <Link href={back} className="btn btn--ghost text-sm">
         ← Back to My Galaxy
       </Link>
     </main>

--- a/app/play/binder/page.tsx
+++ b/app/play/binder/page.tsx
@@ -2,16 +2,27 @@ import Link from "next/link";
 import { requireActivePlayer } from "@/features/profiles/active-profile";
 import { binderService } from "@/features/binder/service.prod";
 import { GalaxyView } from "@/features/binder/GalaxyView";
+import { parsePlace } from "@/features/binder/binder-place";
 import { rewardService } from "@/features/rewards/service.prod";
 import { CollectionRewardModal } from "@/features/rewards/CollectionRewardModal";
 
-export default async function BinderPage() {
+export default async function BinderPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ at?: string | string[] }>;
+}) {
   const child = await requireActivePlayer();
 
-  const [binder, pendingRewards] = await Promise.all([
+  const [{ at }, binder, pendingRewards] = await Promise.all([
+    searchParams,
     binderService.getBinder(child.id),
     rewardService.getPendingRewards(child.id),
   ]);
+
+  // Which place the child is in (#108). Resolved server-side so a refresh, a
+  // deep link, or the way back from a card lands where it should; from there
+  // GalaxyView moves between places with history.pushState, no round trip.
+  const place = parsePlace(at, binder.themes);
 
   return (
     <main
@@ -65,7 +76,7 @@ export default async function BinderPage() {
           </Link>
         </div>
       ) : (
-        <GalaxyView sections={binder.themes} />
+        <GalaxyView sections={binder.themes} initialPlace={place} />
       )}
     </main>
   );

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -9,6 +9,7 @@ import * as schema from "./schema";
  */
 const sql = neon(env.databaseUrl);
 
+/** Drizzle database client instance (server-only). */
 export const db = drizzle(sql, { schema });
 
 export { schema };

--- a/src/features/backup/count-report.ts
+++ b/src/features/backup/count-report.ts
@@ -59,6 +59,10 @@ export function parseCounts(tsv: string): TableCount[] {
   return out;
 }
 
+/**
+ * Compare production table counts against restored backup counts. Returns
+ * tables missing, extras found, and row count mismatches.
+ */
 export function diffCounts(before: TableCount[], after: TableCount[]): CountDiff {
   const beforeMap = new Map(before.map((c) => [qualifiedName(c), c.rows]));
   const afterMap = new Map(after.map((c) => [qualifiedName(c), c.rows]));
@@ -74,6 +78,7 @@ export function diffCounts(before: TableCount[], after: TableCount[]): CountDiff
   return { missingTables, extraTables, rowMismatches };
 }
 
+/** True if the diff shows no discrepancies (perfect restore match). */
 export function isClean(d: CountDiff): boolean {
   return (
     d.missingTables.length === 0 &&

--- a/src/features/binder/CardSlot.tsx
+++ b/src/features/binder/CardSlot.tsx
@@ -3,6 +3,7 @@ import type { BinderCard } from "@/lib/types";
 import { RarityThumb } from "@/features/card/RarityThumb";
 import { AdminCardSlot } from "@/features/admin/AdminCardSlot";
 import { raritySlotClass } from "./rarity-slot";
+import { cardHref, type Place } from "./binder-place";
 import "./rarity-slot.css";
 
 /** Owned card thumbnail (tappable → detail) or a locked silhouette.
@@ -19,9 +20,13 @@ import "./rarity-slot.css";
 export function CardSlot({
   entry,
   admin = false,
+  from,
 }: {
   entry: BinderCard;
   admin?: boolean;
+  /** The place this slot was tapped from, so card detail can send the child
+   *  back there rather than to the hub (#108). */
+  from?: Place;
 }) {
   if (!entry.owned) {
     // Locked stays neutral — no rarity hint (U5-Q5) — but shows the name (U6-FR1).
@@ -47,7 +52,7 @@ export function CardSlot({
 
   return (
     <Link
-      href={`/play/binder/${entry.card.id}`}
+      href={from ? cardHref(entry.card.id, from) : `/play/binder/${entry.card.id}`}
       data-testid={`card-slot-${entry.card.id}`}
       className={`slot-pop block ${raritySlotClass(entry.card.rarity)}`}
     >

--- a/src/features/binder/CategoryPicker.tsx
+++ b/src/features/binder/CategoryPicker.tsx
@@ -1,0 +1,97 @@
+import type { ThemeSection as ThemeSectionData } from "@/lib/types";
+import { CardImage } from "@/features/card/CardImage";
+import { coverCard } from "./category-cover";
+
+/**
+ * The galaxy's category picker (#107). A grid of picture tiles — one per
+ * category — that the binder lands on. Tapping one enters that category.
+ *
+ * This replaces the wrapped sticky row of one chip per theme, which grew by one
+ * every time the seed runbook shipped 30 more cards and was already three or
+ * four wrapped lines on a phone at 16 themes. A tile grid grows *downwards*
+ * instead of pushing the cards off screen, so it still reads at 25+ themes; and
+ * tapping a picture is the cheap interaction for the youngest player, where
+ * reading a row of names is the expensive one.
+ *
+ * A finished category is called out with the same 🏆 "Set complete!" language
+ * the reward modal celebrates it with, so the tile and the celebration are one
+ * promise rather than two marks the child has to learn separately.
+ */
+export function CategoryPicker({
+  sections,
+  onOpen,
+}: {
+  sections: ThemeSectionData[];
+  onOpen: (themeId: string) => void;
+}) {
+  return (
+    <div
+      data-testid="galaxy-category-picker"
+      className="grid grid-cols-2 gap-3 sm:grid-cols-3"
+    >
+      {sections.map((section) => (
+        <CategoryTile
+          key={section.theme.id}
+          section={section}
+          onOpen={() => onOpen(section.theme.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function CategoryTile({
+  section,
+  onOpen,
+}: {
+  section: ThemeSectionData;
+  onOpen: () => void;
+}) {
+  const { theme, progress } = section;
+  const cover = coverCard(section);
+  const pct = progress.total > 0 ? Math.round((progress.owned / progress.total) * 100) : 0;
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      data-testid={`galaxy-category-${theme.id}`}
+      aria-label={
+        progress.complete
+          ? `${theme.name}: set complete, all ${progress.total} collected`
+          : `${theme.name}: ${progress.owned} of ${progress.total} collected`
+      }
+      className="panel slot-pop flex flex-col overflow-hidden p-0 text-left"
+    >
+      <span className="relative block">
+        {cover ? (
+          <CardImage src={cover.card.imageUrl} alt="" dim={256} loading="lazy" />
+        ) : (
+          // Nothing owned here yet — a neutral placeholder, never a dimmed
+          // thumbnail: unearned art stays unearned (U5-Q5).
+          <span className="flex aspect-square w-full items-center justify-center bg-black/20 text-4xl opacity-45">
+            🪐
+          </span>
+        )}
+        {progress.complete ? (
+          <span className="absolute inset-x-0 bottom-0 flex items-center justify-center gap-1 bg-[color:var(--brand-1)] px-1 py-1 text-[0.7rem] font-black leading-none text-black">
+            🏆 Set complete!
+          </span>
+        ) : null}
+      </span>
+
+      <span className="flex flex-col gap-1.5 p-2.5">
+        <span className="line-clamp-1 text-sm font-bold">{theme.name}</span>
+        <span className="h-2 overflow-hidden rounded-full bg-black/30 ring-1 ring-inset ring-white/10">
+          <span
+            className="block h-full rounded-full bg-[linear-gradient(90deg,var(--brand-4),var(--brand-1))] transition-all duration-500"
+            style={{ width: `${pct}%` }}
+          />
+        </span>
+        <span className="text-xs font-bold tabular-nums text-[color:var(--ink-soft)]">
+          {progress.owned} / {progress.total}
+        </span>
+      </span>
+    </button>
+  );
+}

--- a/src/features/binder/GalaxyView.tsx
+++ b/src/features/binder/GalaxyView.tsx
@@ -6,49 +6,58 @@ import type { ThemeSection as ThemeSectionData } from "@/lib/types";
 import { RARITY_META } from "@/features/card/rarity";
 import { ThemeSection } from "./ThemeSection";
 import { SacrificeGrid } from "./SacrificeGrid";
+import { CategoryPicker } from "./CategoryPicker";
 import { countOwnedByRarity, filterCardsByRarity } from "./rarity-filter";
 import { sacrificeReady } from "./sacrifice-filter";
 
 /**
- * Galaxy category view (Inc9 FR1). Sticky tab bar of category chips filters the
- * galaxy to one theme; "★ All" (default) shows every section. Scales as the
- * number of categories grows -- on a phone the chips are a single sideways-
- * scrolling row, so adding categories lengthens the strip instead of growing a
- * taller and taller block under the pinned header.
+ * Galaxy category view (Inc9 FR1).
  *
- * Inc13 FR1/FR2: a second chip row filters by rarity and shows the owned count
- * per rarity. Rarity AND-combines with the active category (Q4.1=A); counts are
- * owned-only within the current category selection (Q4.2=A); the filtered view
- * keeps locked cards so the child sees what's left (Q4.3=B).
+ * #107: a category is now a **place you go**, not a chip you tick. The binder
+ * lands on `CategoryPicker` — a grid of picture tiles — and tapping one enters
+ * that category, which is where the rarity row and the cards live. The old
+ * shape rendered `★ All` plus one chip per theme in a single wrapped sticky
+ * `<nav>`; that row grew by one every seed run and never shrank, and was
+ * already three or four wrapped lines under a sticky header on a phone. A tile
+ * grid grows downwards instead of pushing the cards off screen, so it still
+ * reads at 25+ themes.
  *
- * Inc22 FR9/FR11: a "Show" row switches between the galaxy and a flat grid of
+ * Two consequences of that swap, both deliberate:
+ *   - **`★ All` is gone.** "Every category at once" is a filter, not a
+ *     destination, and 480 slots in one scroll was never a view anyone read.
+ *   - **The rarity row moved inside a category.** It AND-combines with the
+ *     active category (Inc13 Q4.1=A) and its counts are scoped to the current
+ *     selection (Q4.2=A); with no "all categories" selection left, "within the
+ *     current selection" now simply means "within this category". The filtered
+ *     view still keeps locked cards so the child sees what's left (Q4.3=B).
+ *
+ * Inc22 FR9/FR11: the "Show" row switches between the galaxy and a flat grid of
  * the cards that can be sacrificed. The burn view is deliberately GLOBAL — it
- * ignores both chip rows, and its count is the total across every category, so
- * "everything I can burn" is never a filtered subset.
+ * ignores the category and rarity selections, and its count is the total across
+ * every category, so "everything I can burn" is never a filtered subset. That
+ * is why the mode row sits *above* the picker rather than inside a category:
+ * it must never read as a filter applied within one.
  */
 type Mode = "all" | "sacrifice";
 
 export function GalaxyView({ sections }: { sections: ThemeSectionData[] }) {
   const [mode, setMode] = useState<Mode>("all");
-  const [active, setActive] = useState<string>("all");
+  const [openId, setOpenId] = useState<string | null>(null);
   const [rarity, setRarity] = useState<Rarity | null>(null);
 
   const burnable = sacrificeReady(sections);
+  const open = sections.find((s) => s.theme.id === openId) ?? null;
 
-  const inCategory =
-    active === "all"
-      ? sections
-      : sections.filter((s) => s.theme.id === active);
+  function openCategory(themeId: string) {
+    setOpenId(themeId);
+    // Rarity is scoped to a category, so entering one starts unfiltered.
+    setRarity(null);
+  }
 
-  const counts = countOwnedByRarity(inCategory);
-
-  const visible = inCategory
-    .map((section) => ({
-      ...section,
-      cards: filterCardsByRarity(section.cards, rarity),
-    }))
-    // Hide sections with no cards under the active rarity filter.
-    .filter((section) => section.cards.length > 0);
+  function closeCategory() {
+    setOpenId(null);
+    setRarity(null);
+  }
 
   return (
     <div className="flex flex-col gap-6">
@@ -70,62 +79,76 @@ export function GalaxyView({ sections }: { sections: ThemeSectionData[] }) {
 
       {mode === "sacrifice" ? (
         <SacrificeGrid cards={burnable} />
+      ) : open === null ? (
+        <CategoryPicker sections={sections} onOpen={openCategory} />
       ) : (
-        <>
-          <nav
-            data-testid="galaxy-tabs"
-            /* Phone: pins at the top on its own (the header is not sticky
-               there) and scrolls sideways in a single row -- wrapping 16
-               categories built a 338px block that swallowed 40% of the screen.
-               `sm:` and up: wraps as before and clears the now-pinned header.
-               That header is a stable 88px single row from 640px up and pins at
-               top-3, so its bottom edge sits at 100px; 108px leaves an 8px gap.
-               The old top-24 (96px) tucked the nav 4px underneath it. */
-            className="sticky top-3 z-[9] flex flex-nowrap gap-2 overflow-x-auto rounded-[var(--radius)] border border-[color:var(--glass-brd)] p-3 shadow-[var(--shadow-soft)] sm:top-[6.75rem] sm:flex-wrap sm:overflow-x-visible"
-            style={{ background: "var(--bg-1)" }}
-          >
-            <TabChip
-              label="★ All"
-              active={active === "all"}
-              onClick={() => setActive("all")}
-              testid="galaxy-tab-all"
-            />
-            {sections.map((s) => (
-              <TabChip
-                key={s.theme.id}
-                label={s.theme.name}
-                active={active === s.theme.id}
-                onClick={() => setActive(s.theme.id)}
-                testid={`galaxy-tab-${s.theme.id}`}
-              />
-            ))}
-          </nav>
-
-          <div data-testid="galaxy-rarity-filter" className="flex flex-wrap gap-2">
-            <TabChip
-              label="All rarities"
-              active={rarity === null}
-              onClick={() => setRarity(null)}
-              testid="galaxy-rarity-all"
-            />
-            {RARITIES.map((r) => (
-              <TabChip
-                key={r}
-                label={`${RARITY_META[r].label} ${counts[r]}`}
-                active={rarity === r}
-                onClick={() => setRarity(r)}
-                testid={`galaxy-rarity-${r}`}
-                frame={RARITY_META[r].frame}
-              />
-            ))}
-          </div>
-
-          {visible.map((section) => (
-            <ThemeSection key={section.theme.id} section={section} />
-          ))}
-        </>
+        <OpenCategory
+          section={open}
+          rarity={rarity}
+          setRarity={setRarity}
+          onBack={closeCategory}
+        />
       )}
     </div>
+  );
+}
+
+/** One category as a destination: a back bar, the rarity row, and the cards. */
+function OpenCategory({
+  section,
+  rarity,
+  setRarity,
+  onBack,
+}: {
+  section: ThemeSectionData;
+  rarity: Rarity | null;
+  setRarity: (r: Rarity | null) => void;
+  onBack: () => void;
+}) {
+  const counts = countOwnedByRarity([section]);
+  const cards = filterCardsByRarity(section.cards, rarity);
+
+  return (
+    <>
+      <div
+        data-testid="galaxy-category-bar"
+        className="sticky top-24 z-[9] flex items-center gap-3 rounded-[var(--radius)] border border-[color:var(--glass-brd)] p-3 shadow-[var(--shadow-soft)]"
+        style={{ background: "var(--bg-1)" }}
+      >
+        <button
+          type="button"
+          onClick={onBack}
+          data-testid="galaxy-category-back"
+          className="btn btn--ghost text-sm"
+        >
+          ← All categories
+        </button>
+        {/* The name only. The section header below carries the progress bar
+            and its 🏆, so the mark is not repeated within one screen. */}
+        <span className="display truncate text-lg">{section.theme.name}</span>
+      </div>
+
+      <div data-testid="galaxy-rarity-filter" className="flex flex-wrap gap-2">
+        <TabChip
+          label="All rarities"
+          active={rarity === null}
+          onClick={() => setRarity(null)}
+          testid="galaxy-rarity-all"
+        />
+        {RARITIES.map((r) => (
+          <TabChip
+            key={r}
+            label={`${RARITY_META[r].label} ${counts[r]}`}
+            active={rarity === r}
+            onClick={() => setRarity(r)}
+            testid={`galaxy-rarity-${r}`}
+            frame={RARITY_META[r].frame}
+          />
+        ))}
+      </div>
+
+      <ThemeSection section={{ ...section, cards }} />
+    </>
   );
 }
 

--- a/src/features/binder/GalaxyView.tsx
+++ b/src/features/binder/GalaxyView.tsx
@@ -9,7 +9,7 @@ import { SacrificeGrid } from "./SacrificeGrid";
 import { CategoryPicker } from "./CategoryPicker";
 import { countOwnedByRarity, filterCardsByRarity } from "./rarity-filter";
 import { sacrificeReady } from "./sacrifice-filter";
-import { BURN, HUB, type Place, parsePlace, placeParam } from "./binder-place";
+import { BURN, HUB, type Place, parsePlace, placeHref } from "./binder-place";
 
 /**
  * Galaxy category view (Inc9 FR1).
@@ -69,12 +69,7 @@ export function GalaxyView({
    * the URL and the back button without one (supported directly in Next 15).
    */
   const go = useCallback((next: Place) => {
-    const param = placeParam(next);
-    window.history.pushState(
-      null,
-      "",
-      param === null ? "/play/binder" : `/play/binder?at=${encodeURIComponent(param)}`,
-    );
+    window.history.pushState(null, "", placeHref(next));
     setPlace(next);
     // Rarity is scoped to a category, so every arrival starts unfiltered.
     setRarity(null);

--- a/src/features/binder/GalaxyView.tsx
+++ b/src/features/binder/GalaxyView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { RARITIES, type Rarity } from "@/lib/types";
 import type { ThemeSection as ThemeSectionData } from "@/lib/types";
 import { RARITY_META } from "@/features/card/rarity";
@@ -9,146 +9,228 @@ import { SacrificeGrid } from "./SacrificeGrid";
 import { CategoryPicker } from "./CategoryPicker";
 import { countOwnedByRarity, filterCardsByRarity } from "./rarity-filter";
 import { sacrificeReady } from "./sacrifice-filter";
+import { BURN, HUB, type Place, parsePlace, placeParam } from "./binder-place";
 
 /**
  * Galaxy category view (Inc9 FR1).
  *
- * #107: a category is now a **place you go**, not a chip you tick. The binder
- * lands on `CategoryPicker` — a grid of picture tiles — and tapping one enters
- * that category, which is where the rarity row and the cards live. The old
- * shape rendered `★ All` plus one chip per theme in a single wrapped sticky
- * `<nav>`; that row grew by one every seed run and never shrank, and was
- * already three or four wrapped lines under a sticky header on a phone. A tile
- * grid grows downwards instead of pushing the cards off screen, so it still
- * reads at 25+ themes.
+ * #107: a category is a **place you go**, not a chip you tick. The binder lands
+ * on `CategoryPicker` — a grid of picture tiles — and tapping one enters that
+ * category, which is where the rarity row and the cards live. The old shape
+ * rendered `★ All` plus one chip per theme in a single wrapped sticky `<nav>`;
+ * that row grew by one every seed run and never shrank, and was already three
+ * or four wrapped lines under a sticky header on a phone. A tile grid grows
+ * downwards instead of pushing the cards off screen, so it still reads at 25+.
  *
- * Two consequences of that swap, both deliberate:
+ * #108 finished the shape around it. The binder is in exactly one **place** —
+ * the hub, one category, or the burn pile — and that place lives in the URL as
+ * `?at=` (see `binder-place.ts` for why). Three consequences:
+ *
+ *   - **The picker is the hub.** Both other places carry a `← All categories`
+ *     bar, so there is exactly one way back and it is the same one everywhere.
+ *   - **The burn pile is a door on the hub, not a mode above every screen.**
+ *     Inc22 FR11 made the burn view global — it ignores category and rarity and
+ *     counts across the whole galaxy — so a `🌌 All cards | 🔥 Ready to
+ *     sacrifice` pair rendered *inside* Dinosaurs lit "All cards" while the
+ *     child was plainly somewhere specific. It is now one entry on the hub,
+ *     muted at zero rather than hidden: `SacrificeGrid`'s empty state is where
+ *     a child learns the 4-copies rule, so it has to stay reachable before they
+ *     have anything to burn.
  *   - **`★ All` is gone.** "Every category at once" is a filter, not a
  *     destination, and 480 slots in one scroll was never a view anyone read.
- *   - **The rarity row moved inside a category.** It AND-combines with the
- *     active category (Inc13 Q4.1=A) and its counts are scoped to the current
- *     selection (Q4.2=A); with no "all categories" selection left, "within the
- *     current selection" now simply means "within this category". The filtered
- *     view still keeps locked cards so the child sees what's left (Q4.3=B).
  *
- * Inc22 FR9/FR11: the "Show" row switches between the galaxy and a flat grid of
- * the cards that can be sacrificed. The burn view is deliberately GLOBAL — it
- * ignores the category and rarity selections, and its count is the total across
- * every category, so "everything I can burn" is never a filtered subset. That
- * is why the mode row sits *above* the picker rather than inside a category:
- * it must never read as a filter applied within one.
+ * **Sticky budget: two layers, ever** — the page header, plus one place bar
+ * inside a category or the burn pile. The rarity row deliberately scrolls away:
+ * it is set on arrival and rarely changed mid-scroll, and a third sticky line
+ * on a phone would re-open exactly the crowding #107 set out to fix.
+ *
+ * Rarity AND-combines with the category (Inc13 Q4.1=A) with counts scoped to
+ * the current selection (Q4.2=A); with no "all categories" selection left that
+ * now simply means "within this category". The filtered view still keeps locked
+ * cards so the child sees what's left (Q4.3=B).
  */
-type Mode = "all" | "sacrifice";
-
-export function GalaxyView({ sections }: { sections: ThemeSectionData[] }) {
-  const [mode, setMode] = useState<Mode>("all");
-  const [openId, setOpenId] = useState<string | null>(null);
+export function GalaxyView({
+  sections,
+  initialPlace,
+}: {
+  sections: ThemeSectionData[];
+  /** Resolved from `?at=` on the server, so a refresh or deep link lands right. */
+  initialPlace: Place;
+}) {
+  const [place, setPlace] = useState<Place>(initialPlace);
   const [rarity, setRarity] = useState<Rarity | null>(null);
 
   const burnable = sacrificeReady(sections);
-  const open = sections.find((s) => s.theme.id === openId) ?? null;
 
-  function openCategory(themeId: string) {
-    setOpenId(themeId);
-    // Rarity is scoped to a category, so entering one starts unfiltered.
+  /**
+   * Going somewhere is a history push, not a re-render of the server page. All
+   * the sections are already in hand, so re-running the route to change `?at=`
+   * would trade an instant switch for a round trip; `history.pushState` gives
+   * the URL and the back button without one (supported directly in Next 15).
+   */
+  const go = useCallback((next: Place) => {
+    const param = placeParam(next);
+    window.history.pushState(
+      null,
+      "",
+      param === null ? "/play/binder" : `/play/binder?at=${encodeURIComponent(param)}`,
+    );
+    setPlace(next);
+    // Rarity is scoped to a category, so every arrival starts unfiltered.
     setRarity(null);
+    window.scrollTo({ top: 0 });
+  }, []);
+
+  // The back button moves between places rather than off the binder entirely.
+  useEffect(() => {
+    function onPop() {
+      const at = new URLSearchParams(window.location.search).get("at");
+      setPlace(parsePlace(at ?? undefined, sections));
+      setRarity(null);
+    }
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, [sections]);
+
+  if (place.kind === "burn") {
+    return (
+      <div className="flex flex-col gap-6">
+        <PlaceBar
+          title={`🔥 ${burnable.length} ${burnable.length === 1 ? "card" : "cards"}`}
+          onBack={() => go(HUB)}
+        />
+        <SacrificeGrid cards={burnable} />
+      </div>
+    );
   }
 
-  function closeCategory() {
-    setOpenId(null);
-    setRarity(null);
+  const open =
+    place.kind === "category"
+      ? (sections.find((s) => s.theme.id === place.themeId) ?? null)
+      : null;
+
+  if (open) {
+    const counts = countOwnedByRarity([open]);
+    const cards = filterCardsByRarity(open.cards, rarity);
+
+    return (
+      <div className="flex flex-col gap-6">
+        <PlaceBar
+          title={open.theme.name}
+          progress={open.progress}
+          onBack={() => go(HUB)}
+        />
+
+        <div data-testid="galaxy-rarity-filter" className="flex flex-wrap gap-2">
+          <TabChip
+            label="All rarities"
+            active={rarity === null}
+            onClick={() => setRarity(null)}
+            testid="galaxy-rarity-all"
+          />
+          {RARITIES.map((r) => (
+            <TabChip
+              key={r}
+              label={`${RARITY_META[r].label} ${counts[r]}`}
+              active={rarity === r}
+              onClick={() => setRarity(r)}
+              testid={`galaxy-rarity-${r}`}
+              frame={RARITY_META[r].frame}
+            />
+          ))}
+        </div>
+
+        {/* The place bar is this screen's header, so the section's own is off:
+            one name, one progress bar, one 🏆 within a single screen. */}
+        <ThemeSection section={{ ...open, cards }} from={place} heading={false} />
+      </div>
+    );
   }
 
   return (
     <div className="flex flex-col gap-6">
-      <div data-testid="galaxy-mode-filter" className="flex flex-wrap gap-2">
-        <TabChip
-          label="🌌 All cards"
-          active={mode === "all"}
-          onClick={() => setMode("all")}
-          testid="galaxy-mode-all"
-        />
-        <TabChip
-          label={`🔥 Ready to sacrifice ${burnable.length}`}
-          active={mode === "sacrifice"}
-          onClick={() => setMode("sacrifice")}
-          testid="galaxy-mode-sacrifice"
-          frame="#f97316"
-        />
-      </div>
-
-      {mode === "sacrifice" ? (
-        <SacrificeGrid cards={burnable} />
-      ) : open === null ? (
-        <CategoryPicker sections={sections} onOpen={openCategory} />
-      ) : (
-        <OpenCategory
-          section={open}
-          rarity={rarity}
-          setRarity={setRarity}
-          onBack={closeCategory}
-        />
-      )}
+      <BurnDoor count={burnable.length} onOpen={() => go(BURN)} />
+      <CategoryPicker
+        sections={sections}
+        onOpen={(themeId) => go({ kind: "category", themeId })}
+      />
     </div>
   );
 }
 
-/** One category as a destination: a back bar, the rarity row, and the cards. */
-function OpenCategory({
-  section,
-  rarity,
-  setRarity,
+/**
+ * The way into the burn pile, on the hub only. Loud while there is something
+ * to burn, quiet at zero — but never hidden, or the rule behind it could never
+ * be discovered before the day it first applies.
+ */
+function BurnDoor({ count, onOpen }: { count: number; onOpen: () => void }) {
+  const ready = count > 0;
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      data-testid="galaxy-burn-door"
+      className={`flex items-center gap-3 rounded-[var(--radius)] px-4 py-3 text-left font-bold transition ${
+        ready
+          ? "bg-[#f97316] text-black shadow-[var(--shadow-soft)] hover:brightness-110"
+          : "bg-white/10 text-[color:var(--ink-soft)] hover:bg-white/20"
+      }`}
+    >
+      <span aria-hidden>🔥</span>
+      <span className="flex-1">Ready to sacrifice {count}</span>
+      <span aria-hidden>→</span>
+    </button>
+  );
+}
+
+/** The one sticky layer a place is allowed: the way back, and where you are. */
+function PlaceBar({
+  title,
+  progress,
   onBack,
 }: {
-  section: ThemeSectionData;
-  rarity: Rarity | null;
-  setRarity: (r: Rarity | null) => void;
+  title: string;
+  progress?: { owned: number; total: number; complete: boolean };
   onBack: () => void;
 }) {
-  const counts = countOwnedByRarity([section]);
-  const cards = filterCardsByRarity(section.cards, rarity);
+  const pct =
+    progress && progress.total > 0
+      ? Math.round((progress.owned / progress.total) * 100)
+      : 0;
 
   return (
-    <>
-      <div
-        data-testid="galaxy-category-bar"
-        className="sticky top-24 z-[9] flex items-center gap-3 rounded-[var(--radius)] border border-[color:var(--glass-brd)] p-3 shadow-[var(--shadow-soft)]"
-        style={{ background: "var(--bg-1)" }}
+    <div
+      data-testid="galaxy-place-bar"
+      className="sticky top-24 z-[9] flex flex-wrap items-center gap-3 rounded-[var(--radius)] border border-[color:var(--glass-brd)] p-3 shadow-[var(--shadow-soft)]"
+      style={{ background: "var(--bg-1)" }}
+    >
+      <button
+        type="button"
+        onClick={onBack}
+        data-testid="galaxy-place-back"
+        className="btn btn--ghost text-sm"
       >
-        <button
-          type="button"
-          onClick={onBack}
-          data-testid="galaxy-category-back"
-          className="btn btn--ghost text-sm"
+        ← All categories
+      </button>
+      <span className="display min-w-0 flex-1 truncate text-lg">{title}</span>
+      {progress ? (
+        <span
+          className="flex items-center gap-2"
+          data-testid="galaxy-place-progress"
         >
-          ← All categories
-        </button>
-        {/* The name only. The section header below carries the progress bar
-            and its 🏆, so the mark is not repeated within one screen. */}
-        <span className="display truncate text-lg">{section.theme.name}</span>
-      </div>
-
-      <div data-testid="galaxy-rarity-filter" className="flex flex-wrap gap-2">
-        <TabChip
-          label="All rarities"
-          active={rarity === null}
-          onClick={() => setRarity(null)}
-          testid="galaxy-rarity-all"
-        />
-        {RARITIES.map((r) => (
-          <TabChip
-            key={r}
-            label={`${RARITY_META[r].label} ${counts[r]}`}
-            active={rarity === r}
-            onClick={() => setRarity(r)}
-            testid={`galaxy-rarity-${r}`}
-            frame={RARITY_META[r].frame}
-          />
-        ))}
-      </div>
-
-      <ThemeSection section={{ ...section, cards }} />
-    </>
+          <span className="h-2.5 w-24 overflow-hidden rounded-full bg-black/30 ring-1 ring-inset ring-white/10">
+            <span
+              className="block h-full rounded-full bg-[linear-gradient(90deg,var(--brand-4),var(--brand-1))] transition-all duration-500"
+              style={{ width: `${pct}%` }}
+            />
+          </span>
+          <span className="text-sm font-bold tabular-nums text-[color:var(--ink-soft)]">
+            {progress.owned} / {progress.total}
+          </span>
+          {progress.complete ? <span aria-label="Set complete">🏆</span> : null}
+        </span>
+      ) : null}
+    </div>
   );
 }
 

--- a/src/features/binder/ProgressBar.tsx
+++ b/src/features/binder/ProgressBar.tsx
@@ -21,7 +21,9 @@ export function ProgressBar({
       <span className="text-sm font-bold tabular-nums text-[color:var(--ink-soft)]">
         {owned} / {total}
       </span>
-      {complete ? <span aria-label="complete">✅</span> : null}
+      {/* Same 🏆 the picker tile and the reward modal use, so "this set is
+          finished" is one symbol the child learns once rather than three. */}
+      {complete ? <span aria-label="Set complete">🏆</span> : null}
     </div>
   );
 }

--- a/src/features/binder/SacrificeGrid.tsx
+++ b/src/features/binder/SacrificeGrid.tsx
@@ -3,6 +3,7 @@ import type { BinderCard } from "@/lib/types";
 import { RarityThumb } from "@/features/card/RarityThumb";
 import { SACRIFICE_COST, SACRIFICE_MIN } from "@/features/pull/sacrifice";
 import { raritySlotClass } from "./rarity-slot";
+import { BURN, cardHref } from "./binder-place";
 import "./rarity-slot.css";
 
 /**
@@ -10,6 +11,11 @@ import "./rarity-slot.css";
  * headers — burnable piles are rare, so grouping them by category is noise.
  * Each tile deep-links to the card detail page, which is where the sacrifice
  * actually happens (SacrificePanel), so this view is a finder, not an action.
+ *
+ * #108: the tiles carry `?from=burn`, because this screen is a loop — burn one,
+ * come back, burn the next — and before that the way back landed on the hub,
+ * two taps from the pile the child was working through. The heading moved to
+ * the sticky place bar above, which names the pile and counts it.
  */
 export function SacrificeGrid({ cards }: { cards: BinderCard[] }) {
   if (cards.length === 0) {
@@ -32,7 +38,6 @@ export function SacrificeGrid({ cards }: { cards: BinderCard[] }) {
 
   return (
     <section data-testid="sacrifice-grid" className="panel flex flex-col gap-4 p-5">
-      <h2 className="text-xl font-bold">🔥 Ready to sacrifice</h2>
       <p className="text-sm text-[color:var(--ink-soft)]">
         Tap a card to burn {SACRIFICE_COST} copies for an Easter Egg ticket 🥚 — you always keep 1.
       </p>
@@ -40,7 +45,7 @@ export function SacrificeGrid({ cards }: { cards: BinderCard[] }) {
         {cards.map((entry) => (
           <Link
             key={entry.card.id}
-            href={`/play/binder/${entry.card.id}`}
+            href={cardHref(entry.card.id, BURN)}
             data-testid={`sacrifice-card-${entry.card.id}`}
             className={`slot-pop relative block ${raritySlotClass(entry.card.rarity)}`}
           >

--- a/src/features/binder/ThemeSection.tsx
+++ b/src/features/binder/ThemeSection.tsx
@@ -2,32 +2,45 @@ import type { ThemeSection as ThemeSectionData } from "@/lib/types";
 import { ProgressBar } from "./ProgressBar";
 import { CardSlot } from "./CardSlot";
 import { SetCompleteCelebration } from "./SetCompleteCelebration";
+import type { Place } from "./binder-place";
 
 export function ThemeSection({
   section,
   admin = false,
+  heading = true,
+  from,
 }: {
   section: ThemeSectionData;
   /** Admin preview: show source links, no play links, no auto-celebration. */
   admin?: boolean;
+  /**
+   * #108: off inside a category, where the sticky place bar already carries the
+   * name, the progress bar and its 🏆. On in the admin views, which stack many
+   * sections and have nothing else telling them apart.
+   */
+  heading?: boolean;
+  /** Where a tapped card should send the child back to (#108). */
+  from?: Place;
 }) {
   return (
     <section
       data-testid={`theme-section-${section.theme.id}`}
       className="panel flex flex-col gap-4 p-5"
     >
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <h2 className="text-xl font-bold">{section.theme.name}</h2>
-        <ProgressBar
-          themeId={section.theme.id}
-          owned={section.progress.owned}
-          total={section.progress.total}
-          complete={section.progress.complete}
-        />
-      </div>
+      {heading ? (
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className="text-xl font-bold">{section.theme.name}</h2>
+          <ProgressBar
+            themeId={section.theme.id}
+            owned={section.progress.owned}
+            total={section.progress.total}
+            complete={section.progress.complete}
+          />
+        </div>
+      ) : null}
       <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 md:grid-cols-6">
         {section.cards.map((entry) => (
-          <CardSlot key={entry.card.id} entry={entry} admin={admin} />
+          <CardSlot key={entry.card.id} entry={entry} admin={admin} from={from} />
         ))}
       </div>
       {section.progress.complete && !admin ? (

--- a/src/features/binder/binder-place.ts
+++ b/src/features/binder/binder-place.ts
@@ -1,0 +1,105 @@
+import type { ThemeSection } from "@/lib/types";
+
+/**
+ * Where the binder is (#108). PURE → property-tested.
+ *
+ * #107 made a category a place you go rather than a chip you tick, and the
+ * binder then shows exactly one of three things: the picker (the hub), one
+ * category, or the burn pile. Those are mutually exclusive, so they are one
+ * value, not a category selection plus a mode flag.
+ *
+ * That value lives in the URL as `?at=`, for one reason: a card is a link.
+ * Every tile deep-links to `/play/binder/<cardId>`, and before #108 coming
+ * back landed on the hub — two taps from where you were, on every card read,
+ * and worse in the burn pile, which is a loop (burn one, come back, burn the
+ * next). A place in the URL survives that round trip, the browser back button,
+ * and a refresh.
+ *
+ * Rarity is deliberately NOT a place. It is a lens applied inside one, it
+ * resets on entry, and it is the child's most-changed control — putting it in
+ * the URL would fill the history stack with things that are not somewhere you
+ * went.
+ *
+ * `burn` cannot collide with a category: `themes.id` is `gen_random_uuid()`.
+ */
+export type Place =
+  | { kind: "hub" }
+  | { kind: "category"; themeId: string }
+  | { kind: "burn" };
+
+export const HUB: Place = { kind: "hub" };
+export const BURN: Place = { kind: "burn" };
+
+/** The reserved `?at=` value for the burn pile. */
+export const BURN_PARAM = "burn";
+
+/**
+ * Read a place out of `?at=`, resolved against the categories that exist.
+ *
+ * Anything unrecognised — absent, empty, a theme that has been deleted, a
+ * hand-typed value — falls back to the hub rather than erroring. A stale link
+ * should land the child on the front door, never on a broken screen.
+ */
+export function parsePlace(
+  at: string | string[] | undefined,
+  sections: ThemeSection[],
+): Place {
+  const raw = Array.isArray(at) ? at[0] : at;
+  if (!raw) return HUB;
+  if (raw === BURN_PARAM) return BURN;
+  return sections.some((s) => s.theme.id === raw)
+    ? { kind: "category", themeId: raw }
+    : HUB;
+}
+
+/**
+ * The `?at=` value for a place — `null` at the hub, so the hub's URL is the
+ * bare `/play/binder` rather than an empty parameter.
+ */
+export function placeParam(place: Place): string | null {
+  switch (place.kind) {
+    case "hub":
+      return null;
+    case "burn":
+      return BURN_PARAM;
+    case "category":
+      return place.themeId;
+  }
+}
+
+/** The binder URL for a place. Round-trips with {@link parsePlace}. */
+export function placeHref(place: Place): string {
+  const param = placeParam(place);
+  return param === null ? "/play/binder" : `/play/binder?at=${encodeURIComponent(param)}`;
+}
+
+/**
+ * Where a card tile should send the child back to: the place they tapped it
+ * from, carried as `?from=`. Absent at the hub, which has no card tiles of its
+ * own but may gain them.
+ */
+export function cardHref(cardId: string, from: Place): string {
+  const param = placeParam(from);
+  const base = `/play/binder/${encodeURIComponent(cardId)}`;
+  return param === null ? base : `${base}?from=${encodeURIComponent(param)}`;
+}
+
+/**
+ * Card detail's back link. Honours `?from=` when the child arrived by tapping
+ * a tile; otherwise derives the card's own category, so a deep link, a shared
+ * URL or the reward modal still lands somewhere that makes sense rather than
+ * on the hub.
+ *
+ * Deliberately does NOT validate `from` against the catalog — card detail
+ * fetches one card, not the whole binder, and validating here would cost it a
+ * second query to guard against a hand-edited parameter. It doesn't need to:
+ * the binder page resolves `?at=` through {@link parsePlace}, so a junk value
+ * degrades to the hub one hop later instead of erroring.
+ */
+export function backHref(
+  from: string | string[] | undefined,
+  cardThemeId: string,
+): string {
+  const raw = Array.isArray(from) ? from[0] : from;
+  return `/play/binder?at=${encodeURIComponent(raw || cardThemeId)}`;
+}

--- a/src/features/binder/binder-place.ts
+++ b/src/features/binder/binder-place.ts
@@ -27,7 +27,9 @@ export type Place =
   | { kind: "category"; themeId: string }
   | { kind: "burn" };
 
+/** The hub place (category picker). */
 export const HUB: Place = { kind: "hub" };
+/** The burn pile place (sacrifice-ready cards). */
 export const BURN: Place = { kind: "burn" };
 
 /** The reserved `?at=` value for the burn pile. */

--- a/src/features/binder/category-cover.ts
+++ b/src/features/binder/category-cover.ts
@@ -1,0 +1,28 @@
+import { RARITIES, type BinderCard, type ThemeSection } from "@/lib/types";
+
+/**
+ * Which card's art fronts a category tile in the picker (#107). PURE →
+ * property-tested.
+ *
+ * `Theme` is `{ id, name }` — it carries no art of its own, so a picture-first
+ * picker has to borrow one from the category's cards. It borrows the child's
+ * **rarest owned** card: the tile then shows off the best thing they pulled
+ * there, and it changes as they collect, so the picker is a record of their
+ * own galaxy rather than 16 fixed pictures.
+ *
+ * A category with nothing owned returns `null`, and the tile falls back to a
+ * neutral placeholder. That is deliberate and load-bearing: `CardSlot` renders
+ * unowned cards as `❔` with no rarity hint (U5-Q5) precisely so unearned art
+ * stays unearned. A dimmed real thumbnail on the tile would leak exactly what
+ * the locked slot is careful not to show.
+ *
+ * Ties inside a rarity resolve to the first card in catalog order, so the cover
+ * does not shuffle between renders.
+ */
+export function coverCard(section: ThemeSection): BinderCard | null {
+  for (const rarity of [...RARITIES].reverse()) {
+    const hit = section.cards.find((c) => c.owned && c.card.rarity === rarity);
+    if (hit) return hit;
+  }
+  return null;
+}

--- a/src/features/binder/sacrifice-filter.ts
+++ b/src/features/binder/sacrifice-filter.ts
@@ -16,10 +16,12 @@ export function canSacrifice(entry: BinderCard): boolean {
 }
 
 /**
- * Every burnable card across ALL sections. Global by design (FR11): it ignores
- * the category and rarity chips so "show me everything I can burn" is always
- * the complete answer, never a filtered subset the child could misread as all
- * they have.
+ * Every burnable card across ALL sections. Global by design (FR11): it spans
+ * every category and ignores the rarity row, so "show me everything I can burn"
+ * is always the complete answer, never a filtered subset the child could misread
+ * as all they have. Since #108 the burn pile is its own place on the binder hub
+ * rather than a mode over the category you happen to be in, which is what makes
+ * that global count honest about where the child is.
  */
 export function sacrificeReady(sections: ThemeSection[]): BinderCard[] {
   return sections.flatMap((section) => section.cards.filter(canSacrifice));

--- a/src/features/pool/contact-sheet.ts
+++ b/src/features/pool/contact-sheet.ts
@@ -198,6 +198,7 @@ export function planContactSheet(
   };
 }
 
+/** Render a contact sheet as markdown for the bake-off review comment. */
 export function renderContactSheet(sheet: ContactSheet): string {
   const cols = sheet.providerIds.length;
   const banner = [

--- a/src/features/pool/provenance.ts
+++ b/src/features/pool/provenance.ts
@@ -120,6 +120,7 @@ export interface PublishedCard {
   provenance: CardProvenance;
 }
 
+/** Create an empty provenance file structure with no themes. */
 export function emptyProvenance(): ProvenanceFile {
   return { themes: {} };
 }

--- a/src/features/pool/seed-schema.ts
+++ b/src/features/pool/seed-schema.ts
@@ -19,6 +19,7 @@ import { RARITIES, zeroRarityCount, type Rarity } from "@/lib/types";
 /** Every theme is exactly this shape. Set-completion rewards and the rarity
  * filters assume it, so an off-pyramid theme breaks the symmetry permanently. */
 export const CARDS_PER_THEME = 30;
+/** Required card count per rarity for each theme (15/8/5/2 pyramid). */
 export const RARITY_PYRAMID: Record<Rarity, number> = {
   common: 15,
   rare: 8,
@@ -26,6 +27,7 @@ export const RARITY_PYRAMID: Record<Rarity, number> = {
   legendary: 2,
 };
 
+/** Zod schema for a single card in the seed file. */
 export const seedCardSchema = z.object({
   name: z.string().trim().min(1),
   rarity: z.enum(RARITIES as unknown as [string, ...string[]]),
@@ -57,6 +59,7 @@ export const seedCardSchema = z.object({
   provider: z.string().trim().min(1).optional(),
 });
 
+/** Zod schema for a theme in the seed file (30 cards in pyramid shape). */
 export const themeSeedSchema = z
   .object({
     name: z.string().trim().min(1),
@@ -89,6 +92,7 @@ export const themeSeedSchema = z
     }
   });
 
+/** Zod schema for the entire seed file (ensures unique card names globally). */
 export const seedFileSchema = z
   .object({
     themes: z.array(themeSeedSchema).min(1),

--- a/src/features/pull/sacrifice-hint.ts
+++ b/src/features/pull/sacrifice-hint.ts
@@ -6,14 +6,17 @@
 
 import { storageGet, storageSet } from "@/lib/storage";
 
+/** Build the localStorage key for tracking sacrifice hint visibility per child. */
 export function hintKey(childId: string): string {
   return `sacrifice-hint-seen:${childId}`;
 }
 
+/** Check if the given child has already seen the sacrifice hint. */
 export function hasSeenSacrificeHint(childId: string): boolean {
   return storageGet("localStorage", hintKey(childId)) === "1";
 }
 
+/** Mark the sacrifice hint as seen for the given child. */
 export function markSacrificeHintSeen(childId: string): void {
   storageSet("localStorage", hintKey(childId), "1");
 }

--- a/src/features/pull/sacrifice.ts
+++ b/src/features/pull/sacrifice.ts
@@ -15,9 +15,9 @@ export const SACRIFICE_COST = 3;
  * copies is never allowed to take your last one — `pull-service` enforces that
  * with `removeCard(childId, cardId, SACRIFICE_COST, SACRIFICE_COST + 1)`, so a
  * holding of exactly SACRIFICE_COST can't be burned. Every surface that offers
- * or advertises a sacrifice gates on THIS constant, so the card detail page and
- * the galaxy's burn filter are the same expression rather than two that happen
- * to agree (Inc22 D4).
+ * or advertises a sacrifice gates on THIS constant, so the card detail page, the
+ * galaxy's burn pile and the swap board's `one-away` tier (`trade/board.ts`) are
+ * one expression rather than several that happen to agree (Inc22 D4).
  */
 export const SACRIFICE_MIN = SACRIFICE_COST + 1;
 

--- a/src/features/quiz/grammar-bank.ts
+++ b/src/features/quiz/grammar-bank.ts
@@ -139,6 +139,7 @@ const subjectVerbAgreement: QuizQuestion[] = [
   mc("sv-16", "The students ___ hard for the exam.", "study", ["studies", "studying", "is study"]),
 ];
 
+/** Map of grammar topic IDs to their question banks. */
 export const GRAMMAR_BANKS: Record<string, QuizQuestion[]> = {
   "verb-tenses": verbTenses,
   "pronouns-vs-proper-nouns": pronounsProperNouns,
@@ -148,6 +149,7 @@ export const GRAMMAR_BANKS: Record<string, QuizQuestion[]> = {
   "subject-verb-agreement": subjectVerbAgreement,
 };
 
+/** True if the given topic ID is a grammar topic with a question bank. */
 export function isGrammarTopic(topicId: string): boolean {
   return topicId in GRAMMAR_BANKS;
 }

--- a/src/features/quiz/math-gen.ts
+++ b/src/features/quiz/math-gen.ts
@@ -107,6 +107,7 @@ const GENERATORS: Record<string, (id: string, rng: Rng) => QuizQuestion> = {
   fractions: fractionQuestion,
 };
 
+/** True if the given topic ID is a math topic with a generator. */
 export function isMathTopic(topicId: string): boolean {
   return topicId in GENERATORS;
 }

--- a/src/features/quiz/topics.ts
+++ b/src/features/quiz/topics.ts
@@ -3,6 +3,7 @@
 
 import type { Topic } from "./types";
 
+/** All available quiz topics with their lessons. */
 export const TOPICS: Topic[] = [
   {
     id: "multiplication-within-100",
@@ -109,6 +110,7 @@ export const TOPICS: Topic[] = [
 
 const BY_ID = new Map(TOPICS.map((t) => [t.id, t]));
 
+/** Look up a topic by id; returns undefined if not found. */
 export function getTopic(id: string): Topic | undefined {
   return BY_ID.get(id);
 }

--- a/src/features/quiz/types.ts
+++ b/src/features/quiz/types.ts
@@ -46,8 +46,10 @@ export interface Topic {
   lesson: Lesson;
 }
 
+/** Number of questions per quiz. */
 export const QUIZ_LENGTH = 5;
-export const DAILY_TICKET_CAP = 3; // global Easter Egg tickets/day from quizzes (D6=D)
+/** Maximum Easter Egg tickets earnable per day from quizzes (D6=D). */
+export const DAILY_TICKET_CAP = 3;
 
 /** Why an award was or wasn't granted, for a friendly message. */
 export type AwardReason = "ok" | "failed" | "topic-done" | "daily-cap";

--- a/src/features/sound/AudioEngine.ts
+++ b/src/features/sound/AudioEngine.ts
@@ -57,6 +57,7 @@ export function unlock(): void {
   }
 }
 
+/** True if Web Audio is available and not blocked. */
 export function isAvailable(): boolean {
   return available;
 }

--- a/src/features/sound/MusicEngine.ts
+++ b/src/features/sound/MusicEngine.ts
@@ -68,6 +68,7 @@ export function startMusic(): void {
   timer = setInterval(schedule, 120);
 }
 
+/** Stop the synthesized loop and disconnect the audio nodes. */
 export function stopMusic(): void {
   running = false;
   if (timer) {

--- a/src/features/sound/bgm.ts
+++ b/src/features/sound/bgm.ts
@@ -8,6 +8,7 @@
  */
 import { startMusic, stopMusic } from "./MusicEngine";
 
+/** Path to the background music audio file (falls back to synth if unavailable). */
 export const BGM_SRC = "/bgm/playful-loop.mp3";
 
 let el: HTMLAudioElement | null = null;
@@ -46,6 +47,7 @@ export function startBgm(): void {
   else el.play().catch(() => startMusic());
 }
 
+/** Stop all background music (both file and synth). */
 export function stopBgm(): void {
   wantOn = false;
   stopMusic();

--- a/src/features/sound/settings.ts
+++ b/src/features/sound/settings.ts
@@ -5,7 +5,9 @@
 
 import { storageGet, storageSet } from "@/lib/storage";
 
+/** localStorage key for sound effects setting. */
 export const SFX_KEY = "kc.snd.sfx";
+/** localStorage key for background music setting. */
 export const BGM_KEY = "kc.snd.bgm";
 
 function read(key: string, fallback: boolean): boolean {
@@ -18,18 +20,22 @@ function write(key: string, value: boolean): void {
   storageSet("localStorage", key, value ? "1" : "0");
 }
 
+/** Get sound effects enabled state (default: true). */
 export function getSfxEnabled(): boolean {
   return read(SFX_KEY, true);
 }
 
+/** Get background music enabled state (default: false). */
 export function getBgmEnabled(): boolean {
   return read(BGM_KEY, false);
 }
 
+/** Set sound effects enabled state. */
 export function setSfxEnabled(value: boolean): void {
   write(SFX_KEY, value);
 }
 
+/** Set background music enabled state. */
 export function setBgmEnabled(value: boolean): void {
   write(BGM_KEY, value);
 }

--- a/src/features/trade/board.ts
+++ b/src/features/trade/board.ts
@@ -29,8 +29,11 @@ const TIER_RANK: Record<SwapTier, number> = { new: 0, "one-away": 1, rest: 2 };
 /**
  * One more copy takes this holding to SACRIFICE_MIN, the constant every surface
  * that offers or advertises a sacrifice gates on (Inc22 D4). Written as
- * "one below the minimum" rather than a literal 3 so it can never drift from
- * `sacrifice-filter.ts`'s `canSacrifice`.
+ * "one below the minimum" rather than a literal 3 so the PREDICATE can never
+ * drift from `sacrifice-filter.ts`'s `canSacrifice`.
+ *
+ * Its DETECTABILITY is a separate matter, and does not follow the constant:
+ * see `buildColumns` on where the receiver's count comes from.
  */
 export function oneAwayFromBurn(count: number): boolean {
   return count + 1 === SACRIFICE_MIN;
@@ -60,6 +63,16 @@ export interface BoardCard {
  * SACRIFICE_MIN - 1 is a duplicate, so it's in the opposite inventory with its
  * count. Nothing has to be added to `getTradeBoard`'s payload, and no child
  * learns anything new about a friend's shelf.
+ *
+ * That last step is why the tier is only OBSERVABLE while SACRIFICE_MIN - 1 is
+ * at least 2. The opposite inventory is `tradableDuplicates` — count >= 2 —
+ * so a receiver holding fewer copies than that never reaches the board with a
+ * count at all, and `tag` reads them as "rest". At SACRIFICE_MIN = 4 the
+ * one-away holding is 3 and lands in the list; lower SACRIFICE_COST far enough
+ * and the tier stops firing everywhere, silently, with the predicate still
+ * correct and the property tests still green — they draw their expectation
+ * from the same duplicates-only inventory. Widen the payload before lowering
+ * the constant.
  */
 export function buildColumns(input: {
   mine: TradableCard[];

--- a/src/features/trade/board.ts
+++ b/src/features/trade/board.ts
@@ -1,4 +1,5 @@
-import type { Card } from "@/lib/types";
+import { RARITIES, type Card } from "@/lib/types";
+import { SACRIFICE_MIN } from "@/features/pull/sacrifice";
 import type { TradableCard } from "./trade-logic";
 
 /**
@@ -7,9 +8,39 @@ import type { TradableCard } from "./trade-logic";
  * from what `validateTrade` will allow at commit time.
  */
 
+/**
+ * What the swap is worth to whoever RECEIVES this card (#109). Ranked, and
+ * mutually exclusive by construction: a receiver holding none can't also hold
+ * SACRIFICE_MIN - 1.
+ *
+ * - `new`      — the receiver owns none of it.
+ * - `one-away` — one more copy makes it burnable on the receiver's shelf.
+ * - `rest`     — they already have it, and this doesn't unlock anything.
+ *
+ * Deliberately about the RECEIVER only. Giving away a card you hold
+ * SACRIFICE_MIN times costs you a burn, and the board says nothing about that
+ * — ruled out of scope on the map: that's a hazard on the giver's tile, not an
+ * ordering.
+ */
+export type SwapTier = "new" | "one-away" | "rest";
+
+const TIER_RANK: Record<SwapTier, number> = { new: 0, "one-away": 1, rest: 2 };
+
+/**
+ * One more copy takes this holding to SACRIFICE_MIN, the constant every surface
+ * that offers or advertises a sacrifice gates on (Inc22 D4). Written as
+ * "one below the minimum" rather than a literal 3 so it can never drift from
+ * `sacrifice-filter.ts`'s `canSacrifice`.
+ */
+export function oneAwayFromBurn(count: number): boolean {
+  return count + 1 === SACRIFICE_MIN;
+}
+
 export interface BoardCard {
   card: Card;
   count: number;
+  /** What this swap is worth to the party on the OTHER side of the board. */
+  tier: SwapTier;
   /**
    * True when the OTHER party doesn't own this card at all. Drives the badge
    * (FR4) and the "only show what's missing" filter (FR5). Deliberately about
@@ -19,7 +50,17 @@ export interface BoardCard {
   newToOther: boolean;
 }
 
-/** Tag both inventories against the opposite party's ownership set. */
+/**
+ * Tag both inventories against the opposite party's ownership set, and order
+ * each column by what the swap is worth to the party who'd RECEIVE it (#109).
+ *
+ * Both columns are built here, mirrored, so the sort can never be applied to
+ * one side and forgotten on the other. The tier-2 test needs the receiver's
+ * COUNT, not just their ownership — and it's already here: a holding of
+ * SACRIFICE_MIN - 1 is a duplicate, so it's in the opposite inventory with its
+ * count. Nothing has to be added to `getTradeBoard`'s payload, and no child
+ * learns anything new about a friend's shelf.
+ */
 export function buildColumns(input: {
   mine: TradableCard[];
   theirs: TradableCard[];
@@ -27,14 +68,47 @@ export function buildColumns(input: {
   theirOwnedIds: ReadonlySet<string>;
 }): { mine: BoardCard[]; theirs: BoardCard[] } {
   const { mine, theirs, myOwnedIds, theirOwnedIds } = input;
+  const myCounts = countsById(mine);
+  const theirCounts = countsById(theirs);
   return {
-    mine: mine.map((t) => tag(t, theirOwnedIds)),
-    theirs: theirs.map((t) => tag(t, myOwnedIds)),
+    mine: orderByValue(mine.map((t) => tag(t, theirOwnedIds, theirCounts))),
+    theirs: orderByValue(theirs.map((t) => tag(t, myOwnedIds, myCounts))),
   };
 }
 
-function tag(t: TradableCard, otherOwnedIds: ReadonlySet<string>): BoardCard {
-  return { card: t.card, count: t.count, newToOther: !otherOwnedIds.has(t.card.id) };
+function countsById(cards: TradableCard[]): ReadonlyMap<string, number> {
+  return new Map(cards.map((t) => [t.card.id, t.count]));
+}
+
+function tag(
+  t: TradableCard,
+  otherOwnedIds: ReadonlySet<string>,
+  otherCounts: ReadonlyMap<string, number>,
+): BoardCard {
+  const newToOther = !otherOwnedIds.has(t.card.id);
+  const theirCount = otherCounts.get(t.card.id);
+  const tier: SwapTier = newToOther
+    ? "new"
+    : theirCount !== undefined && oneAwayFromBurn(theirCount)
+      ? "one-away"
+      : "rest";
+  return { card: t.card, count: t.count, newToOther, tier };
+}
+
+/**
+ * Best swap first: tier, then rarest, then card id. A TOTAL order — ties broken
+ * all the way down to the id — because a partial one lets tiles reshuffle
+ * between renders under a child's thumb. Rarity ahead of id also clusters
+ * same-rarity cards, which is what the rarity lock narrows to once a side is
+ * picked.
+ */
+export function orderByValue(cards: BoardCard[]): BoardCard[] {
+  return [...cards].sort(
+    (a, b) =>
+      TIER_RANK[a.tier] - TIER_RANK[b.tier] ||
+      RARITIES.indexOf(b.card.rarity) - RARITIES.indexOf(a.card.rarity) ||
+      (a.card.id < b.card.id ? -1 : a.card.id > b.card.id ? 1 : 0),
+  );
 }
 
 /** FR5 — hide the cards the other party already has. `false` is the identity. */

--- a/src/lib/avatars.ts
+++ b/src/lib/avatars.ts
@@ -12,12 +12,15 @@ export const AVATAR_PRESETS = [
 
 export type AvatarKey = (typeof AVATAR_PRESETS)[number]["key"];
 
+/** Array of all valid avatar keys. */
 export const AVATAR_KEYS = AVATAR_PRESETS.map((a) => a.key) as AvatarKey[];
 
+/** Type guard: true if the given string is a valid avatar key. */
 export function isValidAvatar(key: string): key is AvatarKey {
   return AVATAR_KEYS.includes(key as AvatarKey);
 }
 
+/** Get the emoji for a given avatar key, defaulting to "❓" if not found. */
 export function avatarEmoji(key: string): string {
   return AVATAR_PRESETS.find((a) => a.key === key)?.emoji ?? "❓";
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -10,6 +10,7 @@ function required(name: string): string {
   return value;
 }
 
+/** Server-only environment variables with validation. */
 export const env = {
   get databaseUrl(): string {
     return required("DATABASE_URL");

--- a/src/lib/posthog-server.ts
+++ b/src/lib/posthog-server.ts
@@ -2,6 +2,10 @@ import { PostHog } from "posthog-node";
 
 let posthogClient: PostHog | null = null;
 
+/**
+ * Get or initialize the server-side PostHog client. Returns null if the
+ * project token is not configured, logging an error in development only.
+ */
 export function getPostHogClient(): PostHog | null {
   const key = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN;
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -20,6 +20,7 @@ function resolveStorage(kind: StorageKind): Storage | null {
   }
 }
 
+/** Get a value from storage; returns null if unavailable or blocked. */
 export function storageGet(kind: StorageKind, key: string): string | null {
   const store = resolveStorage(kind);
   if (!store) return null;
@@ -30,6 +31,7 @@ export function storageGet(kind: StorageKind, key: string): string | null {
   }
 }
 
+/** Set a value in storage; silently fails if unavailable or blocked. */
 export function storageSet(kind: StorageKind, key: string, value: string): void {
   const store = resolveStorage(kind);
   if (!store) return;

--- a/tests/binder-place.pbt.test.ts
+++ b/tests/binder-place.pbt.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import {
+  BURN,
+  BURN_PARAM,
+  HUB,
+  backHref,
+  cardHref,
+  parsePlace,
+  placeHref,
+  placeParam,
+  type Place,
+} from "@/features/binder/binder-place";
+import type { ThemeSection } from "@/lib/types";
+
+function section(id: string): ThemeSection {
+  return {
+    theme: { id, name: id },
+    cards: [],
+    progress: { owned: 0, total: 0, complete: false },
+  };
+}
+
+/** Theme ids are `gen_random_uuid()`, so never the reserved `burn`. */
+const themeIdArb = fc.uuid();
+const sectionsArb = fc
+  .uniqueArray(themeIdArb, { maxLength: 8 })
+  .map((ids) => ids.map(section));
+
+const placeArb: fc.Arbitrary<Place> = fc.oneof(
+  fc.constant(HUB),
+  fc.constant(BURN),
+  themeIdArb.map((themeId) => ({ kind: "category", themeId }) as Place),
+);
+
+describe("parsePlace (#108 one place, in the URL)", () => {
+  it("absent, empty and unknown all mean the hub", () => {
+    const sections = [section("a"), section("b")];
+    expect(parsePlace(undefined, sections)).toEqual(HUB);
+    expect(parsePlace("", sections)).toEqual(HUB);
+    expect(parsePlace("deleted-theme", sections)).toEqual(HUB);
+  });
+
+  it("never errors and never yields a category that does not exist", () => {
+    fc.assert(
+      fc.property(fc.string(), sectionsArb, (at, sections) => {
+        const place = parsePlace(at, sections);
+        if (place.kind === "category") {
+          expect(sections.some((s) => s.theme.id === place.themeId)).toBe(true);
+        }
+      }),
+    );
+  });
+
+  it("reads the burn pile whatever the catalog holds", () => {
+    fc.assert(
+      fc.property(sectionsArb, (sections) => {
+        expect(parsePlace(BURN_PARAM, sections)).toEqual(BURN);
+      }),
+    );
+  });
+
+  it("takes the first value when a param is repeated", () => {
+    const sections = [section("a"), section("b")];
+    expect(parsePlace(["a", "b"], sections)).toEqual({ kind: "category", themeId: "a" });
+  });
+
+  it("round-trips every place that exists", () => {
+    fc.assert(
+      fc.property(placeArb, (place) => {
+        const sections = place.kind === "category" ? [section(place.themeId)] : [];
+        expect(parsePlace(placeParam(place) ?? undefined, sections)).toEqual(place);
+      }),
+    );
+  });
+});
+
+describe("placeHref", () => {
+  it("gives the hub the bare route, not an empty parameter", () => {
+    expect(placeHref(HUB)).toBe("/play/binder");
+  });
+
+  it("names the other two places", () => {
+    expect(placeHref(BURN)).toBe("/play/binder?at=burn");
+    expect(placeHref({ kind: "category", themeId: "abc" })).toBe("/play/binder?at=abc");
+  });
+});
+
+describe("cardHref", () => {
+  it("carries the place the card was tapped from", () => {
+    expect(cardHref("c1", BURN)).toBe("/play/binder/c1?from=burn");
+    expect(cardHref("c1", { kind: "category", themeId: "t1" })).toBe(
+      "/play/binder/c1?from=t1",
+    );
+  });
+
+  it("omits ?from at the hub", () => {
+    expect(cardHref("c1", HUB)).toBe("/play/binder/c1");
+  });
+
+  it("always points at the card, whatever the origin", () => {
+    fc.assert(
+      fc.property(fc.uuid(), placeArb, (cardId, from) => {
+        expect(cardHref(cardId, from).startsWith(`/play/binder/${cardId}`)).toBe(true);
+      }),
+    );
+  });
+});
+
+describe("backHref (#108 the round trip)", () => {
+  it("returns to the burn pile, which is a loop", () => {
+    expect(backHref("burn", "t1")).toBe("/play/binder?at=burn");
+  });
+
+  it("returns to the category the card was tapped in", () => {
+    expect(backHref("t1", "t1")).toBe("/play/binder?at=t1");
+  });
+
+  it("falls back to the card's own category when nothing was carried", () => {
+    expect(backHref(undefined, "t9")).toBe("/play/binder?at=t9");
+    expect(backHref("", "t9")).toBe("/play/binder?at=t9");
+  });
+
+  it("never lands the child off the binder, whatever ?from says", () => {
+    fc.assert(
+      fc.property(fc.option(fc.string(), { nil: undefined }), fc.uuid(), (from, themeId) => {
+        expect(backHref(from, themeId).startsWith("/play/binder?at=")).toBe(true);
+      }),
+    );
+  });
+
+  it("a junk ?from degrades to the hub one hop later rather than erroring", () => {
+    fc.assert(
+      fc.property(fc.string(), sectionsArb, (junk, sections) => {
+        const href = backHref(junk, "not-a-theme");
+        const at = decodeURIComponent(href.slice("/play/binder?at=".length));
+        expect(() => parsePlace(at, sections)).not.toThrow();
+      }),
+    );
+  });
+});

--- a/tests/category-cover.pbt.test.ts
+++ b/tests/category-cover.pbt.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import { coverCard } from "@/features/binder/category-cover";
+import { RARITIES, type Rarity } from "@/lib/types";
+import type { BinderCard, ThemeSection } from "@/lib/types";
+
+function bcard(id: string, rarity: Rarity, owned: boolean): BinderCard {
+  return {
+    card: { id, themeId: "t", name: id, rarity, imageUrl: "x", eduText: "y", sourceUrl: "" },
+    owned,
+    count: owned ? 1 : 0,
+  };
+}
+
+const rarityArb = fc.constantFrom<Rarity>(...RARITIES);
+const cardArb = fc
+  .tuple(fc.string({ minLength: 1 }), rarityArb, fc.boolean())
+  .map(([id, r, owned]) => bcard(id, r, owned));
+
+const sectionArb: fc.Arbitrary<ThemeSection> = fc
+  .array(cardArb, { maxLength: 20 })
+  .map((cards) => ({
+    theme: { id: "t", name: "T" },
+    cards,
+    progress: {
+      owned: cards.filter((c) => c.owned).length,
+      total: cards.length,
+      complete: cards.length > 0 && cards.every((c) => c.owned),
+    },
+  }));
+
+function section(cards: BinderCard[]): ThemeSection {
+  return {
+    theme: { id: "t", name: "T" },
+    cards,
+    progress: { owned: 0, total: cards.length, complete: false },
+  };
+}
+
+describe("coverCard (#107 category picker)", () => {
+  it("picks the rarest owned card", () => {
+    const cover = coverCard(
+      section([
+        bcard("a", "common", true),
+        bcard("b", "legendary", true),
+        bcard("c", "epic", true),
+      ]),
+    );
+    expect(cover?.card.id).toBe("b");
+  });
+
+  it("ignores unowned cards even when they are rarer", () => {
+    const cover = coverCard(
+      section([bcard("a", "common", true), bcard("b", "legendary", false)]),
+    );
+    expect(cover?.card.id).toBe("a");
+  });
+
+  it("returns null when nothing is owned, so unearned art never leaks (U5-Q5)", () => {
+    fc.assert(
+      fc.property(fc.array(cardArb, { maxLength: 20 }), (cards) => {
+        const locked = cards.map((c) => ({ ...c, owned: false, count: 0 }));
+        expect(coverCard(section(locked))).toBe(null);
+      }),
+    );
+  });
+
+  it("never returns an unowned card", () => {
+    fc.assert(
+      fc.property(sectionArb, (s) => {
+        const cover = coverCard(s);
+        if (cover) expect(cover.owned).toBe(true);
+      }),
+    );
+  });
+
+  it("returns a card iff the category has at least one owned card", () => {
+    fc.assert(
+      fc.property(sectionArb, (s) => {
+        const anyOwned = s.cards.some((c) => c.owned);
+        expect(coverCard(s) !== null).toBe(anyOwned);
+      }),
+    );
+  });
+
+  it("is stable: no owned card in the section is rarer than the cover", () => {
+    fc.assert(
+      fc.property(sectionArb, (s) => {
+        const cover = coverCard(s);
+        if (!cover) return;
+        const rank = (r: Rarity) => RARITIES.indexOf(r);
+        for (const c of s.cards) {
+          if (c.owned) {
+            expect(rank(c.card.rarity)).toBeLessThanOrEqual(rank(cover.card.rarity));
+          }
+        }
+      }),
+    );
+  });
+
+  it("ties inside a rarity resolve to the first card in catalog order", () => {
+    const cover = coverCard(
+      section([
+        bcard("first", "epic", true),
+        bcard("second", "epic", true),
+      ]),
+    );
+    expect(cover?.card.id).toBe("first");
+  });
+});

--- a/tests/trade-board.pbt.test.ts
+++ b/tests/trade-board.pbt.test.ts
@@ -47,11 +47,8 @@ describe("buildColumns (Inc22 FR4 — badge only what's new to the other side)",
     fc.assert(
       fc.property(inventoryArb, inventoryArb, ownedArb, ownedArb, (mine, theirs, myOwned, theirOwned) => {
         const cols = buildColumns({ mine, theirs, myOwnedIds: myOwned, theirOwnedIds: theirOwned });
-        expect(sortedIds(cols.mine)).toEqual([...mine.map((t) => t.card.id)].sort());
-        expect(sortedIds(cols.theirs)).toEqual([...theirs.map((t) => t.card.id)].sort());
-        for (const t of mine) {
-          expect(cols.mine.find((c) => c.card.id === t.card.id)!.count).toBe(t.count);
-        }
+        expect(sortedPairs(cols.mine)).toEqual(sortedPairs(mine));
+        expect(sortedPairs(cols.theirs)).toEqual(sortedPairs(theirs));
       }),
     );
   });
@@ -162,6 +159,15 @@ describe("isPickable (Inc22 FR6 — agrees with validateTrade)", () => {
 
 function sortedIds(cards: BoardCard[]): string[] {
   return cards.map((c) => c.card.id).sort();
+}
+
+/**
+ * Membership as a multiset of (id, count) pairs. Ids repeat in a generated
+ * inventory, so a first-match lookup would check one entry's count twice and
+ * miss the other entirely.
+ */
+function sortedPairs(cards: { card: { id: string }; count: number }[]): string[] {
+  return cards.map((c) => `${c.card.id}\u0000${c.count}`).sort();
 }
 
 const TIER_RANK: Record<SwapTier, number> = { new: 0, "one-away": 1, rest: 2 };

--- a/tests/trade-board.pbt.test.ts
+++ b/tests/trade-board.pbt.test.ts
@@ -5,7 +5,12 @@ import {
   applyMissingFilter,
   missingCount,
   isPickable,
+  oneAwayFromBurn,
+  orderByValue,
+  type BoardCard,
+  type SwapTier,
 } from "@/features/trade/board";
+import { SACRIFICE_MIN } from "@/features/pull/sacrifice";
 import { validateTrade, type TradableCard } from "@/features/trade/trade-logic";
 import { RARITIES, type Rarity } from "@/lib/types";
 
@@ -36,13 +41,17 @@ describe("buildColumns (Inc22 FR4 — badge only what's new to the other side)",
     );
   });
 
-  it("preserves both inventories card-for-card, in order", () => {
+  it("preserves both inventories card-for-card — the sort reorders, never drops", () => {
+    // Order is #109's business; membership is not. A column that loses a card
+    // silently removes a swap the child could have made.
     fc.assert(
       fc.property(inventoryArb, inventoryArb, ownedArb, ownedArb, (mine, theirs, myOwned, theirOwned) => {
         const cols = buildColumns({ mine, theirs, myOwnedIds: myOwned, theirOwnedIds: theirOwned });
-        expect(cols.mine.map((c) => c.card.id)).toEqual(mine.map((t) => t.card.id));
-        expect(cols.theirs.map((c) => c.card.id)).toEqual(theirs.map((t) => t.card.id));
-        expect(cols.mine.map((c) => c.count)).toEqual(mine.map((t) => t.count));
+        expect(sortedIds(cols.mine)).toEqual([...mine.map((t) => t.card.id)].sort());
+        expect(sortedIds(cols.theirs)).toEqual([...theirs.map((t) => t.card.id)].sort());
+        for (const t of mine) {
+          expect(cols.mine.find((c) => c.card.id === t.card.id)!.count).toBe(t.count);
+        }
       }),
     );
   });
@@ -144,6 +153,154 @@ describe("isPickable (Inc22 FR6 — agrees with validateTrade)", () => {
     fc.assert(
       fc.property(tcardArb, tcardArb, (a, b) => {
         expect(isPickable(a.card, b.card)).toBe(isPickable(b.card, a.card));
+      }),
+    );
+  });
+});
+
+// ---- #109: what a swap is worth to whoever receives the card ----
+
+function sortedIds(cards: BoardCard[]): string[] {
+  return cards.map((c) => c.card.id).sort();
+}
+
+const TIER_RANK: Record<SwapTier, number> = { new: 0, "one-away": 1, rest: 2 };
+
+describe("oneAwayFromBurn (#109 tier 2 — expressed through SACRIFICE_MIN, never a literal)", () => {
+  it("is true for exactly one holding: one below the burn minimum", () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 20 }), (count) => {
+        expect(oneAwayFromBurn(count)).toBe(count === SACRIFICE_MIN - 1);
+      }),
+    );
+  });
+
+  it("one more copy always lands exactly on the burn minimum", () => {
+    // The whole promise of the tier: accept this swap and the receiver can burn.
+    // If SACRIFICE_MIN ever moves, this stays true and the literal would not.
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 20 }), (count) => {
+        if (oneAwayFromBurn(count)) expect(count + 1).toBe(SACRIFICE_MIN);
+      }),
+    );
+  });
+});
+
+describe("tiers (#109 — mirrored, receiver-valued)", () => {
+  it("tier 'new' is exactly newToOther, on both columns", () => {
+    fc.assert(
+      fc.property(inventoryArb, inventoryArb, ownedArb, ownedArb, (mine, theirs, myOwned, theirOwned) => {
+        const cols = buildColumns({ mine, theirs, myOwnedIds: myOwned, theirOwnedIds: theirOwned });
+        for (const c of [...cols.mine, ...cols.theirs]) {
+          expect(c.tier === "new").toBe(c.newToOther);
+        }
+      }),
+    );
+  });
+
+  it("tier 'one-away' means the RECEIVER — not the giver — is one copy from burning", () => {
+    // The mirror is the easy thing to get backwards: my column is tiered by the
+    // friend's shelf, theirs by mine.
+    fc.assert(
+      fc.property(inventoryArb, inventoryArb, ownedArb, ownedArb, (mine, theirs, myOwned, theirOwned) => {
+        const cols = buildColumns({ mine, theirs, myOwnedIds: myOwned, theirOwnedIds: theirOwned });
+        const theirCount = new Map(theirs.map((t) => [t.card.id, t.count]));
+        const myCount = new Map(mine.map((t) => [t.card.id, t.count]));
+        for (const c of cols.mine) {
+          const held = theirCount.get(c.card.id);
+          expect(c.tier === "one-away").toBe(
+            theirOwned.has(c.card.id) && held !== undefined && oneAwayFromBurn(held),
+          );
+        }
+        for (const c of cols.theirs) {
+          const held = myCount.get(c.card.id);
+          expect(c.tier === "one-away").toBe(
+            myOwned.has(c.card.id) && held !== undefined && oneAwayFromBurn(held),
+          );
+        }
+      }),
+    );
+  });
+
+  it("a card the receiver owns but holds only once is 'rest', never 'one-away'", () => {
+    // Single copies never reach the duplicate list, so the count is simply absent.
+    // Absent must read as "not one away", not as "unknown, assume yes".
+    const card = tcard("solo", "rare", 4);
+    const cols = buildColumns({
+      mine: [card],
+      theirs: [],
+      myOwnedIds: new Set(["solo"]),
+      theirOwnedIds: new Set(["solo"]),
+    });
+    expect(cols.mine[0].tier).toBe("rest");
+  });
+
+  it("puts a receiver holding SACRIFICE_MIN - 1 in tier 2, and one more copy in tier 3", () => {
+    const oneAway = tcard("one-away", "rare", 2);
+    const already = tcard("already", "rare", 2);
+    const cols = buildColumns({
+      mine: [oneAway, already],
+      theirs: [tcard("one-away", "rare", SACRIFICE_MIN - 1), tcard("already", "rare", SACRIFICE_MIN)],
+      myOwnedIds: new Set(["one-away", "already"]),
+      theirOwnedIds: new Set(["one-away", "already"]),
+    });
+    expect(cols.mine.find((c) => c.card.id === "one-away")!.tier).toBe("one-away");
+    expect(cols.mine.find((c) => c.card.id === "already")!.tier).toBe("rest");
+  });
+});
+
+describe("orderByValue (#109 — best swap first, and it never moves under a thumb)", () => {
+  const boardCardArb = fc
+    .tuple(tcardArb, fc.constantFrom<SwapTier>("new", "one-away", "rest"))
+    .map(([t, tier]) => ({ ...t, tier, newToOther: tier === "new" }) satisfies BoardCard);
+  const columnArb = fc.array(boardCardArb, { maxLength: 20 });
+
+  it("is a permutation — nothing added, nothing lost", () => {
+    fc.assert(
+      fc.property(columnArb, (cards) => {
+        expect(sortedIds(orderByValue(cards))).toEqual(sortedIds(cards));
+      }),
+    );
+  });
+
+  it("never mutates its input", () => {
+    fc.assert(
+      fc.property(columnArb, (cards) => {
+        const before = cards.map((c) => c.card.id);
+        orderByValue(cards);
+        expect(cards.map((c) => c.card.id)).toEqual(before);
+      }),
+    );
+  });
+
+  it("orders new → one-away → rest, then rarest, then id", () => {
+    fc.assert(
+      fc.property(columnArb, (cards) => {
+        const out = orderByValue(cards);
+        for (let i = 1; i < out.length; i += 1) {
+          const [a, b] = [out[i - 1], out[i]];
+          expect(TIER_RANK[a.tier]).toBeLessThanOrEqual(TIER_RANK[b.tier]);
+          if (a.tier !== b.tier) continue;
+          expect(RARITIES.indexOf(a.card.rarity)).toBeGreaterThanOrEqual(
+            RARITIES.indexOf(b.card.rarity),
+          );
+          if (a.card.rarity !== b.card.rarity) continue;
+          expect(a.card.id <= b.card.id).toBe(true);
+        }
+      }),
+    );
+  });
+
+  it("is a TOTAL order: the same cards in any arrival order give the same column", () => {
+    // The property that matters at the thumb — a re-render must not reshuffle
+    // tiles, so distinct cards can never compare equal.
+    fc.assert(
+      fc.property(columnArb, (cards) => {
+        const unique = [...new Map(cards.map((c) => [c.card.id, c])).values()];
+        const shuffled = [...unique].reverse();
+        expect(orderByValue(shuffled).map((c) => c.card.id)).toEqual(
+          orderByValue(unique).map((c) => c.card.id),
+        );
       }),
     );
   });


### PR DESCRIPTION
## Intent

Resolve wayfinder ticket #109 on map #106: pin the two swap tiers on the kid-to-kid swap board and ship the mirrored sort. Both columns are ordered by what the swap is worth to whoever RECEIVES the card, in three tiers: new (receiver owns none — the existing newToOther) → one-away (receiver holds SACRIFICE_MIN - 1, so this copy makes it burnable) → rest. Decisions the user made explicitly during grilling, which a reviewer reading only the diff would not know: (1) 'new' deliberately beats 'one-away' — stress-tested and kept, because a never-seen card is what the board exists for and the burn payoff is indirect; (2) tier 2 ships with NO visible marking on the tile — how a tile says 'one more and you can burn it' is ticket #110's call, which this unblocks, so a mid-way state where tier-2 cards float up unlabelled is intentional, not an oversight; (3) the giver-side cost (handing over a card you hold SACRIFICE_MIN times drops you to SACRIFICE_COST and costs you a burn) is deliberately OUT OF SCOPE and recorded as such on the map — it is a hazard flag on the giver's tile, not an ordering; (4) tie-break inside a tier is rarity descending then card id, chosen to be a TOTAL order so tiles cannot reshuffle between renders under a child's thumb, and because clustering same-rarity cards is what the rarity lock narrows to. Constraints honoured: tier 2 must be expressed through SACRIFICE_MIN (count + 1 === SACRIFICE_MIN), never a literal 3, per Inc22 D4 which requires every surface advertising a sacrifice to gate on the constant; no change to getTradeBoardAction's payload was permitted, because a wider payload would show a child more about a friend's shelf — the receiver counts were verified already present via tradableDuplicates (count >= 2). Deliberately untouched, all belonging to ticket #111: the two missing-only filters, isPickable's rarity lock, and the friend strip. Every rule a child sees is a pure property-tested module beside the component, this repo's standing pattern, so the tiers and ordering live in board.ts with property tests in tests/trade-board.pbt.test.ts. The pre-existing test asserting buildColumns preserved inventory order was intentionally rewritten as a multiset-preservation property, since ordering is now this ticket's business.

## What Changed

- **Galaxy is now a set of places, not a chip row (#107).** `GalaxyView` lands on a new picture-first `CategoryPicker` (one tile per theme, cover art borrowed from the child's rarest owned card via the new property-tested `category-cover.ts`, `🪐` placeholder when nothing is owned so unearned art stays unearned), and the burn pile becomes its own destination behind a `BurnDoor` instead of a mode layered over whatever category was selected. Inside a category, a sticky `PlaceBar` carries the name, progress and back link, so `ThemeSection` gained a `heading` opt-out. Rarity stays a lens inside a place.
- **The binder's place lives in the URL (#108).** New `binder-place.ts` (`Place` = hub | category | burn) owns `parsePlace` / `placeParam` / `placeHref` / `cardHref` / `backHref`; `app/play/binder/page.tsx` resolves `?at=` server-side and hands `initialPlace` to `GalaxyView`, which moves between places with `history.pushState`. Card tiles carry `?from=`, and `app/play/binder/[cardId]/page.tsx` uses it so returning from a card lands where the child tapped it — previously always the hub, which cost a re-entry on every card and on every loop through the burn pile.
- **Swap board columns are ordered by what the swap is worth to the receiver (#109).** `board.ts` adds a `SwapTier` (`new` → `one-away` → `rest`) and `orderByValue`, applied to both columns in `buildColumns` so the mirror can't be applied to one side only. Tier 2 is expressed as `count + 1 === SACRIFICE_MIN` (never a literal), receiver counts come from the existing `tradableDuplicates` payload so nothing new is exposed about a friend's shelf, and ties break rarity-descending then card id to give a total order that can't reshuffle between renders. Tier 2 intentionally ships with no tile marking — that's #110's call. The `buildColumns` test that asserted inventory *order* was rewritten as a multiset-preservation property, since ordering is now this module's job.
- Property tests added for `binder-place` and `category-cover` and extended for the trade board; `CONTEXT.md` gains **Place** and **Swap tier**, and the vision document's binder/`SACRIFICE_MIN` entries were refreshed to match. `aidlc-docs` increment artifacts were deliberately left alone as AI-DLC history.

## Risk Assessment

✅ Low: The follow-up commit applies all three accepted fixes exactly as instructed — a strictly stronger id-keyed test property, routing the one production URL push through the property-tested placeHref, and a comment-only correction — leaving a pure, well-bounded, property-tested change that satisfies every source-verifiable criterion in the intent.

## Testing

Ran the one relevant test file (tests/trade-board.pbt.test.ts, 20 property/example tests) at default and 5x search depth — all pass, no flakiness — then produced reviewer-visible visual evidence by server-rendering the actual TradeBoard component with real board.ts logic and the app's compiled Tailwind CSS, and screenshotting it in headless Chrome. The after shot shows both columns ordered new → one-away → rest with rarity-desc/id tie-breaks (tier-2 commons Ant/Bee ahead of tier-3 legendary Kraken), tier-2 tiles carrying no badge, and the mirror proven by Shark being one-away in your column but rest in Maya's while Moth is the reverse; the before shot, rendered from the base commit's board.ts against the same fixture, shows the unordered arrival sequence. A CLI transcript records arrival order, board order, per-tile tier and whose shelf decided it, plus a stability check that reversing arrival order yields the same column. Card art is a name-bearing placeholder SVG because real art lives in Blob and is unreachable offline; the tile does not render the card name, so this keeps the screenshot legible without altering the surface under test. No product or setup failures found; the render harness was deleted and the local static server stopped, leaving the worktree clean.

- Evidence: Swap board AFTER (#109 ordering) — both columns new → one-away → rest, tier 2 unbadged (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M15TZ0RCANBBVHZXTVYBCGEH/swap-board.png</code>)
- Evidence: Swap board BEFORE (base commit board.ts) — raw inventory arrival order (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M15TZ0RCANBBVHZXTVYBCGEH/swap-board-before.png</code>)
<details>
<summary>Evidence: Ordering transcript: arrival order → board order, tier per tile, mirror, stability</summary>

<code>SACRIFICE_MIN = 4 -&gt; &#34;one-away&#34; = receiver holds 3&#10;&#10;── Your doubles (tiered by MAYA&#39;s shelf) ──&#10;arrival order : wolf, bee, kraken, moth, dragon, robot, ant, tiger, comet, shark, fern, yeti&#10;board order : dragon, yeti, comet, shark, ant, bee, kraken, robot, tiger, wolf, fern, moth&#10;dragon legendary new (Maya holds 0) | yeti epic new 0 | comet rare new 0&#10;shark rare one-away 3 | ant common one-away 3 | bee common one-away 3&#10;kraken legendary rest 2 | robot rare rest 2 | tiger rare rest 2 | wolf rare rest 5 | fern common rest 4 | moth common rest 2&#10;&#10;── Maya&#39;s doubles (tiered by YOUR shelf) ──&#10;arrival order : wolf, kraken, shark, ghost, moth, bee, tiger, ant, orca, robot, fern&#10;board order : ghost, orca, tiger, fern, moth, kraken, robot, shark, wolf, ant, bee&#10;&#10;── the mirror ──&#10;shark your column: one-away (Maya holds 3) Maya&#39;s column: rest (you hold 2)&#10;moth your column: rest (Maya holds 2) Maya&#39;s column: one-away (you hold 3)&#10;&#10;── tier 2 carries no badge (ticket #110&#39;s call) ──&#10;shark/ant/bee/tiger/fern/moth tier=one-away newToOther=false -&gt; tile renders no badge&#10;&#10;── stable under re-render ──&#10;inventory handed back in the opposite order -&gt; same board order: true</code>

```text
SACRIFICE_MIN = 4  ->  "one-away" = receiver holds 3

── Your doubles  (tiered by MAYA's shelf) ─────────────────────────────
   arrival order : wolf, bee, kraken, moth, dragon, robot, ant, tiger, comet, shark, fern, yeti
   board order   : dragon, yeti, comet, shark, ant, bee, kraken, robot, tiger, wolf, fern, moth
   card     rarity     tier       Maya holds
   dragon   legendary  new        0
   yeti     epic       new        0
   comet    rare       new        0
   shark    rare       one-away   3
   ant      common     one-away   3
   bee      common     one-away   3
   kraken   legendary  rest       2
   robot    rare       rest       2
   tiger    rare       rest       2
   wolf     rare       rest       5
   fern     common     rest       4
   moth     common     rest       2

── Maya's doubles (tiered by YOUR shelf) ─────────────────────────────
   arrival order : wolf, kraken, shark, ghost, moth, bee, tiger, ant, orca, robot, fern
   board order   : ghost, orca, tiger, fern, moth, kraken, robot, shark, wolf, ant, bee
   card     rarity     tier       You  holds
   ghost    epic       new        0
   orca     epic       new        0
   tiger    rare       one-away   3
   fern     common     one-away   3
   moth     common     one-away   3
   kraken   legendary  rest       4
   robot    rare       rest       2
   shark    rare       rest       2
   wolf     rare       rest       2
   ant      common     rest       4
   bee      common     rest       2

── the mirror ───────────────────────────
   shark    your column: one-away   (Maya holds 3)   Maya's column: rest       (you hold 2)
   moth     your column: rest       (Maya holds 2)   Maya's column: one-away   (you hold 3)

── tier 2 carries no badge (ticket #110's call) ──
   shark    tier=one-away  newToOther=false  -> tile renders no badge
   ant      tier=one-away  newToOther=false  -> tile renders no badge
   bee      tier=one-away  newToOther=false  -> tile renders no badge
   tiger    tier=one-away  newToOther=false  -> tile renders no badge
   fern     tier=one-away  newToOther=false  -> tile renders no badge
   moth     tier=one-away  newToOther=false  -> tile renders no badge

── stable under re-render ───────────────
   inventory handed back in the opposite order -> same board order: true
   dragon, yeti, comet, shark, ant, bee, kraken, robot, tiger, wolf, fern, moth
   ghost, orca, tiger, fern, moth, kraken, robot, shark, wolf, ant, bee
```
</details>
<details>
<summary>Evidence: Rendered swap board HTML (self-contained, after)</summary>

```text
<!doctype html>
<html lang="en"><head><meta charset="utf-8"><title>Swap board — #109 ordering</title>
<style>/*! tailwindcss v4.3.3 | MIT License | https://tailwindcss.com */
@layer properties;
@layer theme, base, components, utilities;
@layer theme {
  :root, :host {
    --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
      "Noto Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
      "Segoe UI Symbol", "Noto Color Emoji";
    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
      "Courier New", monospace;
    --color-red-300: oklch(80.8% 0.114 19.571);
    --color-red-400: oklch(70.4% 0.191 22.216);
    --color-red-500: oklch(63.7% 0.237 25.331);
    --color-amber-100: oklch(96.2% 0.059 95.617);
    --color-amber-200: oklch(92.4% 0.12 95.746);
    --color-amber-500: oklch(76.9% 0.188 70.08);
    --color-amber-900: oklch(41.4% 0.112 45.904);
    --color-green-300: oklch(87.1% 0.15 154.449);
    --color-green-400: oklch(79.2% 0.209 151.711);
    --color-green-500: oklch(72.3% 0.219 149.579);
    --color-emerald-100: oklch(95% 0.052 163.051);
    --color-emerald-500: oklch(69.6% 0.17 162.48);
    --color-slate-50: oklch(98.4% 0.003 247.858);
    --color-slate-200: oklch(92.9% 0.013 255.508);
    --color-slate-500: oklch(55.4% 0.046 257.417);
    --color-slate-600: oklch(44.6% 0.043 257.281);
    --color-black: #000;
    --color-white: #fff;
    --spacing: 0.25rem;
    --container-xs: 20rem;
    --container-sm: 24rem;
    --container-md: 28rem;
    --container-xl: 36rem;
    --container-2xl: 42rem;
    --container-3xl: 48rem;
    --container-5xl: 64rem;
    --container-6xl: 72rem;
    --text-xs: 0.75rem;
    --text-xs--line-height: calc(1 / 0.75);
    --text-sm: 0.875rem;
    --text-sm--line-height: calc(1.25 / 0.875);
    --text-base: 1rem;
    --text-base--line-height: calc(1.5 / 1);
    --text-lg: 1.125rem;
    --text-lg--line-height: calc(1.75 / 1.125);
    --text-xl: 1.25rem;
    --text-xl--line-height: calc(1.75 / 1.25);
    --text-2xl: 1.5rem;
    --text-2xl--line-height: calc(2 / 1.5);
    --text-3xl: 1.875rem;
    --text-3xl--line-height: calc(2.25 / 1.875);
    --text-4xl: 2.25rem;
    --text-4xl--line-height: calc(2.5 / 2.25);
    --text-5xl: 3rem;
    --text-5xl--line-height: 1;
    --text-6xl: 3.75rem;
    --text-6xl--line-height: 1;
    --text-7xl: 4.5rem;
    --text-7xl--line-height: 1;
    --font-weight-medium: 500;
    --font-weight-semibold: 600;
    --font-weight-bold: 700;
    --font-weight-extrabold: 800;
    --font-weight-black: 900;
    --tracking-tight: -0.025em;
    --tracking-wide: 0.025em;
    --leading-tight: 1.25;
    --leading-relaxed: 1.625;
    --radius-lg: 0.5rem;
    --radius-xl: 0.75rem;
    --radius-2xl: 1rem;
    --blur-sm: 8px;
    --default-transition-duration: 150ms;
    --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
    --default-font-family: var(--font-sans);
    --default-mono-font-family: var(--font-mono);
  }
}
@layer base {
  *, ::after, ::before, ::backdrop, ::file-selector-button {
    box-sizing: border-box;
    margin: 0;
    padding: 0;
    border: 0 solid;
  }
  html, :host {
    line-height: 1.5;
    -webkit-text-size-adjust: 100%;
    tab-size: 4;
    font-family: var(--default-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
    font-feature-settings: var(--default-font-feature-settings, normal);
    font-variation-settings: var(--default-font-variation-settings, normal);
    -webkit-tap-highlight-color: transparent;
  }
  hr {
    height: 0;
    color: inherit;
    border-top-width: 1px;
  }
  abbr:where([title]) {
    -webkit-text-decoration: underline dotted;
    text-decoration: underline dotted;
  }
  h1, h2, h3, h4, h5, h6 {
    font-size: inherit;
    font-weight: inherit;
  }
  a {
    color: inherit;
    -webkit-text-decoration: inherit;
    text-decoration: inherit;
  }
  b, strong {
    font-weight: bolder;
  }
  code, kbd, samp, pre {
    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
    font-feature-settings: var(--default-mono-font-feature-settings, normal);
    font-variation-settings: var(--default-mono-font-variation-settings, normal);
    font-size: 1em;
  }
  small {
    font-size: 80%;
  }
  sub, sup {
    font-size: 75%;
    line-height: 0;
    position: relative;
    vertical-align: baseline;
  }
  sub {
    bottom: -0.25em;
  }
  sup {
    top: -0.5em;
  }
  table {
    text-indent: 0;
    border-color: inherit;
    border-collapse: collapse;
  }
  :-moz-focusring:where(:not(iframe)) {
    outline: auto;
  }
  progress {
    vertical-align: baseline;
  }
  summary {
    display: list-item;
  }
  ol, ul, menu {
    list-style: none;
  }
  img, svg, video, canvas, audio, iframe, embed, object {
    display: block;
    vertical-align: middle;
  }
  img, video {
    max-width: 100%;
    height: auto;
  }
  button, input, select, optgroup, textarea, ::file-selector-button {
    font: inherit;
    font-feature-settings: inherit;
    font-variation-settings: inherit;
    letter-spacing: inherit;
    color: inherit;
    border-radius: 0;
    background-color: transparent;
    opacity: 1;
  }
  :where(select:is([multiple], [size])) optgroup {
    font-weight: bolder;
  }
  :where(select:is([multiple], [size])) optgroup option {
    padding-inline-start: 20px;
  }
  ::file-selector-button {
    margin-inline-end: 4px;
  }
  ::placeholder {
    opacity: 1;
  }
  @supports (not (-webkit-appearance: -apple-pay-button))  or (contain-intrinsic-size: 1px) {
    ::placeholder {
      color: currentcolor;
      @supports (color: color-mix(in lab, red, red)) {
        color: color-mix(in oklab, currentcolor 50%, transparent);
      }
    }
  }
  textarea {
    resize: vertical;
  }
  ::-webkit-search-decoration {
    -webkit-appearance: none;
  }
  ::-webkit-date-and-time-value {
    min-height: 1lh;
    text-align: inherit;
  }
  ::-webkit-datetime-edit {
    display: inline-flex;
  }
  ::-webkit-datetime-edit-fields-wrapper {
    padding: 0;
  }
  ::-webkit-datetime-edit, ::-webkit-datetime-edit-year-field, ::-webkit-datetime-edit-month-field, ::-webkit-datetime-edit-day-field, ::-webkit-datetime-edit-hour-field, ::-webkit-datetime-edit-minute-field, ::-webkit-datetime-edit-second-field, ::-webkit-datetime-edit-millisecond-field, ::-webkit-datetime-edit-meridiem-field {
    padding-block: 0;
  }
  ::-webkit-calendar-picker-indicator {
    line-height: 1;
  }
  :-moz-ui-invalid {
    box-shadow: none;
  }
  button, input:where([type="button"], [type="reset"], [type="submit"]), ::file-selector-button {
    appearance: button;
  }
  ::-webkit-inner-spin-button, ::-webkit-outer-spin-button {
    height: auto;
  }
  [hidden]:where(:not([hidden="until-found"])) {
    display: none !important;
  }
}
@layer utilities {
  .collapse {
    visibility: collapse;
  }
  .invisible {
    visibility: hidden;
  }
  .visible {
    visibility: visible;
  }
  .sr-only {
    position: absolute;
    width: 1px;
    height: 1px;
    padding: 0;
    margin: -1px;
    overflow: hidden;
    clip-path: inset(50%);
    white-space: nowrap;
    border-width: 0;
  }
  .absolute {
    position: absolute;
  }
  .fixed {
    position: fixed;
  }
  .relative {
    position: relative;
  }
  .static {
    position: static;
  }
  .sticky {
    position: sticky;
  }
  .inset-0 {
    inset: 0px;
  }
  .inset-x-0 {
    inset-inline: 0px;
  }
  .top-0 {
    top: 0px;
  }
  .top-1 {
    top: var(--spacing);
  }
  .top-2 {
    top: calc(var(--spacing) * 2);
  }
  .top-3 {
    top: calc(var(--spacing) * 3);
  }
  .top-24 {
    top: calc(var(--spacing) * 24);
  }
  .top-\[76px\] {
    top: 76px;
  }
  .right-1 {
    right: var(--spacing);
  }
  .right-2 {
    right: calc(var(--spacing) * 2);
  }
  .right-3 {
    right: calc(var(--spacing) * 3);
  }
  .bottom-0 {
    bottom: 0px;
  }
  .bottom-1 {
    bottom: var(--spacing);
  }
  .bottom-3 {
    bottom: calc(var(--spa

... [58561 bytes truncated] ...

20width%3D%22200%22%20height%3D%22200%22%20fill%3D%22%234c1d95%22%2F%3E%3Ctext%20x%3D%22100%22%20y%3D%22110%22%20font-family%3D%22system-ui%2Csans-serif%22%20font-size%3D%2226%22%20font-weight%3D%22700%22%20fill%3D%22%23ffffff%22%20text-anchor%3D%22middle%22%3EOrca%3C%2Ftext%3E%3C%2Fsvg%3E" alt="Orca" width="200" height="200" class="aspect-square w-full object-cover"/><span class="pill absolute bottom-1 right-1 text-xs">×3</span><span class="rarity-badge">Epic</span></button><button type="button" aria-pressed="false" aria-label="Tiger, Rare" data-testid="trade-theirs-tiger" class="relative overflow-hidden rounded-xl border-2 bg-white/10 transition  hover:scale-105" style="border-color:#60a5fa"><img src="data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22200%22%20height%3D%22200%22%3E%3Crect%20width%3D%22200%22%20height%3D%22200%22%20fill%3D%22%231e3a8a%22%2F%3E%3Ctext%20x%3D%22100%22%20y%3D%22110%22%20font-family%3D%22system-ui%2Csans-serif%22%20font-size%3D%2226%22%20font-weight%3D%22700%22%20fill%3D%22%23ffffff%22%20text-anchor%3D%22middle%22%3ETiger%3C%2Ftext%3E%3C%2Fsvg%3E" alt="Tiger" width="200" height="200" class="aspect-square w-full object-cover"/><span class="pill absolute bottom-1 right-1 text-xs">×2</span><span class="rarity-badge">Rare</span></button><button type="button" aria-pressed="false" aria-label="Fern, Common" data-testid="trade-theirs-fern" class="relative overflow-hidden rounded-xl border-2 bg-white/10 transition  hover:scale-105" style="border-color:#9ca3af"><img src="data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22200%22%20height%3D%22200%22%3E%3Crect%20width%3D%22200%22%20height%3D%22200%22%20fill%3D%22%233f4a5a%22%2F%3E%3Ctext%20x%3D%22100%22%20y%3D%22110%22%20font-family%3D%22system-ui%2Csans-serif%22%20font-size%3D%2226%22%20font-weight%3D%22700%22%20fill%3D%22%23ffffff%22%20text-anchor%3D%22middle%22%3EFern%3C%2Ftext%3E%3C%2Fsvg%3E" alt="Fern" width="200" height="200" class="aspect-square w-full object-cover"/><span class="pill absolute bottom-1 right-1 text-xs">×4</span><span class="rarity-badge">Common</span></button><button type="button" aria-pressed="false" aria-label="Moth, Common" data-testid="trade-theirs-moth" class="relative overflow-hidden rounded-xl border-2 bg-white/10 transition  hover:scale-105" style="border-color:#9ca3af"><img src="data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22200%22%20height%3D%22200%22%3E%3Crect%20width%3D%22200%22%20height%3D%22200%22%20fill%3D%22%233f4a5a%22%2F%3E%3Ctext%20x%3D%22100%22%20y%3D%22110%22%20font-family%3D%22system-ui%2Csans-serif%22%20font-size%3D%2226%22%20font-weight%3D%22700%22%20fill%3D%22%23ffffff%22%20text-anchor%3D%22middle%22%3EMoth%3C%2Ftext%3E%3C%2Fsvg%3E" alt="Moth" width="200" height="200" class="aspect-square w-full object-cover"/><span class="pill absolute bottom-1 right-1 text-xs">×2</span><span class="rarity-badge">Common</span></button><button type="button" aria-pressed="false" aria-label="Kraken, Legendary" data-testid="trade-theirs-kraken" class="relative overflow-hidden rounded-xl border-2 bg-white/10 transition  hover:scale-105" style="border-color:#fbbf24"><img src="data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22200%22%20height%3D%22200%22%3E%3Crect%20width%3D%22200%22%20height%3D%22200%22%20fill%3D%22%2378350f%22%2F%3E%3Ctext%20x%3D%22100%22%20y%3D%22110%22%20font-family%3D%22system-ui%2Csans-serif%22%20font-size%3D%2226%22%20font-weight%3D%22700%22%20fill%3D%22%23ffffff%22%20text-anchor%3D%22middle%22%3EKraken%3C%2Ftext%3E%3C%2Fsvg%3E" alt="Kraken" width="200" height="200" class="aspect-square w-full object-cover"/><span class="pill absolute bottom-1 right-1 text-xs">×2</span><span class="rarity-badge">Legendary</span></button><button type="button" aria-pressed="false" aria-label="Robot, Rare" data-testid="trade-theirs-robot" class="relative overflow-hidden rounded-xl border-2 bg-white/10 transition  hover:scale-105" style="border-color:#60a5fa"><img src="data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22200%22%20height%3D%22200%22%3E%3Crect%20width%3D%22200%22%20height%3D%22200%22%20fill%3D%22%231e3a8a%22%2F%3E%3Ctext%20x%3D%22100%22%20y%3D%22110%22%20font-family%3D%22system-ui%2Csans-serif%22%20font-size%3D%2226%22%20font-weight%3D%22700%22%20fill%3D%22%23ffffff%22%20text-anchor%3D%22middle%22%3ERobot%3C%2Ftext%3E%3C%2Fsvg%3E" alt="Robot" width="200" height="200" class="aspect-square w-full object-cover"/><span class="pill absolute bottom-1 right-1 text-xs">×2</span><span class="rarity-badge">Rare</span></button><button type="button" aria-pressed="false" aria-label="Shark, Rare" data-testid="trade-theirs-shark" class="relative overflow-hidden rounded-xl border-2 bg-white/10 transition  hover:scale-105" style="border-color:#60a5fa"><img src="data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22200%22%20height%3D%22200%22%3E%3Crect%20width%3D%22200%22%20height%3D%22200%22%20fill%3D%22%231e3a8a%22%2F%3E%3Ctext%20x%3D%22100%22%20y%3D%22110%22%20font-family%3D%22system-ui%2Csans-serif%22%20font-size%3D%2226%22%20font-weight%3D%22700%22%20fill%3D%22%23ffffff%22%20text-anchor%3D%22middle%22%3EShark%3C%2Ftext%3E%3C%2Fsvg%3E" alt="Shark" width="200" height="200" class="aspect-square w-full object-cover"/><span class="pill absolute bottom-1 right-1 text-xs">×3</span><span class="rarity-badge">Rare</span></button><button type="button" aria-pressed="false" aria-label="Wolf, Rare" data-testid="trade-theirs-wolf" class="relative overflow-hidden rounded-xl border-2 bg-white/10 transition  hover:scale-105" style="border-color:#60a5fa"><img src="data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22200%22%20height%3D%22200%22%3E%3Crect%20width%3D%22200%22%20height%3D%22200%22%20fill%3D%22%231e3a8a%22%2F%3E%3Ctext%20x%3D%22100%22%20y%3D%22110%22%20font-family%3D%22system-ui%2Csans-serif%22%20font-size%3D%2226%22%20font-weight%3D%22700%22%20fill%3D%22%23ffffff%22%20text-anchor%3D%22middle%22%3EWolf%3C%2Ftext%3E%3C%2Fsvg%3E" alt="Wolf" width="200" height="200" class="aspect-square w-full object-cover"/><span class="pill absolute bottom-1 right-1 text-xs">×5</span><span class="rarity-badge">Rare</span></button><button type="button" aria-pressed="false" aria-label="Ant, Common" data-testid="trade-theirs-ant" class="relative overflow-hidden rounded-xl border-2 bg-white/10 transition  hover:scale-105" style="border-color:#9ca3af"><img src="data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22200%22%20height%3D%22200%22%3E%3Crect%20width%3D%22200%22%20height%3D%22200%22%20fill%3D%22%233f4a5a%22%2F%3E%3Ctext%20x%3D%22100%22%20y%3D%22110%22%20font-family%3D%22system-ui%2Csans-serif%22%20font-size%3D%2226%22%20font-weight%3D%22700%22%20fill%3D%22%23ffffff%22%20text-anchor%3D%22middle%22%3EAnt%3C%2Ftext%3E%3C%2Fsvg%3E" alt="Ant" width="200" height="200" class="aspect-square w-full object-cover"/><span class="pill absolute bottom-1 right-1 text-xs">×3</span><span class="rarity-badge">Common</span></button><button type="button" aria-pressed="false" aria-label="Bee, Common" data-testid="trade-theirs-bee" class="relative overflow-hidden rounded-xl border-2 bg-white/10 transition  hover:scale-105" style="border-color:#9ca3af"><img src="data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22200%22%20height%3D%22200%22%3E%3Crect%20width%3D%22200%22%20height%3D%22200%22%20fill%3D%22%233f4a5a%22%2F%3E%3Ctext%20x%3D%22100%22%20y%3D%22110%22%20font-family%3D%22system-ui%2Csans-serif%22%20font-size%3D%2226%22%20font-weight%3D%22700%22%20fill%3D%22%23ffffff%22%20text-anchor%3D%22middle%22%3EBee%3C%2Ftext%3E%3C%2Fsvg%3E" alt="Bee" width="200" height="200" class="aspect-square w-full object-cover"/><span class="pill absolute bottom-1 right-1 text-xs">×3</span><span class="rarity-badge">Common</span></button></div></section></div></div>
</main></body></html>
```
</details>
- Evidence: Rendered swap board HTML (self-contained, before) (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M15TZ0RCANBBVHZXTVYBCGEH/swap-board-before.html</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Rebase** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/features/binder/GalaxyView.tsx` - merge conflict rebasing onto origin/main

🔧 Fix applied.
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `tests/trade-board.pbt.test.ts:53` - tests/trade-board.pbt.test.ts:53 — the rewritten preservation property replaces a positional count assertion with `cols.mine.find(c =&gt; c.card.id === t.card.id)`. `inventoryArb` is `fc.array(tcardArb)` over `fc.string({minLength:1})` (fast-check 3.x printable-ASCII, small size), so an inventory can contain two entries with the SAME card id and different counts. `find` returns only the first match, so the loop asserts that entry&#39;s count against both `t`s and fails nondeterministically. The multiset-of-ids assertions on lines 50-51 are fine; only the count loop is. Also note the loop covers `mine` only — `cols.theirs` counts are now unasserted, which the old positional check at least half-covered. Fix by comparing multisets of `{id, count}` pairs for both columns (e.g. sort `[id, count]` tuples), or by making `inventoryArb` generate distinct ids via `fc.uniqueArray(..., {selector: t =&gt; t.card.id})`.
- ℹ️ `src/features/binder/GalaxyView.tsx:76` - src/features/binder/GalaxyView.tsx:73-77 — `go()` rebuilds the binder URL inline (`param === null ? &#34;/play/binder&#34; : `/play/binder?at=${encodeURIComponent(param)}``), which is character-for-character what the exported, property-tested `placeHref` in binder-place.ts:71 already does. `placeHref` is currently used by nothing but its own test, so the one production path that pushes a place URL bypasses the module that owns the URL shape — the two can drift and only the unused one is pinned by tests. Import `placeHref` and call `window.history.pushState(null, &#34;&#34;, placeHref(next))`, dropping the `placeParam` import.
- ℹ️ `src/features/trade/board.ts:35` - src/features/trade/board.ts:35 — the &#39;one-away&#39; tier is only *detectable* while `SACRIFICE_MIN - 1 &gt;= 2`, because receiver counts come solely from `tradableDuplicates` (count &gt;= 2). Today SACRIFICE_MIN is 4 (`SACRIFICE_COST + 1`), so a receiver holding 3 is in the duplicate list and the tier works. But `oneAwayFromBurn`&#39;s doc claims the expression &#39;can never drift&#39; from the constant, and that only holds for the predicate, not for the data feeding it: if SACRIFICE_COST were ever lowered to 1 (SACRIFICE_MIN 2), a one-away receiver holds exactly 1 copy, never appears in the opposite inventory, and the tier would silently stop firing everywhere. No test would catch it — the tier property tests derive their expectation from the same duplicate-only inventory. Noting the coupling; no change needed at the current constant.

🔧 Fix: Fix flaky count property, route push through placeHref, correct tier comment
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx vitest run tests/trade-board.pbt.test.ts` — 20 pass (tiers, oneAwayFromBurn/SACRIFICE_MIN, orderByValue permutation/total-order/no-mutation, multiset preservation)</code>
- <code>`FC_NUM_RUNS=500 npx vitest run tests/trade-board.pbt.test.ts` — re-run at 5x property-search depth, 20 pass, no flakiness</code>
- <code>`grep -rln &#34;buildColumns|orderByValue|oneAwayFromBurn&#34; tests src app` — confirmed that test file is the complete relevant set</code>
- <code>Manual: SSR-rendered the real `src/features/trade/TradeBoard.tsx` (real buildColumns/orderByValue/Column/Tile + compiled app/globals.css) with the board open on friend &#34;Maya&#34;, then screenshotted it in headless Chrome at 1300x860</code>
- <code>Manual before/after: rendered the identical fixture against the base commit&#39;s `board.ts` (`git show 995ceab:src/features/trade/board.ts`) to capture the pre-#109 arrival-order board for comparison</code>
- `Manual: fixture designed so the mirror is falsifiable — Shark is one-away in your column (Maya holds SACRIFICE_MIN-1=3) but rest in hers (you hold 2); Moth is the reverse`
- `Manual: re-ran buildColumns with both inventories in reverse arrival order and compared rendered column ids — identical, confirming the total order holds under re-render`

</details>

<details>
<summary>⚠️ **Document** - 2 infos</summary>

- ℹ️ `aidlc-docs/inception/application-design/increment9-galaxy-nav-design.md` - aidlc-docs (increments 9, 13, 22) still describe the galaxy as a sticky &#39;★ All&#39; + per-theme chip row with a global burn mode layered over it, which #107/#108 replaced. Left untouched deliberately: README declares aidlc-docs to be AI-DLC v1 history, and rewriting historical increment artifacts would falsify the record. Current behaviour is now owned by CONTEXT.md (Place), the vision document&#39;s feature list, and GalaxyView/binder-place doc comments.
- ℹ️ `tests/sacrifice-filter.pbt.test.ts:69` - Comments and a describe() title in this test still say &#39;ignores every chip&#39; / &#39;while a category chip is active&#39; — vocabulary this change retired. Not edited because the pass is forbidden from touching tests; worth folding into the next change that edits this file.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the Binder with category tiles, in-category rarity filtering, and a dedicated burn pile.
  * Added navigation that preserves the selected Binder location when opening cards and using browser back navigation.
  * Added category artwork, collection progress, and completion indicators.
  * Trade board cards are now grouped into “new,” “one-away,” and “rest” value tiers with consistent ordering.
* **Documentation**
  * Clarified Binder locations, rarity filtering, burn-pile behavior, and trade-board terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->