### PR TITLE
feat(trade): say the swap tier once above a band instead of on every tile

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,7 +46,9 @@ same way. Domain nouns come from the app; architecture nouns from `/codebase-des
   swap-board columns are ordered (#109): **new** (they own none) → **one-away** (they
   hold `SACRIFICE_MIN - 1`, so this copy makes it burnable) → **rest**. Mirrored — each
   column is tiered against the *other* party's shelf. Never about acquisition recency:
-  `collections` has no timestamp.
+  `collections` has no timestamp. Said once as a band heading naming the receiver rather
+  than as a per-tile badge (#110) — a tier is a property of a group, so a column is cut
+  into bands (`bandsByTier`) whose order is exactly `orderByValue`'s.
 - **Offer** — an HMAC-signed, expiring token pinning the exact cards/rarity the server
   chose, so a claim can't be swapped for an un-offered card (pull eggs, quiz answers).
 - **Gate** — the admin passcode gate; issues a short-lived signed cookie.

--- a/Product-Definition/vision-document.md
+++ b/Product-Definition/vision-document.md
@@ -111,7 +111,7 @@ Grounded in the repository as of 2026-08-03 — 14 feature modules under `src/fe
   Grammar questions a child has already answered are remembered and deprioritised.
 - **Trading** — atomic two-sided duplicate swap between two children; friend-first board whose two columns
   are each ordered and cut into labelled bands by what the swap is worth to whoever *receives* the card
-  (new to them → one more makes it burnable → the rest), with no per-tile badges.
+  (new to them → one more makes it burnable → the rest), rather than a tier badge on every tile.
 - **Sacrifice** — burn 4+ copies (keep 1) for a rarity-pick ticket, same tier or one up, 50/50.
 - **Set-completion rewards** — bonus card once per (child, theme, rarity) set completed, cascading.
 - **Admin** — passcode-gated (20s sliding TTL): manage profiles, grant every ticket type, view any

--- a/Product-Definition/vision-document.md
+++ b/Product-Definition/vision-document.md
@@ -109,8 +109,9 @@ Grounded in the repository as of 2026-08-03 — 14 feature modules under `src/fe
   answer, and a "why"); award granted server-side via signed offer. **Ten topics** (4 maths, 6 grammar)
   since Inc 25, of which **three are drawn per child per day** — free choice was removed deliberately.
   Grammar questions a child has already answered are remembered and deprioritised.
-- **Trading** — atomic two-sided duplicate swap between two children; friend-first board that badges only
-  what the other party lacks.
+- **Trading** — atomic two-sided duplicate swap between two children; friend-first board whose two columns
+  are each ordered and cut into labelled bands by what the swap is worth to whoever *receives* the card
+  (new to them → one more makes it burnable → the rest), with no per-tile badges.
 - **Sacrifice** — burn 4+ copies (keep 1) for a rarity-pick ticket, same tier or one up, 50/50.
 - **Set-completion rewards** — bonus card once per (child, theme, rarity) set completed, cascading.
 - **Admin** — passcode-gated (20s sliding TTL): manage profiles, grant every ticket type, view any

--- a/app/play/trade/page.tsx
+++ b/app/play/trade/page.tsx
@@ -22,8 +22,8 @@ export default async function TradePage() {
           Swap doubles, <span className="title-pop">{child.name}</span>!
         </h1>
         <p className="text-sm text-[color:var(--ink-soft)]">
-          Pick a friend, then swap a double for one of theirs — same rarity. 🎁 marks a card the
-          other player doesn&apos;t have yet.
+          Pick a friend, then swap a double for one of theirs — same rarity. Each side is sorted
+          by what the swap is worth to whoever gets the card.
         </p>
       </div>
 

--- a/src/features/trade/TradeBoard.tsx
+++ b/src/features/trade/TradeBoard.tsx
@@ -14,9 +14,11 @@ import { getTradeBoardAction, executeTradeAction } from "./actions";
 import type { TradableCard } from "./trade-logic";
 import {
   applyMissingFilter,
+  bandsByTier,
   buildColumns,
   isPickable,
   type BoardCard,
+  type SwapTier,
 } from "./board";
 
 export type FriendSummary = {
@@ -29,8 +31,9 @@ export type FriendSummary = {
 
 /**
  * Friend-first swap board (Inc22). Pick the friend FIRST, then see both
- * inventories side by side with the cards that are new to the other party
- * badged. Server re-validates and commits atomically; giver A is always the
+ * inventories side by side, each ordered by what the swap is worth to whoever
+ * would RECEIVE those cards (#109) and cut into labelled tier bands (#110).
+ * Server re-validates and commits atomically; giver A is always the
  * server-side active profile.
  */
 export function TradeBoard({
@@ -183,14 +186,14 @@ export function TradeBoard({
           <Column
             testid="mine"
             title="Your doubles"
-            badgeSummary={`🎁 ${myBadged} new for ${friend.name}`}
             filterLabel={`Only show what ${friend.name} is missing`}
             filterOn={onlyTheirsMissing}
             setFilterOn={setOnlyTheirsMissing}
             badged={myBadged}
             total={columns.mine.length}
             cards={applyMissingFilter(columns.mine, onlyTheirsMissing)}
-            wantLabel={`🎁 New for ${friend.name}`}
+            receiver={friend.name}
+            newGlyph="🎁"
             selectedId={mine?.card.id ?? null}
             otherPick={theirs?.card ?? null}
             onPick={(c) => {
@@ -208,14 +211,14 @@ export function TradeBoard({
           <Column
             testid="theirs"
             title={`${friend.name}'s doubles`}
-            badgeSummary={`🆕 ${theirBadged} new for you`}
             filterLabel="Only show what you're missing"
             filterOn={onlyMineMissing}
             setFilterOn={setOnlyMineMissing}
             badged={theirBadged}
             total={columns.theirs.length}
             cards={applyMissingFilter(columns.theirs, onlyMineMissing)}
-            wantLabel="🆕 New for you"
+            receiver={YOU}
+            newGlyph="🆕"
             selectedId={theirs?.card.id ?? null}
             otherPick={mine?.card ?? null}
             onPick={(c) => {
@@ -266,17 +269,54 @@ export function TradeBoard({
   );
 }
 
+/**
+ * The receiver on the far side of a column, as the headings address them.
+ * `YOU` is a sentinel, not a name: the copy has to switch person for it
+ * ("one more and YOU can burn it"), and a friend can't be called it.
+ */
+const YOU = "you";
+
+/** The band heading — a whole sentence, naming WHOSE shelf the tier is about
+ *  (#110). Said once above the band instead of on every tile. */
+function bandTitle(tier: SwapTier, receiver: string, newGlyph: string): string {
+  const you = receiver === YOU;
+  if (tier === "new") return `${newGlyph} New for ${receiver}`;
+  if (tier === "one-away") return `🔥 One more and ${receiver} can burn it`;
+  return you ? "You already have these" : `${receiver} already has these`;
+}
+
+/**
+ * The same sentence on the tile itself, for a screen reader: a band heading is
+ * not announced with the button inside it, so the tier rides in each tile's
+ * accessible name too. `rest` says nothing — an unlabelled tile means they
+ * already have it, exactly as it did when the badge was visible (FR4).
+ */
+function tierPhrase(tier: SwapTier, receiver: string): string {
+  if (tier === "new") return `new for ${receiver}`;
+  if (tier === "one-away") return `one more and ${receiver} can burn it`;
+  return "";
+}
+
+/**
+ * One side of the board, cut into tier bands (#110). The heading carries the
+ * tier, so the tiles carry no badges at all — including the 🎁 that used to
+ * mark tier 1 (FR4), which the first band now says in full and in words.
+ *
+ * The header pill that counted the same cards went with it: it sat directly
+ * above a heading saying the same thing in the same words. The filter's own
+ * `(badged/total)` count stays — it's about what the checkbox would leave.
+ */
 function Column({
   testid,
   title,
-  badgeSummary,
   filterLabel,
   filterOn,
   setFilterOn,
   badged,
   total,
   cards,
-  wantLabel,
+  receiver,
+  newGlyph,
   selectedId,
   otherPick,
   onPick,
@@ -284,14 +324,14 @@ function Column({
 }: {
   testid: string;
   title: string;
-  badgeSummary: string;
   filterLabel: string;
   filterOn: boolean;
   setFilterOn: (v: boolean) => void;
   badged: number;
   total: number;
   cards: BoardCard[];
-  wantLabel: string;
+  receiver: string;
+  newGlyph: string;
   selectedId: string | null;
   otherPick: CardType | null;
   onPick: (c: BoardCard) => void;
@@ -299,10 +339,7 @@ function Column({
 }) {
   return (
     <section className="panel flex flex-col gap-3 p-4" data-testid={`trade-column-${testid}`}>
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <h2 className="text-lg font-bold">{title}</h2>
-        <span className="pill pill--gold text-xs">{badgeSummary}</span>
-      </div>
+      <h2 className="text-lg font-bold">{title}</h2>
       <label className="flex cursor-pointer items-center gap-2 text-sm">
         <input
           type="checkbox"
@@ -315,61 +352,67 @@ function Column({
       {cards.length === 0 ? (
         <Hint>{emptyHint}</Hint>
       ) : (
-        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
-          {cards.map((c) => (
-            <Tile
-              key={c.card.id}
-              entry={c}
-              wantLabel={wantLabel}
-              testid={testid}
-              selected={selectedId === c.card.id}
-              pickable={isPickable(c.card, otherPick)}
-              onPick={() => onPick(c)}
-            />
-          ))}
-        </div>
+        bandsByTier(cards).map((band) => (
+          <div key={band.tier} className="flex flex-col gap-2">
+            <h3
+              data-testid={`trade-band-${testid}-${band.tier}`}
+              className="text-xs font-bold uppercase tracking-wide text-[color:var(--ink-soft)]"
+            >
+              {bandTitle(band.tier, receiver, newGlyph)} ({band.cards.length})
+            </h3>
+            <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+              {band.cards.map((c) => (
+                <Tile
+                  key={c.card.id}
+                  entry={c}
+                  receiver={receiver}
+                  testid={testid}
+                  selected={selectedId === c.card.id}
+                  pickable={isPickable(c.card, otherPick)}
+                  onPick={() => onPick(c)}
+                />
+              ))}
+            </div>
+          </div>
+        ))
       )}
     </section>
   );
 }
 
-/** A card tile. Badged ONLY when it's new to the other party (FR4) — an unbadged
- *  tile simply means they already have it. Mismatched rarities are dimmed but
- *  stay visible (FR6). */
+/** A card tile. Carries no tier badge since #110 — the band heading above it
+ *  says the tier, in a sentence, once. Mismatched rarities are dimmed but stay
+ *  visible (FR6). */
 function Tile({
   entry,
-  wantLabel,
+  receiver,
   testid,
   selected,
   pickable,
   onPick,
 }: {
   entry: BoardCard;
-  wantLabel: string;
+  receiver: string;
   testid: string;
   selected: boolean;
   pickable: boolean;
   onPick: () => void;
 }) {
   const meta = RARITY_META[entry.card.rarity];
+  const phrase = tierPhrase(entry.tier, receiver);
   return (
     <button
       type="button"
       onClick={onPick}
       disabled={!pickable}
       aria-pressed={selected}
-      aria-label={`${entry.card.name}, ${meta.label}${entry.newToOther ? `, ${wantLabel}` : ""}`}
+      aria-label={`${entry.card.name}, ${meta.label}${phrase ? `, ${phrase}` : ""}`}
       data-testid={`trade-${testid}-${entry.card.id}`}
       className={`relative overflow-hidden rounded-xl border-2 bg-white/10 transition ${
         selected ? "ring-4 ring-[color:var(--brand-1)]" : ""
       } ${pickable ? "hover:scale-105" : "cursor-not-allowed opacity-25 grayscale"}`}
       style={{ borderColor: meta.frame }}
     >
-      {entry.newToOther ? (
-        <span className="absolute left-1 top-1 z-10 rounded-full bg-[#22c55e] px-1.5 py-0.5 text-[0.6rem] font-black leading-tight text-black">
-          {wantLabel}
-        </span>
-      ) : null}
       <CardImage src={entry.card.imageUrl} alt={entry.card.name} dim={200} />
       <span className="pill absolute bottom-1 right-1 text-xs">×{entry.count}</span>
       <span className="rarity-badge">{meta.label}</span>

--- a/src/features/trade/TradeBoard.tsx
+++ b/src/features/trade/TradeBoard.tsx
@@ -18,8 +18,8 @@ import {
   buildColumns,
   isPickable,
   type BoardCard,
-  type SwapTier,
 } from "./board";
+import { ME, bandCopy, type Receiver } from "./band-copy";
 
 export type FriendSummary = {
   id: string;
@@ -268,45 +268,6 @@ export function TradeBoard({
 }
 
 /**
- * Who receives the cards in a column — what every band heading is addressed
- * to. A discriminant rather than a name string: the copy switches person for
- * the child's own column ("one more and YOU can burn it"), and deciding that
- * by comparing against the name would put a friend called "You" in the wrong
- * person. It carries the column's glyph for the same reason — one value, so
- * the two can't disagree.
- */
-type Receiver = { kind: "friend"; name: string } | { kind: "me" };
-
-const ME: Receiver = { kind: "me" };
-
-/** How a heading names the receiver. */
-function receiverName(receiver: Receiver): string {
-  return receiver.kind === "friend" ? receiver.name : "you";
-}
-
-/** The band heading — a whole sentence, naming WHOSE shelf the tier is about
- *  (#110). Said once above the band instead of on every tile. */
-function bandTitle(tier: SwapTier, receiver: Receiver): string {
-  const who = receiverName(receiver);
-  if (tier === "new") return `${receiver.kind === "friend" ? "🎁" : "🆕"} New for ${who}`;
-  if (tier === "one-away") return `🔥 One more and ${who} can burn it`;
-  return receiver.kind === "friend" ? `${who} already has these` : "You already have these";
-}
-
-/**
- * The same sentence on the tile itself, for a screen reader: a band heading is
- * not announced with the button inside it, so the tier rides in each tile's
- * accessible name too. `rest` says nothing — an unlabelled tile means they
- * already have it, exactly as it did when the badge was visible (FR4).
- */
-function tierPhrase(tier: SwapTier, receiver: Receiver): string {
-  const who = receiverName(receiver);
-  if (tier === "new") return `new for ${who}`;
-  if (tier === "one-away") return `one more and ${who} can burn it`;
-  return "";
-}
-
-/**
  * One side of the board, cut into tier bands (#110). The heading carries the
  * tier, so the tiles carry no badges at all — including the 🎁 that used to
  * mark tier 1 (FR4), which the first band now says in full and in words.
@@ -365,7 +326,7 @@ function Column({
               data-testid={`trade-band-${testid}-${band.tier}`}
               className="text-xs font-bold uppercase tracking-wide text-[color:var(--ink-soft)]"
             >
-              {bandTitle(band.tier, receiver)} ({band.cards.length})
+              {bandCopy(band.tier, receiver).heading} ({band.cards.length})
             </h3>
             <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
               {band.cards.map((c) => (
@@ -406,7 +367,7 @@ function Tile({
   onPick: () => void;
 }) {
   const meta = RARITY_META[entry.card.rarity];
-  const phrase = tierPhrase(entry.tier, receiver);
+  const { phrase } = bandCopy(entry.tier, receiver);
   return (
     <button
       type="button"

--- a/src/features/trade/TradeBoard.tsx
+++ b/src/features/trade/TradeBoard.tsx
@@ -288,13 +288,13 @@ function bandTitle(tier: SwapTier, receiver: string, newGlyph: string): string {
 /**
  * The same sentence on the tile itself, for a screen reader: a band heading is
  * not announced with the button inside it, so the tier rides in each tile's
- * accessible name too. `rest` says nothing — an unlabelled tile means they
- * already have it, exactly as it did when the badge was visible (FR4).
+ * accessible name too, including the receiver context for `rest` tiles that
+ * are already owned (FR4).
  */
 function tierPhrase(tier: SwapTier, receiver: string): string {
   if (tier === "new") return `new for ${receiver}`;
   if (tier === "one-away") return `one more and ${receiver} can burn it`;
-  return "";
+  return receiver === YOU ? "you already have this" : `${receiver} already has this`;
 }
 
 /**

--- a/src/features/trade/TradeBoard.tsx
+++ b/src/features/trade/TradeBoard.tsx
@@ -374,7 +374,7 @@ function Tile({
       onClick={onPick}
       disabled={!pickable}
       aria-pressed={selected}
-      aria-label={`${entry.card.name}, ${meta.label}${phrase ? `, ${phrase}` : ""}`}
+      aria-label={`${entry.card.name}, ${meta.label}, ${phrase}`}
       data-testid={`trade-${testid}-${entry.card.id}`}
       className={`relative overflow-hidden rounded-xl border-2 bg-white/10 transition ${
         selected ? "ring-4 ring-[color:var(--brand-1)]" : ""

--- a/src/features/trade/TradeBoard.tsx
+++ b/src/features/trade/TradeBoard.tsx
@@ -192,8 +192,7 @@ export function TradeBoard({
             badged={myBadged}
             total={columns.mine.length}
             cards={applyMissingFilter(columns.mine, onlyTheirsMissing)}
-            receiver={friend.name}
-            newGlyph="🎁"
+            receiver={{ kind: "friend", name: friend.name }}
             selectedId={mine?.card.id ?? null}
             otherPick={theirs?.card ?? null}
             onPick={(c) => {
@@ -217,8 +216,7 @@ export function TradeBoard({
             badged={theirBadged}
             total={columns.theirs.length}
             cards={applyMissingFilter(columns.theirs, onlyMineMissing)}
-            receiver={YOU}
-            newGlyph="🆕"
+            receiver={ME}
             selectedId={theirs?.card.id ?? null}
             otherPick={mine?.card ?? null}
             onPick={(c) => {
@@ -270,19 +268,29 @@ export function TradeBoard({
 }
 
 /**
- * The receiver on the far side of a column, as the headings address them.
- * `YOU` is a sentinel, not a name: the copy has to switch person for it
- * ("one more and YOU can burn it"), and a friend can't be called it.
+ * Who receives the cards in a column — what every band heading is addressed
+ * to. A discriminant rather than a name string: the copy switches person for
+ * the child's own column ("one more and YOU can burn it"), and deciding that
+ * by comparing against the name would put a friend called "You" in the wrong
+ * person. It carries the column's glyph for the same reason — one value, so
+ * the two can't disagree.
  */
-const YOU = "you";
+type Receiver = { kind: "friend"; name: string } | { kind: "me" };
+
+const ME: Receiver = { kind: "me" };
+
+/** How a heading names the receiver. */
+function receiverName(receiver: Receiver): string {
+  return receiver.kind === "friend" ? receiver.name : "you";
+}
 
 /** The band heading — a whole sentence, naming WHOSE shelf the tier is about
  *  (#110). Said once above the band instead of on every tile. */
-function bandTitle(tier: SwapTier, receiver: string, newGlyph: string): string {
-  const you = receiver === YOU;
-  if (tier === "new") return `${newGlyph} New for ${receiver}`;
-  if (tier === "one-away") return `🔥 One more and ${receiver} can burn it`;
-  return you ? "You already have these" : `${receiver} already has these`;
+function bandTitle(tier: SwapTier, receiver: Receiver): string {
+  const who = receiverName(receiver);
+  if (tier === "new") return `${receiver.kind === "friend" ? "🎁" : "🆕"} New for ${who}`;
+  if (tier === "one-away") return `🔥 One more and ${who} can burn it`;
+  return receiver.kind === "friend" ? `${who} already has these` : "You already have these";
 }
 
 /**
@@ -291,9 +299,10 @@ function bandTitle(tier: SwapTier, receiver: string, newGlyph: string): string {
  * accessible name too. `rest` says nothing — an unlabelled tile means they
  * already have it, exactly as it did when the badge was visible (FR4).
  */
-function tierPhrase(tier: SwapTier, receiver: string): string {
-  if (tier === "new") return `new for ${receiver}`;
-  if (tier === "one-away") return `one more and ${receiver} can burn it`;
+function tierPhrase(tier: SwapTier, receiver: Receiver): string {
+  const who = receiverName(receiver);
+  if (tier === "new") return `new for ${who}`;
+  if (tier === "one-away") return `one more and ${who} can burn it`;
   return "";
 }
 
@@ -316,7 +325,6 @@ function Column({
   total,
   cards,
   receiver,
-  newGlyph,
   selectedId,
   otherPick,
   onPick,
@@ -330,8 +338,7 @@ function Column({
   badged: number;
   total: number;
   cards: BoardCard[];
-  receiver: string;
-  newGlyph: string;
+  receiver: Receiver;
   selectedId: string | null;
   otherPick: CardType | null;
   onPick: (c: BoardCard) => void;
@@ -358,7 +365,7 @@ function Column({
               data-testid={`trade-band-${testid}-${band.tier}`}
               className="text-xs font-bold uppercase tracking-wide text-[color:var(--ink-soft)]"
             >
-              {bandTitle(band.tier, receiver, newGlyph)} ({band.cards.length})
+              {bandTitle(band.tier, receiver)} ({band.cards.length})
             </h3>
             <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
               {band.cards.map((c) => (
@@ -392,7 +399,7 @@ function Tile({
   onPick,
 }: {
   entry: BoardCard;
-  receiver: string;
+  receiver: Receiver;
   testid: string;
   selected: boolean;
   pickable: boolean;

--- a/src/features/trade/band-copy.ts
+++ b/src/features/trade/band-copy.ts
@@ -1,0 +1,74 @@
+import type { SwapTier } from "./board";
+
+/**
+ * What a tier band SAYS (#110). PURE, and beside the component rather than in
+ * it, because the words are a rule the child reads: the tier is stated once
+ * above a band instead of stamped on every tile, and the same sentence has to
+ * reach a screen reader from the tile itself.
+ */
+
+/**
+ * Who receives the cards in a column — what every band heading is addressed
+ * to. A discriminant rather than a name string: the copy switches person for
+ * the child's own column ("one more and YOU can burn it"), and deciding that
+ * by comparing against the name would put a friend called "You" in the wrong
+ * person. The column's glyph is derived from the same discriminant, so the
+ * glyph and the person it addresses can never disagree.
+ */
+export type Receiver = { kind: "friend"; name: string } | { kind: "me" };
+
+export const ME: Receiver = { kind: "me" };
+
+export interface BandCopy {
+  /** The band heading — a whole sentence, naming WHOSE shelf the tier is about. */
+  heading: string;
+  /**
+   * The same sentence on the tile itself, for a screen reader: a band heading
+   * is not announced with the button inside it, so the tier rides in each
+   * tile's accessible name too. `rest` says nothing — an unlabelled tile means
+   * they already have it, exactly as it did when the badge was visible (FR4).
+   */
+  phrase: string;
+}
+
+/**
+ * Both strings a band needs, from one sentence per tier. Written together so
+ * they cannot drift: editing one would otherwise leave sighted and
+ * screen-reader users reading different copy.
+ */
+export function bandCopy(tier: SwapTier, receiver: Receiver): BandCopy {
+  const who = receiverName(receiver);
+  switch (tier) {
+    case "new":
+      return said(receiver.kind === "friend" ? "🎁" : "🆕", `new for ${who}`);
+    case "one-away":
+      return said("🔥", `one more and ${who} can burn it`);
+    case "rest":
+      // The only tier whose subject is the receiver, so the only one whose verb
+      // has to agree with the person — and the one the tile leaves unsaid.
+      return {
+        heading:
+          receiver.kind === "friend" ? `${who} already has these` : "You already have these",
+        phrase: "",
+      };
+  }
+}
+
+/** How a heading names the receiver. */
+function receiverName(receiver: Receiver): string {
+  return receiver.kind === "friend" ? receiver.name : "you";
+}
+
+/**
+ * One sentence, said twice: aloud on the tile as-is, and in the heading behind
+ * the band's glyph with its opening word capitalised. Safe because every
+ * sentence that reaches here opens on a literal ("new…", "one more…") — the
+ * one that opens on the receiver's name is spelled out above, so a friend
+ * called "ana" is never re-capitalised into someone else.
+ */
+function said(glyph: string, sentence: string): BandCopy {
+  return {
+    heading: `${glyph} ${sentence[0].toUpperCase()}${sentence.slice(1)}`,
+    phrase: sentence,
+  };
+}

--- a/src/features/trade/band-copy.ts
+++ b/src/features/trade/band-copy.ts
@@ -51,7 +51,12 @@ export function bandCopy(tier: SwapTier, receiver: Receiver): BandCopy {
       // has to agree with the person — which is why it can't go through
       // `said`, and why heading and phrase are spelled out as a pair.
       return receiver.kind === "friend"
-        ? { heading: `${who} already has these`, phrase: `${who} already has this` }
+        ? receiver.name === "You"
+          ? {
+              heading: "Your friend named You already has these",
+              phrase: "your friend named You already has this",
+            }
+          : { heading: `${who} already has these`, phrase: `${who} already has this` }
         : { heading: "You already have these", phrase: "you already have this" };
   }
 }

--- a/src/features/trade/board.ts
+++ b/src/features/trade/board.ts
@@ -26,6 +26,11 @@ export type SwapTier = "new" | "one-away" | "rest";
 
 const TIER_RANK: Record<SwapTier, number> = { new: 0, "one-away": 1, rest: 2 };
 
+/** The tiers best-swap-first, derived from the ranking so the two can't drift. */
+const TIER_ORDER: SwapTier[] = (Object.keys(TIER_RANK) as SwapTier[]).sort(
+  (a, b) => TIER_RANK[a] - TIER_RANK[b],
+);
+
 /**
  * One more copy takes this holding to SACRIFICE_MIN, the constant every surface
  * that offers or advertises a sacrifice gates on (Inc22 D4). Written as
@@ -122,6 +127,33 @@ export function orderByValue(cards: BoardCard[]): BoardCard[] {
       RARITIES.indexOf(b.card.rarity) - RARITIES.indexOf(a.card.rarity) ||
       (a.card.id < b.card.id ? -1 : a.card.id > b.card.id ? 1 : 0),
   );
+}
+
+export interface TierBand {
+  tier: SwapTier;
+  cards: BoardCard[];
+}
+
+/**
+ * Cut an ordered column into its tier bands (#110). The tier is a property of
+ * a GROUP of cards, so it's said once above the band instead of stamped on
+ * every tile: a column where half the cards are one-away would otherwise wear
+ * a badge almost everywhere, and the `new` tier — the one `orderByValue` ranks
+ * FIRST — would stop standing out.
+ *
+ * Empty bands are dropped, so a column never shows a heading over nothing.
+ * Order inside a band is untouched, and the bands come out in tier order, so
+ * reading the bands top to bottom is exactly `orderByValue`'s sequence — the
+ * grouping makes that order legible, it never re-does it.
+ *
+ * The heading copy lives with the component: it names the RECEIVER ("one more
+ * and Ana can burn it" / "…and you can burn it"), which only the column knows.
+ */
+export function bandsByTier(cards: BoardCard[]): TierBand[] {
+  return TIER_ORDER.map((tier) => ({
+    tier,
+    cards: cards.filter((c) => c.tier === tier),
+  })).filter((band) => band.cards.length > 0);
 }
 
 /** FR5 — hide the cards the other party already has. `false` is the identity. */

--- a/src/features/trade/board.ts
+++ b/src/features/trade/board.ts
@@ -50,10 +50,11 @@ export interface BoardCard {
   /** What this swap is worth to the party on the OTHER side of the board. */
   tier: SwapTier;
   /**
-   * True when the OTHER party doesn't own this card at all. Drives the badge
-   * (FR4) and the "only show what's missing" filter (FR5). Deliberately about
-   * ownership, not duplicates: what matters is whether the swap gives them
-   * something genuinely new.
+   * True when the OTHER party doesn't own this card at all. Drives the "only
+   * show what's missing" filter (FR5) and its count; since #110 the `new` band
+   * heading is what says it on screen, so no tile wears a badge for it any
+   * more (FR4). Deliberately about ownership, not duplicates: what matters is
+   * whether the swap gives them something genuinely new.
    */
   newToOther: boolean;
 }

--- a/src/features/trade/board.ts
+++ b/src/features/trade/board.ts
@@ -67,8 +67,11 @@ export interface BoardCard {
  * one side and forgotten on the other. The tier-2 test needs the receiver's
  * COUNT, not just their ownership — and it's already here: a holding of
  * SACRIFICE_MIN - 1 is a duplicate, so it's in the opposite inventory with its
- * count. Nothing has to be added to `getTradeBoard`'s payload, and no child
- * learns anything new about a friend's shelf.
+ * count. Nothing has to be added to `getTradeBoard`'s payload — the tier is
+ * derived from what the board already sends. What the child then LEARNS from
+ * it did change with #110: the band heading says "one more and Ana can burn
+ * it" in words, so a friend's exact holding of SACRIFICE_MIN - 1 is now on
+ * screen. That disclosure is the point of the ticket, not a leak.
  *
  * That last step is why the tier is only OBSERVABLE while SACRIFICE_MIN - 1 is
  * at least 2. The opposite inventory is `tradableDuplicates` — count >= 2 —
@@ -147,7 +150,7 @@ export interface TierBand {
  * reading the bands top to bottom is exactly `orderByValue`'s sequence — the
  * grouping makes that order legible, it never re-does it.
  *
- * The heading copy lives with the component: it names the RECEIVER ("one more
+ * The heading copy lives in `band-copy.ts`: it names the RECEIVER ("one more
  * and Ana can burn it" / "…and you can burn it"), which only the column knows.
  */
 export function bandsByTier(cards: BoardCard[]): TierBand[] {

--- a/tests/trade-band-copy.pbt.test.ts
+++ b/tests/trade-band-copy.pbt.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import fc from "fast-check";
-import { ME, bandCopy, type Receiver } from "@/features/trade/band-copy";
+import { ME, bandCopy, type BandCopy, type Receiver } from "@/features/trade/band-copy";
 import type { SwapTier } from "@/features/trade/board";
 
 const ANA: Receiver = { kind: "friend", name: "Ana" };
@@ -8,6 +8,34 @@ const ANA: Receiver = { kind: "friend", name: "Ana" };
 const FRIEND_CALLED_YOU: Receiver = { kind: "friend", name: "You" };
 
 const TIERS: SwapTier[] = ["new", "one-away", "rest"];
+
+/**
+ * The pair each tier says, spelled out here independently of the module: the
+ * heading counts a band and the phrase names one card, so `rest` differs by its
+ * number and every other tier is the same words behind a glyph. Written as a
+ * whole expected pair rather than derived from the heading by a suffix rewrite,
+ * because any such rewrite would run over the generated name too — a friend
+ * called "these" would fail the property against correct code.
+ */
+function expectedCopy(tier: SwapTier, receiver: Receiver): BandCopy {
+  const who = receiver.kind === "friend" ? receiver.name : "you";
+  switch (tier) {
+    case "new":
+      return {
+        heading: `${receiver.kind === "friend" ? "🎁" : "🆕"} New for ${who}`,
+        phrase: `new for ${who}`,
+      };
+    case "one-away":
+      return {
+        heading: `🔥 One more and ${who} can burn it`,
+        phrase: `one more and ${who} can burn it`,
+      };
+    case "rest":
+      return receiver.kind === "friend"
+        ? { heading: `${who} already has these`, phrase: `${who} already has this` }
+        : { heading: "You already have these", phrase: "you already have this" };
+  }
+}
 
 describe("bandCopy (#110 — the sentence a band says)", () => {
   it("says exactly what the board says today", () => {
@@ -32,12 +60,9 @@ describe("bandCopy (#110 — the sentence a band says)", () => {
     fc.assert(
       fc.property(fc.constantFrom(...TIERS), fc.string({ minLength: 1 }), (tier, name) => {
         for (const receiver of [{ kind: "friend", name } as Receiver, ME]) {
-          const { heading, phrase } = bandCopy(tier, receiver);
-          expect(phrase).not.toBe("");
-          // The heading counts a band and the phrase names one card, so `rest`
-          // differs by its number alone — every other tier is the same words.
-          const singular = heading.toLowerCase().replace(/these$/, "this");
-          expect(singular.endsWith(phrase.toLowerCase())).toBe(true);
+          const copy = bandCopy(tier, receiver);
+          expect(copy.phrase).not.toBe("");
+          expect(copy).toEqual(expectedCopy(tier, receiver));
         }
       }),
     );

--- a/tests/trade-band-copy.pbt.test.ts
+++ b/tests/trade-band-copy.pbt.test.ts
@@ -32,7 +32,12 @@ function expectedCopy(tier: SwapTier, receiver: Receiver): BandCopy {
       };
     case "rest":
       return receiver.kind === "friend"
-        ? { heading: `${who} already has these`, phrase: `${who} already has this` }
+        ? receiver.name === "You"
+          ? {
+              heading: "Your friend named You already has these",
+              phrase: "your friend named You already has this",
+            }
+          : { heading: `${who} already has these`, phrase: `${who} already has this` }
         : { heading: "You already have these", phrase: "you already have this" };
   }
 }
@@ -75,7 +80,9 @@ describe("bandCopy (#110 — the sentence a band says)", () => {
     for (const tier of TIERS) {
       expect(bandCopy(tier, FRIEND_CALLED_YOU)).not.toEqual(bandCopy(tier, ME));
     }
-    expect(bandCopy("rest", FRIEND_CALLED_YOU).heading).toBe("You already has these");
+    expect(bandCopy("rest", FRIEND_CALLED_YOU).heading).toBe(
+      "Your friend named You already has these",
+    );
     expect(bandCopy("rest", ME).heading).toBe("You already have these");
     expect(bandCopy("new", FRIEND_CALLED_YOU).heading).toBe("🎁 New for You");
     expect(bandCopy("new", ME).heading).toBe("🆕 New for you");

--- a/tests/trade-band-copy.test.ts
+++ b/tests/trade-band-copy.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import { ME, bandCopy, type Receiver } from "@/features/trade/band-copy";
+import type { SwapTier } from "@/features/trade/board";
+
+const ANA: Receiver = { kind: "friend", name: "Ana" };
+/** A friend whose name is the word the second-person copy uses. */
+const FRIEND_CALLED_YOU: Receiver = { kind: "friend", name: "You" };
+
+const TIERS: SwapTier[] = ["new", "one-away", "rest"];
+
+describe("bandCopy (#110 — the sentence a band says)", () => {
+  it("says exactly what the board says today", () => {
+    expect(bandCopy("new", ANA).heading).toBe("🎁 New for Ana");
+    expect(bandCopy("new", ME).heading).toBe("🆕 New for you");
+    expect(bandCopy("one-away", ANA).heading).toBe("🔥 One more and Ana can burn it");
+    expect(bandCopy("one-away", ME).heading).toBe("🔥 One more and you can burn it");
+    expect(bandCopy("rest", ANA).heading).toBe("Ana already has these");
+    expect(bandCopy("rest", ME).heading).toBe("You already have these");
+
+    expect(bandCopy("new", ANA).phrase).toBe("new for Ana");
+    expect(bandCopy("new", ME).phrase).toBe("new for you");
+    expect(bandCopy("one-away", ANA).phrase).toBe("one more and Ana can burn it");
+    expect(bandCopy("one-away", ME).phrase).toBe("one more and you can burn it");
+    expect(bandCopy("rest", ANA).phrase).toBe("");
+    expect(bandCopy("rest", ME).phrase).toBe("");
+  });
+
+  it("heading and tile phrase are the same sentence, so they can't drift", () => {
+    // The heading is seen and the phrase is heard; a reader and a listener must
+    // not be told different things about the same band.
+    fc.assert(
+      fc.property(fc.constantFrom(...TIERS), fc.string({ minLength: 1 }), (tier, name) => {
+        for (const receiver of [{ kind: "friend", name } as Receiver, ME]) {
+          const { heading, phrase } = bandCopy(tier, receiver);
+          if (phrase === "") continue;
+          expect(heading.toLowerCase().endsWith(phrase.toLowerCase())).toBe(true);
+        }
+      }),
+    );
+  });
+
+  it("picks the person by the discriminant, not by the receiver's name", () => {
+    // A friend literally called "You" is still a third party. Deciding person by
+    // comparing the name against "you" would flip this column into the child's
+    // own voice and tell them the friend's shelf is theirs.
+    for (const tier of TIERS) {
+      expect(bandCopy(tier, FRIEND_CALLED_YOU)).not.toEqual(bandCopy(tier, ME));
+    }
+    expect(bandCopy("rest", FRIEND_CALLED_YOU).heading).toBe("You already has these");
+    expect(bandCopy("rest", ME).heading).toBe("You already have these");
+    expect(bandCopy("new", FRIEND_CALLED_YOU).heading).toBe("🎁 New for You");
+    expect(bandCopy("new", ME).heading).toBe("🆕 New for you");
+  });
+
+  it("the receiver's own column always speaks in the second person", () => {
+    for (const tier of TIERS) {
+      const { heading, phrase } = bandCopy(tier, ME);
+      expect(`${heading} ${phrase}`.toLowerCase()).toContain("you");
+    }
+  });
+
+  it("a friend's band always names that friend, whatever they are called", () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1 }), (name) => {
+        for (const tier of TIERS) {
+          const { heading } = bandCopy(tier, { kind: "friend", name });
+          expect(heading).toContain(name);
+        }
+      }),
+    );
+  });
+
+  it("never leaves a band without a heading", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...TIERS), fc.string({ minLength: 1 }), (tier, name) => {
+        for (const receiver of [{ kind: "friend", name } as Receiver, ME]) {
+          expect(bandCopy(tier, receiver).heading.trim().length).toBeGreaterThan(0);
+        }
+      }),
+    );
+  });
+});

--- a/tests/trade-board.pbt.test.ts
+++ b/tests/trade-board.pbt.test.ts
@@ -31,6 +31,11 @@ const tcardArb = fc
 const inventoryArb = fc.array(tcardArb, { maxLength: 15 });
 const ownedArb = fc.array(fc.string({ minLength: 1 }), { maxLength: 20 }).map((ids) => new Set(ids));
 
+const boardCardArb = fc
+  .tuple(tcardArb, fc.constantFrom<SwapTier>("new", "one-away", "rest"))
+  .map(([t, tier]) => ({ ...t, tier, newToOther: tier === "new" }) satisfies BoardCard);
+const columnArb = fc.array(boardCardArb, { maxLength: 20 });
+
 describe("buildColumns (Inc22 FR4 — badge only what's new to the other side)", () => {
   it("newToOther is exactly the complement of the other party's owned set", () => {
     fc.assert(
@@ -257,11 +262,6 @@ describe("tiers (#109 — mirrored, receiver-valued)", () => {
 });
 
 describe("orderByValue (#109 — best swap first, and it never moves under a thumb)", () => {
-  const boardCardArb = fc
-    .tuple(tcardArb, fc.constantFrom<SwapTier>("new", "one-away", "rest"))
-    .map(([t, tier]) => ({ ...t, tier, newToOther: tier === "new" }) satisfies BoardCard);
-  const columnArb = fc.array(boardCardArb, { maxLength: 20 });
-
   it("is a permutation — nothing added, nothing lost", () => {
     fc.assert(
       fc.property(columnArb, (cards) => {
@@ -314,11 +314,6 @@ describe("orderByValue (#109 — best swap first, and it never moves under a thu
 });
 
 describe("bandsByTier (#110 — the tier is said once above a band, not on every tile)", () => {
-  const boardCardArb = fc
-    .tuple(tcardArb, fc.constantFrom<SwapTier>("new", "one-away", "rest"))
-    .map(([t, tier]) => ({ ...t, tier, newToOther: tier === "new" }) satisfies BoardCard);
-  const columnArb = fc.array(boardCardArb, { maxLength: 20 });
-
   it("reading the bands top to bottom is exactly the ordered column", () => {
     // The whole point of the shape: the bands make #109's order LEGIBLE, so
     // they must never re-do it. If this ever fails, a child's best swap has

--- a/tests/trade-board.pbt.test.ts
+++ b/tests/trade-board.pbt.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import fc from "fast-check";
 import {
+  bandsByTier,
   buildColumns,
   applyMissingFilter,
   missingCount,
@@ -307,6 +308,64 @@ describe("orderByValue (#109 — best swap first, and it never moves under a thu
         expect(orderByValue(shuffled).map((c) => c.card.id)).toEqual(
           orderByValue(unique).map((c) => c.card.id),
         );
+      }),
+    );
+  });
+});
+
+describe("bandsByTier (#110 — the tier is said once above a band, not on every tile)", () => {
+  const boardCardArb = fc
+    .tuple(tcardArb, fc.constantFrom<SwapTier>("new", "one-away", "rest"))
+    .map(([t, tier]) => ({ ...t, tier, newToOther: tier === "new" }) satisfies BoardCard);
+  const columnArb = fc.array(boardCardArb, { maxLength: 20 });
+
+  it("reading the bands top to bottom is exactly the ordered column", () => {
+    // The whole point of the shape: the bands make #109's order LEGIBLE, so
+    // they must never re-do it. If this ever fails, a child's best swap has
+    // moved because of a heading.
+    fc.assert(
+      fc.property(columnArb, (cards) => {
+        const column = orderByValue(cards);
+        expect(bandsByTier(column).flatMap((b) => b.cards)).toEqual(column);
+      }),
+    );
+  });
+
+  it("every card lands in exactly one band, and it's the band of its tier", () => {
+    fc.assert(
+      fc.property(columnArb, (cards) => {
+        const bands = bandsByTier(orderByValue(cards));
+        expect(sortedIds(bands.flatMap((b) => b.cards))).toEqual(sortedIds(cards));
+        for (const band of bands) {
+          for (const c of band.cards) expect(c.tier).toBe(band.tier);
+        }
+      }),
+    );
+  });
+
+  it("never emits a heading over nothing", () => {
+    fc.assert(
+      fc.property(columnArb, (cards) => {
+        for (const band of bandsByTier(cards)) expect(band.cards.length).toBeGreaterThan(0);
+      }),
+    );
+  });
+
+  it("bands come out best-swap-first, matching the tier ranking", () => {
+    fc.assert(
+      fc.property(columnArb, (cards) => {
+        const ranks = bandsByTier(cards).map((b) => TIER_RANK[b.tier]);
+        expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+      }),
+    );
+  });
+
+  it("never mutates its input", () => {
+    fc.assert(
+      fc.property(columnArb, (cards) => {
+        const before = cards.map((c) => c.card.id);
+        bandsByTier(cards);
+        expect(cards.map((c) => c.card.id)).toEqual(before);
       }),
     );
   });


### PR DESCRIPTION
## Intent

Resolve wayfinder ticket #110 on map #106: how does a swap tile say 'one more of these and you can burn it'? #109 shipped the tier ORDERING (new -> one-away -> rest, mirrored per receiver) with tier 2 deliberately unmarked; this change is the visual answer only.

Four takes were prototyped on a throwaway branch (prototype/110-one-away-flag, route /proto-110) against real card art at real tile density; the user picked take B: no per-tile mark at all, each column cut into labelled tier bands whose heading carries the whole sentence and names the RECEIVER ('One more and Ana can burn it' in my column, '...and you can burn it' in theirs).

Deliberate decisions a reviewer would not guess from the diff:
- The tiles lose ALL badges, including the shipped tier-1 gift/new badge (Inc22 FR4). Intended: a badge per fact swamps the board once half a column is one-away, and the band heading now says tier 1 in full words.
- The column header pill ('4 new for Ana') was removed intentionally: it sat directly above a band heading saying the same thing in the same words. The filter checkbox's own (badged/total) count was deliberately KEPT.
- The fire glyph is reused from the galaxy's burn pile on purpose, but only inside a sentence saying 'not yet, one more' — the ticket's warning was about a bare glyph promising 'burnable NOW'.
- bandsByTier is pure, in board.ts beside the other board rules, property-tested on the load-bearing invariant: reading the bands top to bottom is EXACTLY orderByValue's column, so a heading can never move a child's best swap. Empty bands are dropped.
- band-copy.ts holds the words: heading and screen-reader phrase come from one sentence per tier so they cannot drift, and the person is chosen by a Receiver discriminant rather than by comparing a name against 'you' (a friend named 'You' would otherwise flip the column's person). Both are tested.
- This branch MERGES CodeRabbit's commit 75280af rather than discarding it: it made rest tiles announce 'Ana already has this' to a screen reader where they were previously silent, and the user reviewed and accepted that change. It edited the pre-refactor tierPhrase, so the conflict was structural; the change is kept in the module's shape, singular on the tile where the heading is plural.
- Out of scope by prior map decisions: the giver's own cost in a swap, acquisition recency, and any flag inside the galaxy's 'Ready to sacrifice' grid. Composition with the two missing-only filters and the rarity lock is ticket #111, deliberately untouched.
- The user reviewed the previous run's document findings and chose to leave both: the stale describe() title in tests/trade-board.pbt.test.ts mentioning the removed badge, and the pre-existing hand-copied PBT inventory drift in Product-Definition/technical-environment.md, whose real fix is a generator or CI check and its own ticket.

## What Changed

- Each trade column is now cut into labelled tier bands (`bandsByTier` in `src/features/trade/board.ts`), with empty bands dropped and band order flattening back to exactly `orderByValue`'s sequence — property-tested as the load-bearing invariant.
- Tiles lost all tier badges, including the shipped 🎁/🆕 new-to-them badge, and the column header count pill was removed as duplicate of the first band heading; the filter checkbox's own `(badged/total)` count stays. Tile `aria-label`s now carry the tier phrase for every tier, so rest tiles announce "Ana already has this" / "you already have this" where they were previously silent.
- New pure `src/features/trade/band-copy.ts` derives both the band heading and the screen-reader phrase from one sentence per tier so they can't drift, and picks person from a `Receiver` discriminant (`{kind:"friend",name}` vs `ME`) rather than comparing a name against "you" — so a friend named "You" can't flip a column's person. Board copy in `app/play/trade/page.tsx`, `CONTEXT.md`, and the vision document were updated to describe bands rather than badges.

## Risk Assessment

✅ Low: The follow-up commit applies exactly the four approved informational fixes — an unreachable-branch collapse that leaves the rendered string identical, a test-oracle hardening, an arbitrary hoist, and a test-file rename — leaving the already-clean, well-bounded band-rendering change and all its intent criteria intact.

## Testing

Ran the two targeted property-test files for the change (31 tests, all green), then proved the user-visible behaviour by booting the app on a temporary route that renders the real Column component — this branch's and the base commit's, side by side — with fixture inventories driven through the real buildColumns() and real generated card art. Screenshots at desktop and mobile width show the three labelled bands in orderByValue order with receiver-named sentences ("One more and Ana can burn it" / "…and you can burn it"), badge-free tiles, and the removed header pill, with the base-commit rendering directly beneath for contrast; a filter-on shot shows empty bands dropped and the checkbox's (4/10) count retained. The rendered HTML also confirms every tile's accessible name now carries its tier sentence, including rest tiles that were silent before. All temporary scaffolding was deleted and the worktree is clean; no failures or flakiness observed.

- Evidence: Before/after: base-commit per-tile badges vs #110 tier bands (desktop, 1280px) (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M16GVEE6XJKMA2289GTBK2CW/ev110-before-after-desktop.png</code>)
- Evidence: Tier bands stacked at mobile width (500px) — headings carry the sentence, tiles carry no badges (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M16GVEE6XJKMA2289GTBK2CW/ev110-after-mobile.png</code>)
- Evidence: Missing-only filter on: column collapses to the single &#34;New for Ana&#34; band, no heading over an empty band, (4/10) count kept (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M16GVEE6XJKMA2289GTBK2CW/ev110-after-filter-on.png</code>)
<details>
<summary>Evidence: Band headings and tile accessible names, this branch vs base commit</summary>

<code>BAND HEADINGS (visible):&#10;mine-new 🎁 New for Ana&#10;mine-one-away 🔥 One more and Ana can burn it&#10;mine-rest Ana already has these&#10;theirs-new 🆕 New for you&#10;theirs-one-away 🔥 One more and you can burn it&#10;theirs-rest You already have these&#10;&#10;TILE ACCESSIBLE NAMES — AFTER (this branch):&#10;Whale Shark, Legendary, new for Ana&#10;Carnotaurus, Epic, one more and Ana can burn it&#10;Microraptor, Rare, Ana already has this&#10;Solaris, Legendary, new for you&#10;Honey Bee, Common, one more and you can burn it&#10;Melody, Common, you already have this&#10;&#10;SAME TILES — BEFORE (base bce0481): rest tiles announced name+rarity only&#10;Whale Shark, Legendary, 🎁 New for Ana&#10;Carnotaurus, Epic&#10;Microraptor, Rare&#10;Melody, Common</code>

```text
Rendered /ev110-evidence (real Column from TradeBoard.tsx, fixtures through real buildColumns)

BAND HEADINGS (visible, AFTER):
  mine-new         🎁 New for Ana
  mine-one-away    🔥 One more and Ana can burn it
  mine-rest        Ana already has these
  theirs-new       🆕 New for you
  theirs-one-away  🔥 One more and you can burn it
  theirs-rest      You already have these

TILE ACCESSIBLE NAMES — AFTER (this branch):
  Whale Shark, Legendary, new for Ana
  Polar Bear, Epic, new for Ana
  Arctic Fox, Rare, new for Ana
  Brownie, Common, new for Ana
  Carnotaurus, Epic, one more and Ana can burn it
  Platypus, Rare, one more and Ana can burn it
  Honey Bee, Common, one more and Ana can burn it
  Microraptor, Rare, Ana already has this
  Kangaroo, Common, Ana already has this
  Green Tree Frog, Common, Ana already has this
  Solaris, Legendary, new for you
  Terranova, Epic, new for you
  Basilisk, Rare, new for you
  Goblin, Common, new for you
  Microraptor, Rare, one more and you can burn it
  Honey Bee, Common, one more and you can burn it
  Carnotaurus, Epic, you already have this
  Platypus, Rare, you already have this
  Styracosaurus, Common, you already have this
  Melody, Common, you already have this

TILE ACCESSIBLE NAMES — BEFORE (base bce0481): rest tiles announce name+rarity only
  Whale Shark, Legendary, 🎁 New for Ana
  Polar Bear, Epic, 🎁 New for Ana
  Arctic Fox, Rare, 🎁 New for Ana
  Brownie, Common, 🎁 New for Ana
  Carnotaurus, Epic
  Platypus, Rare
  Honey Bee, Common
  Microraptor, Rare
  Kangaroo, Common
  Green Tree Frog, Common
  Solaris, Legendary, 🆕 New for you
  Terranova, Epic, 🆕 New for you
  Basilisk, Rare, 🆕 New for you
  Goblin, Common, 🆕 New for you
  Microraptor, Rare
  Honey Bee, Common
  Carnotaurus, Epic
  Platypus, Rare
  Styracosaurus, Common
  Melody, Common
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- ℹ️ `src/features/trade/TradeBoard.tsx:377` - Dead ternary in the tile aria-label: `phrase ? `, ${phrase}` : &#34;&#34;`. `bandCopy` returns a non-empty `phrase` for all three tiers (and `tests/trade-band-copy.test.ts:36` asserts exactly that), so the falsy branch is unreachable. It implies an optional-phrase contract the module does not have. Inline it as `, ${phrase}`.
- ℹ️ `tests/trade-band-copy.test.ts:39` - The heading/phrase drift property singularises with `heading.toLowerCase().replace(/these$/, &#34;this&#34;)` over the whole string, so the oracle depends on the generated receiver name. With `name = &#34;these&#34;`, tier `new` gives heading &#34;🎁 New for these&#34; -&gt; &#34;🎁 new for this&#34; while phrase is &#34;new for these&#34;, and `endsWith` fails on correct code. Astronomically unlikely with `fc.string`, but the fix is cheap: apply the singularisation to `phrase` instead (`phrase.replace(/this$/, &#34;these&#34;)`) or compare against the tier-specific expected pair rather than a suffix rewrite.
- ℹ️ `tests/trade-board.pbt.test.ts:317` - `boardCardArb` and `columnArb` are duplicated verbatim in the new `bandsByTier` describe from the `orderByValue` describe (lines 260-263). Hoist the pair to module scope beside `tcardArb` so widening the input space in one place cannot leave the other block testing a narrower one.
- ℹ️ `tests/trade-band-copy.test.ts:1` - The new file carries three `fc.assert` property tests but is named `trade-band-copy.test.ts`, outside the repo&#39;s documented property-test convention `tests/**/*.pbt.test.ts` (Product-Definition/technical-environment.md:380 and :419). The tests do execute — `vitest.config.ts` includes `tests/**/*.test.ts` and CI runs `pnpm test` — so nothing is skipped; the cost is that the blocking-PBT inventory selected by that glob no longer covers these properties. Flagging separately from the hand-copied-count drift the intent deliberately deferred, since the file name is a new choice in this change.

🔧 Fix: Fix band-copy PBT oracle, hoist arbitraries, drop dead ternary
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx vitest run tests/trade-band-copy.pbt.test.ts tests/trade-board.pbt.test.ts` — 31 tests pass (bandsByTier flatten == orderByValue invariant, empty-band dropping, heading/phrase-can&#39;t-drift, Receiver-discriminant person switch incl. a friend named &#34;You&#34;)</code>
- <code>Manual render: temporary route rendering the real `Column` from `src/features/trade/TradeBoard.tsx` (mechanically generated copy with only `export` added) beside the base-commit `bce0481` `Column`, with fixture inventories run through the real `buildColumns()` and card art fetched from the project&#39;s own seed image provider</code>
- <code>`npx next dev` + headless Chrome `--screenshot` at 1280x1600 (before/after comparison), 500x1250 (mobile stacking), and `?filter=1` at 1280x900 (missing-only filter composed with the bands)</code>
- <code>Extracted band headings (`data-testid=&#34;trade-band-*&#34;`) and every tile `aria-label` from the rendered HTML of both the new and base Column, confirming rest tiles announce &#34;Ana already has this&#34;/&#34;you already have this&#34; where the base build announced name+rarity only</code>
- <code>Cleanup verification: `git status --porcelain` empty after removing the temp route, generated component copies, fetched art, `.env.local` and `.next`</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `.github/workflows/ci.yml:8` - Same hand-copied test-inventory drift the user already deferred in Product-Definition/technical-environment.md also lives in .github/workflows/ci.yml comments (line 8: &#34;23 of the 63 test files&#34;; line 227: &#34;329 tests across 52 files, 23 of them property-based, and 104 fc.assert&#34;). Actual counts are 26 PBT files, 81 test files, 122 fc.assert sites — already wrong before this change, and this change adds one more PBT file. No edit made: it belongs to the same deferred generator/CI-check ticket, which should cover the ci.yml copy too, not just technical-environment.md.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Trade boards now group cards into receiver-focused value bands: new cards, additional burnable copies, and further duplicates.
  - Added clear, receiver-named headings for each value band.
  - Improved accessibility with descriptive tier labels and first-person wording where applicable.
  - Preserved card ordering within each band and removed empty bands.

- **Documentation**
  - Updated trade instructions and feature documentation to explain recipient-value sorting and the new banded layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->