### PR TITLE
feat(trade): drop the missing-only filters and keep locked tiles reachable

### DIFF
--- a/aidlc-docs/construction/build-and-test/increment22-trade-sacrifice-build-and-test.md
+++ b/aidlc-docs/construction/build-and-test/increment22-trade-sacrifice-build-and-test.md
@@ -79,10 +79,16 @@ Not performed here: `/play/*` requires a Google-authenticated parent session, wh
 A dev server is running on **http://localhost:3000**. Worth eyeballing:
 
 1. `/play/trade` — friend chips show `🎁 5` / `🎁 19` style counts before any card is picked.
-2. Pick a friend → two columns; only the badged cards carry a label, the rest carry none.
-3. Tick "Only show what X is missing" on each column → non-badged cards disappear; counts in the
-   label match what's left.
-4. Pick a card on one side → mismatched rarities on the other side go dim/grey and stop responding.
+2. Pick a friend (say Ana) → two columns, each cut into tier bands under a heading that names the
+   tier in a sentence and counts it, addressed to whoever would RECEIVE that column. Your doubles:
+   `🎁 New for Ana (5)` / `🔥 One more and Ana can burn it (2)` / `Ana already has these (12)`.
+   Ana's doubles: `🆕 New for you` / `🔥 One more and you can burn it` / `You already have these`.
+   No card carries a tier badge, and there is no filter checkbox.
+3. Each band's count matches the tiles under it, and the bands run new → one-away → rest down the
+   column; every double is in exactly one band, so the whole inventory is still reachable.
+4. Pick a card on one side → mismatched rarities on the other side go dim/grey and stop responding,
+   but stay tabbable: Tab onto one and the focus ring is clearly visible, the screen reader reads
+   "… needs a Rare to swap", and pressing it plays the denied sound and changes nothing.
 5. Phone viewport — columns stack with **your** doubles on top.
 6. `/play/binder` — Show row reads `🔥 Ready to sacrifice 0` and opens the empty state (per §2).
    To exercise the populated path, grant a 4th copy of some card to a test child first.

--- a/src/features/trade/TradeBoard.tsx
+++ b/src/features/trade/TradeBoard.tsx
@@ -169,7 +169,7 @@ export function TradeBoard({
       {/* Step 2 — the swap board (FR2) */}
       {friend && columns ? (
         <div className="grid w-full gap-5 md:grid-cols-2" data-testid="trade-board">
-          {/* Own doubles first — on mobile these stack above the friend's (FR5=A). */}
+          {/* Own doubles first — on mobile these stack above the friend's (Q5=A — FR2's mobile order). */}
           <Column
             testid="mine"
             title="Your doubles"

--- a/src/features/trade/TradeBoard.tsx
+++ b/src/features/trade/TradeBoard.tsx
@@ -12,13 +12,7 @@ import { useSound } from "@/features/sound/useSound";
 import { playReward } from "@/features/sound/sfx";
 import { getTradeBoardAction, executeTradeAction } from "./actions";
 import type { TradableCard } from "./trade-logic";
-import {
-  applyMissingFilter,
-  bandsByTier,
-  buildColumns,
-  isPickable,
-  type BoardCard,
-} from "./board";
+import { bandsByTier, buildColumns, isPickable, type BoardCard } from "./board";
 import { ME, bandCopy, type Receiver } from "./band-copy";
 
 export type FriendSummary = {
@@ -51,10 +45,6 @@ export function TradeBoard({
   } | null>(null);
   const [mine, setMine] = useState<BoardCard | null>(null);
   const [theirs, setTheirs] = useState<BoardCard | null>(null);
-  // FR5 / Q1=B — both filters start OFF: the child sees their whole inventory
-  // on arrival and opts into the narrowing.
-  const [onlyTheirsMissing, setOnlyTheirsMissing] = useState(false);
-  const [onlyMineMissing, setOnlyMineMissing] = useState(false);
   const [result, setResult] = useState<{ gave: CardType; got: CardType } | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
@@ -136,9 +126,6 @@ export function TradeBoard({
         })
       : null;
 
-  const myBadged = columns ? columns.mine.filter((c) => c.newToOther).length : 0;
-  const theirBadged = columns ? columns.theirs.filter((c) => c.newToOther).length : 0;
-
   return (
     <div className="flex w-full max-w-5xl flex-col items-center gap-5">
       <ErrorBanner testId="trade-error" message={error} />
@@ -186,12 +173,7 @@ export function TradeBoard({
           <Column
             testid="mine"
             title="Your doubles"
-            filterLabel={`Only show what ${friend.name} is missing`}
-            filterOn={onlyTheirsMissing}
-            setFilterOn={setOnlyTheirsMissing}
-            badged={myBadged}
-            total={columns.mine.length}
-            cards={applyMissingFilter(columns.mine, onlyTheirsMissing)}
+            cards={columns.mine}
             receiver={{ kind: "friend", name: friend.name }}
             selectedId={mine?.card.id ?? null}
             otherPick={theirs?.card ?? null}
@@ -200,22 +182,13 @@ export function TradeBoard({
               posthog.capture("trade_initiated", { card_rarity: c.card.rarity });
               setMine(c);
             }}
-            emptyHint={
-              onlyTheirsMissing
-                ? `${friend.name} already has all your doubles — untick to swap anyway.`
-                : "You have no doubles to trade yet."
-            }
+            emptyHint="You have no doubles to trade yet."
           />
 
           <Column
             testid="theirs"
             title={`${friend.name}'s doubles`}
-            filterLabel="Only show what you're missing"
-            filterOn={onlyMineMissing}
-            setFilterOn={setOnlyMineMissing}
-            badged={theirBadged}
-            total={columns.theirs.length}
-            cards={applyMissingFilter(columns.theirs, onlyMineMissing)}
+            cards={columns.theirs}
             receiver={ME}
             selectedId={theirs?.card.id ?? null}
             otherPick={mine?.card ?? null}
@@ -223,11 +196,7 @@ export function TradeBoard({
               play("click");
               setTheirs(c);
             }}
-            emptyHint={
-              onlyMineMissing
-                ? `You already have all of ${friend.name}'s doubles — untick to swap anyway.`
-                : `${friend.name} has no doubles to swap.`
-            }
+            emptyHint={`${friend.name} has no doubles to swap.`}
           />
         </div>
       ) : null}
@@ -272,18 +241,17 @@ export function TradeBoard({
  * tier, so the tiles carry no badges at all — including the 🎁 that used to
  * mark tier 1 (FR4), which the first band now says in full and in words.
  *
- * The header pill that counted the same cards went with it: it sat directly
- * above a heading saying the same thing in the same words. The filter's own
- * `(badged/total)` count stays — it's about what the checkbox would leave.
+ * The "only show what's missing" checkbox went the same way (#111). It kept
+ * exactly the `new` band — which the sort already floats to the top, under a
+ * heading that names it in a sentence and counts it. The checkbox restated
+ * that in its own label, and was the only control on the board that could
+ * REMOVE a swap the child was allowed to make. Nothing here narrows any more:
+ * the column shows the whole inventory, ordered so the best swap is first, and
+ * every card stays reachable.
  */
 function Column({
   testid,
   title,
-  filterLabel,
-  filterOn,
-  setFilterOn,
-  badged,
-  total,
   cards,
   receiver,
   selectedId,
@@ -293,11 +261,6 @@ function Column({
 }: {
   testid: string;
   title: string;
-  filterLabel: string;
-  filterOn: boolean;
-  setFilterOn: (v: boolean) => void;
-  badged: number;
-  total: number;
   cards: BoardCard[];
   receiver: Receiver;
   selectedId: string | null;
@@ -308,15 +271,6 @@ function Column({
   return (
     <section className="panel flex flex-col gap-3 p-4" data-testid={`trade-column-${testid}`}>
       <h2 className="text-lg font-bold">{title}</h2>
-      <label className="flex cursor-pointer items-center gap-2 text-sm">
-        <input
-          type="checkbox"
-          checked={filterOn}
-          onChange={(e) => setFilterOn(e.target.checked)}
-          data-testid={`trade-filter-${testid}`}
-        />
-        {filterLabel} ({badged}/{total})
-      </label>
       {cards.length === 0 ? (
         <Hint>{emptyHint}</Hint>
       ) : (

--- a/src/features/trade/TradeBoard.tsx
+++ b/src/features/trade/TradeBoard.tsx
@@ -13,7 +13,7 @@ import { playReward } from "@/features/sound/sfx";
 import { getTradeBoardAction, executeTradeAction } from "./actions";
 import type { TradableCard } from "./trade-logic";
 import { bandsByTier, buildColumns, isPickable, type BoardCard } from "./board";
-import { ME, bandCopy, type Receiver } from "./band-copy";
+import { ME, bandCopy, tileLabel, type Receiver } from "./band-copy";
 
 export type FriendSummary = {
   id: string;
@@ -290,7 +290,7 @@ function Column({
                   receiver={receiver}
                   testid={testid}
                   selected={selectedId === c.card.id}
-                  pickable={isPickable(c.card, otherPick)}
+                  otherPick={otherPick}
                   onPick={() => onPick(c)}
                 />
               ))}
@@ -302,33 +302,44 @@ function Column({
   );
 }
 
-/** A card tile. Carries no tier badge since #110 — the band heading above it
- *  says the tier, in a sentence, once. Mismatched rarities are dimmed but stay
- *  visible (FR6). */
+/**
+ * A card tile. Carries no tier badge since #110 — the band heading above it
+ * says the tier, in a sentence, once. Mismatched rarities are dimmed but stay
+ * visible (FR6), and stay REACHABLE (#111): the lock is `aria-disabled`, not
+ * `disabled`, because a `disabled` button leaves the tab order entirely, so a
+ * child driving the board by keyboard or screen reader met the locked half of
+ * a column as silence — no tile, and no reason. Dimmed-but-focusable puts the
+ * rule where it can be heard, which is the point of dimming rather than
+ * removing in the first place. The click has to be guarded by hand in
+ * exchange, since `aria-disabled` is a claim to assistive tech and not a
+ * behaviour the browser enforces.
+ */
 function Tile({
   entry,
   receiver,
   testid,
   selected,
-  pickable,
+  otherPick,
   onPick,
 }: {
   entry: BoardCard;
   receiver: Receiver;
   testid: string;
   selected: boolean;
-  pickable: boolean;
+  otherPick: CardType | null;
   onPick: () => void;
 }) {
   const meta = RARITY_META[entry.card.rarity];
-  const { phrase } = bandCopy(entry.tier, receiver);
+  const pickable = isPickable(entry.card, otherPick);
   return (
     <button
       type="button"
-      onClick={onPick}
-      disabled={!pickable}
+      onClick={() => {
+        if (pickable) onPick();
+      }}
+      aria-disabled={!pickable}
       aria-pressed={selected}
-      aria-label={`${entry.card.name}, ${meta.label}, ${phrase}`}
+      aria-label={tileLabel(entry, receiver, otherPick)}
       data-testid={`trade-${testid}-${entry.card.id}`}
       className={`relative overflow-hidden rounded-xl border-2 bg-white/10 transition ${
         selected ? "ring-4 ring-[color:var(--brand-1)]" : ""

--- a/src/features/trade/TradeBoard.tsx
+++ b/src/features/trade/TradeBoard.tsx
@@ -331,24 +331,28 @@ function Tile({
 }) {
   const meta = RARITY_META[entry.card.rarity];
   const pickable = isPickable(entry.card, otherPick);
+  const { play } = useSound();
   return (
     <button
       type="button"
       onClick={() => {
         if (pickable) onPick();
+        else play("denied");
       }}
       aria-disabled={!pickable}
       aria-pressed={selected}
       aria-label={tileLabel(entry, receiver, otherPick)}
       data-testid={`trade-${testid}-${entry.card.id}`}
-      className={`relative overflow-hidden rounded-xl border-2 bg-white/10 transition ${
+      className={`relative overflow-hidden rounded-xl border-2 bg-white/10 transition focus-visible:outline-none focus-visible:shadow-[var(--ring-focus)] ${
         selected ? "ring-4 ring-[color:var(--brand-1)]" : ""
-      } ${pickable ? "hover:scale-105" : "cursor-not-allowed opacity-25 grayscale"}`}
+      } ${pickable ? "hover:scale-105" : "cursor-not-allowed"}`}
       style={{ borderColor: meta.frame }}
     >
-      <CardImage src={entry.card.imageUrl} alt={entry.card.name} dim={200} />
-      <span className="pill absolute bottom-1 right-1 text-xs">×{entry.count}</span>
-      <span className="rarity-badge">{meta.label}</span>
+      <span className={`block ${pickable ? "" : "opacity-25 grayscale"}`}>
+        <CardImage src={entry.card.imageUrl} alt={entry.card.name} dim={200} />
+        <span className="pill absolute bottom-1 right-1 text-xs">×{entry.count}</span>
+        <span className="rarity-badge">{meta.label}</span>
+      </span>
     </button>
   );
 }

--- a/src/features/trade/TradeBoard.tsx
+++ b/src/features/trade/TradeBoard.tsx
@@ -343,12 +343,16 @@ function Tile({
       aria-pressed={selected}
       aria-label={tileLabel(entry, receiver, otherPick)}
       data-testid={`trade-${testid}-${entry.card.id}`}
-      className={`relative overflow-hidden rounded-xl border-2 bg-white/10 transition focus-visible:outline-none focus-visible:shadow-[var(--ring-focus)] ${
+      className={`rounded-xl transition focus-visible:outline-[3px] focus-visible:outline-offset-2 focus-visible:outline-[color:var(--brand-1)] ${
         selected ? "ring-4 ring-[color:var(--brand-1)]" : ""
       } ${pickable ? "hover:scale-105" : "cursor-not-allowed"}`}
-      style={{ borderColor: meta.frame }}
     >
-      <span className={`block ${pickable ? "" : "opacity-25 grayscale"}`}>
+      <span
+        className={`relative block overflow-hidden rounded-xl border-2 bg-white/10 ${
+          pickable ? "" : "opacity-25 grayscale"
+        }`}
+        style={{ borderColor: meta.frame }}
+      >
         <CardImage src={entry.card.imageUrl} alt={entry.card.name} dim={200} />
         <span className="pill absolute bottom-1 right-1 text-xs">×{entry.count}</span>
         <span className="rarity-badge">{meta.label}</span>

--- a/src/features/trade/band-copy.ts
+++ b/src/features/trade/band-copy.ts
@@ -1,10 +1,12 @@
-import type { SwapTier } from "./board";
+import type { Card } from "@/lib/types";
+import { RARITY_META } from "@/features/card/rarity";
+import { isPickable, type SwapTier } from "./board";
 
 /**
- * What a tier band SAYS (#110). PURE, and beside the component rather than in
- * it, because the words are a rule the child reads: the tier is stated once
- * above a band instead of stamped on every tile, and the same sentence has to
- * reach a screen reader from the tile itself.
+ * What a tier band and a tile SAY (#110, #111). PURE, and beside the component
+ * rather than in it, because the words are a rule the child reads: the tier is
+ * stated once above a band instead of stamped on every tile, and the same
+ * sentence has to reach a screen reader from the tile itself.
  */
 
 /**
@@ -78,4 +80,28 @@ function said(glyph: string, sentence: string): BandCopy {
     heading: `${glyph} ${sentence[0].toUpperCase()}${sentence.slice(1)}`,
     phrase: sentence,
   };
+}
+
+/**
+ * A tile's whole accessible name (#111). Pure and here, rather than
+ * interpolated in the component, for the reason `bandCopy` is: it is the only
+ * channel through which a child who can't see the board learns why half a
+ * column stopped responding.
+ *
+ * The rarity lock dims a mismatched tile but keeps it in the tab order, so a
+ * listener DOES reach it — and reaching a tile that says nothing about the
+ * lock is worse than the `disabled` silence it replaced. The reason is
+ * appended from `isPickable` itself, not from a second copy of the rule, so a
+ * tile cannot be dimmed and mute or lit and apologetic.
+ */
+export function tileLabel(
+  entry: { card: Card; tier: SwapTier },
+  receiver: Receiver,
+  otherPick: Card | null,
+): string {
+  const { label } = RARITY_META[entry.card.rarity];
+  const name = `${entry.card.name}, ${label}, ${bandCopy(entry.tier, receiver).phrase}`;
+  return isPickable(entry.card, otherPick) || !otherPick
+    ? name
+    : `${name}, needs a ${RARITY_META[otherPick.rarity].label} to swap`;
 }

--- a/src/features/trade/band-copy.ts
+++ b/src/features/trade/band-copy.ts
@@ -101,7 +101,7 @@ export function tileLabel(
 ): string {
   const { label } = RARITY_META[entry.card.rarity];
   const name = `${entry.card.name}, ${label}, ${bandCopy(entry.tier, receiver).phrase}`;
-  return isPickable(entry.card, otherPick) || !otherPick
+  return otherPick === null || isPickable(entry.card, otherPick)
     ? name
     : `${name}, needs a ${RARITY_META[otherPick.rarity].label} to swap`;
 }

--- a/src/features/trade/board.ts
+++ b/src/features/trade/board.ts
@@ -3,7 +3,7 @@ import { SACRIFICE_MIN } from "@/features/pull/sacrifice";
 import type { TradableCard } from "./trade-logic";
 
 /**
- * Friend-first trade board logic (Inc22 FR2/FR4/FR5/FR6/FR7). PURE — no I/O, so
+ * Friend-first trade board logic (Inc22 FR2/FR6/FR7). PURE — no I/O, so
  * every rule the child sees on the board is property-testable and can't drift
  * from what `validateTrade` will allow at commit time.
  */
@@ -47,16 +47,16 @@ export function oneAwayFromBurn(count: number): boolean {
 export interface BoardCard {
   card: Card;
   count: number;
-  /** What this swap is worth to the party on the OTHER side of the board. */
-  tier: SwapTier;
   /**
-   * True when the OTHER party doesn't own this card at all. Drives the "only
-   * show what's missing" filter (FR5) and its count; since #110 the `new` band
-   * heading is what says it on screen, so no tile wears a badge for it any
-   * more (FR4). Deliberately about ownership, not duplicates: what matters is
-   * whether the swap gives them something genuinely new.
+   * What this swap is worth to the party on the OTHER side of the board.
+   *
+   * The only thing a tile carries about the receiver, since #111. There used
+   * to be a `newToOther` boolean beside it, back when the "only show what's
+   * missing" checkbox (FR5) filtered on it — but `tier === "new"` is the same
+   * predicate, and once the filter went the field had no readers that the tier
+   * didn't already serve. Two names for one fact is how the two drift.
    */
-  newToOther: boolean;
+  tier: SwapTier;
 }
 
 /**
@@ -114,7 +114,7 @@ function tag(
     : theirCount !== undefined && oneAwayFromBurn(theirCount)
       ? "one-away"
       : "rest";
-  return { card: t.card, count: t.count, newToOther, tier };
+  return { card: t.card, count: t.count, tier };
 }
 
 /**
@@ -158,11 +158,6 @@ export function bandsByTier(cards: BoardCard[]): TierBand[] {
     tier,
     cards: cards.filter((c) => c.tier === tier),
   })).filter((band) => band.cards.length > 0);
-}
-
-/** FR5 — hide the cards the other party already has. `false` is the identity. */
-export function applyMissingFilter(cards: BoardCard[], onlyMissing: boolean): BoardCard[] {
-  return onlyMissing ? cards.filter((c) => c.newToOther) : cards;
 }
 
 /** FR7 — how many of `mine` the given ownership set lacks. Drives the friend chips. */

--- a/tests/trade-band-copy.pbt.test.ts
+++ b/tests/trade-band-copy.pbt.test.ts
@@ -149,7 +149,7 @@ describe("tileLabel (#111 — a dimmed tile still says why)", () => {
       fc.property(cardArb, tierArb, receiverArb, fc.option(cardArb, { nil: null }), (card, tier, receiver, otherPick) => {
         const label = tileLabel({ card, tier }, receiver, otherPick);
         const locked = otherPick !== null && !isPickable(card, otherPick);
-        expect(label.includes("to swap")).toBe(locked);
+        expect(label.endsWith(" to swap")).toBe(locked);
         if (locked) {
           expect(label).toContain(`needs a ${RARITY_META[otherPick!.rarity].label} to swap`);
         }
@@ -174,7 +174,7 @@ describe("tileLabel (#111 — a dimmed tile still says why)", () => {
     fc.assert(
       fc.property(cardArb, cardArb, tierArb, receiverArb, (card, other, tier, receiver) => {
         const sameRarity: Card = { ...other, rarity: card.rarity };
-        expect(tileLabel({ card, tier }, receiver, sameRarity)).not.toContain("to swap");
+        expect(tileLabel({ card, tier }, receiver, sameRarity).endsWith(" to swap")).toBe(false);
       }),
     );
   });

--- a/tests/trade-band-copy.pbt.test.ts
+++ b/tests/trade-band-copy.pbt.test.ts
@@ -152,7 +152,7 @@ describe("tileLabel (#111 — a dimmed tile still says why)", () => {
         const lockSuffix = otherPick === null ? null : `, needs a ${RARITY_META[otherPick.rarity].label} to swap`;
         expect(lockSuffix !== null && label.endsWith(lockSuffix)).toBe(locked);
         if (locked) {
-          expect(label).toContain(`needs a ${RARITY_META[otherPick!.rarity].label} to swap`);
+          expect(label.endsWith(lockSuffix!)).toBe(true);
         }
       }),
     );

--- a/tests/trade-band-copy.pbt.test.ts
+++ b/tests/trade-band-copy.pbt.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import fc from "fast-check";
-import { ME, bandCopy, type BandCopy, type Receiver } from "@/features/trade/band-copy";
-import type { SwapTier } from "@/features/trade/board";
+import { ME, bandCopy, tileLabel, type BandCopy, type Receiver } from "@/features/trade/band-copy";
+import { isPickable, type SwapTier } from "@/features/trade/board";
+import { RARITY_META } from "@/features/card/rarity";
+import { RARITIES, type Card, type Rarity } from "@/lib/types";
 
 const ANA: Receiver = { kind: "friend", name: "Ana" };
 /** A friend whose name is the word the second-person copy uses. */
@@ -112,6 +114,67 @@ describe("bandCopy (#110 — the sentence a band says)", () => {
         for (const receiver of [{ kind: "friend", name } as Receiver, ME]) {
           expect(bandCopy(tier, receiver).heading.trim().length).toBeGreaterThan(0);
         }
+      }),
+    );
+  });
+});
+
+describe("tileLabel (#111 — a dimmed tile still says why)", () => {
+  const rarityArb = fc.constantFrom<Rarity>(...RARITIES);
+  const cardArb = fc
+    .tuple(fc.string({ minLength: 1 }), rarityArb)
+    .map(
+      ([id, rarity]): Card => ({
+        id,
+        themeId: "t",
+        name: id,
+        rarity,
+        imageUrl: "x",
+        eduText: "y",
+        sourceUrl: "",
+      }),
+    );
+  const tierArb = fc.constantFrom(...TIERS);
+  const receiverArb = fc.oneof(
+    fc.constant(ME),
+    fc.string({ minLength: 1 }).map((name): Receiver => ({ kind: "friend", name })),
+  );
+
+  it("says why exactly when the rarity lock is holding the tile out", () => {
+    // The invariant the whole a11y change rests on. A tile the lock dims is
+    // still reachable by keyboard since #111, so silence there is worse than
+    // the `disabled` it replaced — and a tile that apologises while perfectly
+    // pickable is a lie in the other direction.
+    fc.assert(
+      fc.property(cardArb, tierArb, receiverArb, fc.option(cardArb, { nil: null }), (card, tier, receiver, otherPick) => {
+        const label = tileLabel({ card, tier }, receiver, otherPick);
+        const locked = otherPick !== null && !isPickable(card, otherPick);
+        expect(label.includes("to swap")).toBe(locked);
+        if (locked) {
+          expect(label).toContain(`needs a ${RARITY_META[otherPick!.rarity].label} to swap`);
+        }
+      }),
+    );
+  });
+
+  it("always carries the card, its rarity and its tier, locked or not", () => {
+    // The lock reason is an APPENDIX. Whatever the pick state, a listener
+    // still hears which card this is and what the swap is worth.
+    fc.assert(
+      fc.property(cardArb, tierArb, receiverArb, fc.option(cardArb, { nil: null }), (card, tier, receiver, otherPick) => {
+        const label = tileLabel({ card, tier }, receiver, otherPick);
+        expect(label).toContain(card.name);
+        expect(label).toContain(RARITY_META[card.rarity].label);
+        expect(label).toContain(bandCopy(tier, receiver).phrase);
+      }),
+    );
+  });
+
+  it("a matching rarity never reads as locked", () => {
+    fc.assert(
+      fc.property(cardArb, cardArb, tierArb, receiverArb, (card, other, tier, receiver) => {
+        const sameRarity: Card = { ...other, rarity: card.rarity };
+        expect(tileLabel({ card, tier }, receiver, sameRarity)).not.toContain("to swap");
       }),
     );
   });

--- a/tests/trade-band-copy.pbt.test.ts
+++ b/tests/trade-band-copy.pbt.test.ts
@@ -149,7 +149,8 @@ describe("tileLabel (#111 — a dimmed tile still says why)", () => {
       fc.property(cardArb, tierArb, receiverArb, fc.option(cardArb, { nil: null }), (card, tier, receiver, otherPick) => {
         const label = tileLabel({ card, tier }, receiver, otherPick);
         const locked = otherPick !== null && !isPickable(card, otherPick);
-        expect(label.endsWith(" to swap")).toBe(locked);
+        const lockSuffix = otherPick === null ? null : `, needs a ${RARITY_META[otherPick.rarity].label} to swap`;
+        expect(lockSuffix !== null && label.endsWith(lockSuffix)).toBe(locked);
         if (locked) {
           expect(label).toContain(`needs a ${RARITY_META[otherPick!.rarity].label} to swap`);
         }
@@ -174,7 +175,11 @@ describe("tileLabel (#111 — a dimmed tile still says why)", () => {
     fc.assert(
       fc.property(cardArb, cardArb, tierArb, receiverArb, (card, other, tier, receiver) => {
         const sameRarity: Card = { ...other, rarity: card.rarity };
-        expect(tileLabel({ card, tier }, receiver, sameRarity).endsWith(" to swap")).toBe(false);
+        expect(
+          tileLabel({ card, tier }, receiver, sameRarity).endsWith(
+            `, needs a ${RARITY_META[sameRarity.rarity].label} to swap`,
+          ),
+        ).toBe(false);
       }),
     );
   });

--- a/tests/trade-board.pbt.test.ts
+++ b/tests/trade-board.pbt.test.ts
@@ -3,7 +3,6 @@ import fc from "fast-check";
 import {
   bandsByTier,
   buildColumns,
-  applyMissingFilter,
   missingCount,
   isPickable,
   oneAwayFromBurn,
@@ -33,16 +32,19 @@ const ownedArb = fc.array(fc.string({ minLength: 1 }), { maxLength: 20 }).map((i
 
 const boardCardArb = fc
   .tuple(tcardArb, fc.constantFrom<SwapTier>("new", "one-away", "rest"))
-  .map(([t, tier]) => ({ ...t, tier, newToOther: tier === "new" }) satisfies BoardCard);
+  .map(([t, tier]) => ({ ...t, tier }) satisfies BoardCard);
 const columnArb = fc.array(boardCardArb, { maxLength: 20 });
 
-describe("buildColumns (Inc22 FR4 — badge only what's new to the other side)", () => {
-  it("newToOther is exactly the complement of the other party's owned set", () => {
+describe("buildColumns (#109 — tier each column against the other side)", () => {
+  it("the `new` tier is exactly the complement of the other party's owned set", () => {
+    // Stated on the tier rather than on a `newToOther` flag beside it: #111
+    // deleted that field once the filter reading it went, because the two were
+    // the same predicate under two names.
     fc.assert(
       fc.property(inventoryArb, inventoryArb, ownedArb, ownedArb, (mine, theirs, myOwned, theirOwned) => {
         const cols = buildColumns({ mine, theirs, myOwnedIds: myOwned, theirOwnedIds: theirOwned });
-        for (const c of cols.mine) expect(c.newToOther).toBe(!theirOwned.has(c.card.id));
-        for (const c of cols.theirs) expect(c.newToOther).toBe(!myOwned.has(c.card.id));
+        for (const c of cols.mine) expect(c.tier === "new").toBe(!theirOwned.has(c.card.id));
+        for (const c of cols.theirs) expect(c.tier === "new").toBe(!myOwned.has(c.card.id));
       }),
     );
   });
@@ -70,38 +72,18 @@ describe("buildColumns (Inc22 FR4 — badge only what's new to the other side)",
       myOwnedIds: new Set(["shared", "mine-only"]),
       theirOwnedIds: new Set(["shared"]),
     });
-    expect(cols.mine.find((c) => c.card.id === "mine-only")!.newToOther).toBe(true);
-    expect(cols.mine.find((c) => c.card.id === "shared")!.newToOther).toBe(false);
-    expect(cols.theirs[0].newToOther).toBe(false);
-  });
-});
-
-describe("applyMissingFilter (Inc22 FR5)", () => {
-  it("off is the identity", () => {
-    fc.assert(
-      fc.property(inventoryArb, ownedArb, (mine, owned) => {
-        const cols = buildColumns({ mine, theirs: [], myOwnedIds: new Set(), theirOwnedIds: owned });
-        expect(applyMissingFilter(cols.mine, false)).toBe(cols.mine);
-      }),
-    );
-  });
-
-  it("on keeps exactly the badged cards", () => {
-    fc.assert(
-      fc.property(inventoryArb, ownedArb, (mine, owned) => {
-        const cols = buildColumns({ mine, theirs: [], myOwnedIds: new Set(), theirOwnedIds: owned });
-        const out = applyMissingFilter(cols.mine, true);
-        expect(out.every((c) => c.newToOther)).toBe(true);
-        expect(out.length).toBe(cols.mine.filter((c) => c.newToOther).length);
-      }),
-    );
+    expect(cols.mine.find((c) => c.card.id === "mine-only")!.tier).toBe("new");
+    expect(cols.mine.find((c) => c.card.id === "shared")!.tier).not.toBe("new");
+    expect(cols.theirs[0].tier).not.toBe("new");
   });
 });
 
 describe("missingCount (Inc22 FR7 — friend chip counts)", () => {
-  it("always equals the number of badged cards on the board", () => {
-    // The chip on the friend strip and the badges on the board are computed at
-    // different times from different data; they must never disagree.
+  it("always equals the size of the `new` band on the board", () => {
+    // The chip on the friend strip and the band heading on the board are
+    // computed at different times from different data; they must never
+    // disagree. The chip is the only survivor of #111's cull — the board's own
+    // count of the same cards now lives in the band heading.
     fc.assert(
       fc.property(inventoryArb, ownedArb, (mine, theirOwned) => {
         const cols = buildColumns({
@@ -110,7 +92,7 @@ describe("missingCount (Inc22 FR7 — friend chip counts)", () => {
           myOwnedIds: new Set(),
           theirOwnedIds: theirOwned,
         });
-        expect(missingCount(mine, theirOwned)).toBe(cols.mine.filter((c) => c.newToOther).length);
+        expect(missingCount(mine, theirOwned)).toBe(cols.mine.filter((c) => c.tier === "new").length);
       }),
     );
   });
@@ -199,17 +181,6 @@ describe("oneAwayFromBurn (#109 tier 2 — expressed through SACRIFICE_MIN, neve
 });
 
 describe("tiers (#109 — mirrored, receiver-valued)", () => {
-  it("tier 'new' is exactly newToOther, on both columns", () => {
-    fc.assert(
-      fc.property(inventoryArb, inventoryArb, ownedArb, ownedArb, (mine, theirs, myOwned, theirOwned) => {
-        const cols = buildColumns({ mine, theirs, myOwnedIds: myOwned, theirOwnedIds: theirOwned });
-        for (const c of [...cols.mine, ...cols.theirs]) {
-          expect(c.tier === "new").toBe(c.newToOther);
-        }
-      }),
-    );
-  });
-
   it("tier 'one-away' means the RECEIVER — not the giver — is one copy from burning", () => {
     // The mirror is the easy thing to get backwards: my column is tiered by the
     // friend's shelf, theirs by mine.


### PR DESCRIPTION
## Intent

Resolve wayfinder ticket #111: decide and ship how the swap board's tier sort composes with the controls the board already has. Three decisions taken with the owner: (1) both 'only show what's missing' checkboxes are REMOVED, not restated — since #110 each one kept exactly the 'new' tier band, which the sort already floats to the top under a heading that names and counts it, and the checkbox was the only control that could remove a swap the child was allowed to make; BoardCard.newToOther is dropped with it since tier === 'new' is the same predicate and applyMissingFilter was its last reader. (2) The rarity lock keeps dimming in place rather than removing (order was already frozen under a pick, since buildColumns never reads selection state), and the dimmed tile gains aria-disabled instead of disabled so it stays in the tab order, with the reason appended to its accessible name via a new pure tileLabel in band-copy.ts. (3) The friend strip stays as-is — no tier-2 companion pill and no re-rank, because a second pill is the badge-per-tier noise #110 removed and the count would need a per-friend counts payload #109's reasoning declines. Execution is in scope for this map.

## What Changed

- Removed both "only show what's missing" checkboxes from the swap board columns, along with their labels, counts and filtered empty hints: each column now renders its whole inventory under the tier band headings that already name and count the `new` band. `applyMissingFilter` and the `BoardCard.newToOther` field are deleted with them, since `tier === "new"` is the same predicate and the filter was its last reader; the board PBTs now assert the tier directly.
- A rarity-locked tile is now `aria-disabled` rather than `disabled`, so it stays in the tab order, gets a focus outline, and plays the `denied` sound on click instead of silently ignoring it. The dimming (`opacity-25 grayscale`) moved onto an inner wrapper so the focus outline is not dimmed with the art.
- Added a pure `tileLabel` in `band-copy.ts` that builds a tile's accessible name from card, rarity and tier band phrase, appending "needs a &lt;rarity&gt; to swap" exactly when `isPickable` rejects the tile against the current pick; covered by new property tests, and the increment-22 build-and-test walkthrough was updated to describe the band-based board and the tabbable locked tile.

## Risk Assessment

✅ Low: The functional change remains a well-bounded removal of a client-only filter plus a contained a11y swap with equivalent property-test coverage; both residual findings are a cosmetic focus-indicator nuance on one tile state and documentation drift.

## Testing

Ran the targeted trade property suites (all green), then verified the change the way a child would meet it: the real TradeBoard rendered in headless Chrome from a throwaway Next dev harness, at head and at base ff288c2, driven by mouse and keyboard. The before/after screenshots show the two "only show what's missing" checkboxes gone (base: ticking them dropped 9 tiles to 5; head: 0 checkboxes with the whole inventory under the tier band headings), the rarity-locked tiles dimmed but now focusable via Tab with the reason in their accessible name instead of `disabled` silence, a locked click refused (no selection change, no confirm bar) while the matching-rarity pick still opens the confirm bar, and the friend strip untouched. Only issue seen is a copy nit — the reason reads "needs a Epic to swap". Harness files, the temporary next.config patch and .next were removed; the worktree is clean.

- Evidence: AFTER — swap board, no filter checkboxes, whole inventory under tier bands (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M16XSYKTKAWRKW25V8D00PJN/04-after-board.png</code>)
- Evidence: BEFORE (base ff288c2) — the two &#34;only show what&#39;s missing&#34; checkboxes (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M16XSYKTKAWRKW25V8D00PJN/01-before-board-base.png</code>)
- Evidence: BEFORE — both filters ticked: 9 swappable tiles reduced to 5 (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M16XSYKTKAWRKW25V8D00PJN/02-before-filters-on-base.png</code>)
- Evidence: AFTER — locked (rarity-mismatched) tile reached by Tab, focus outline visible, still dimmed (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M16XSYKTKAWRKW25V8D00PJN/06-after-locked-tile-keyboard-focus.png</code>)
- Evidence: AFTER — rarity lock after picking Comet (Epic) (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M16XSYKTKAWRKW25V8D00PJN/05-after-rarity-lock.png</code>)
- Evidence: BEFORE — locked tiles under a pick (disabled, out of the tab order) (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M16XSYKTKAWRKW25V8D00PJN/03-before-locked-tiles-base.png</code>)
- Evidence: AFTER — matching-rarity pick (Titan, Epic) still opens the confirm bar (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M16XSYKTKAWRKW25V8D00PJN/07-after-valid-epic-pick-confirm.png</code>)
<details>
<summary>Evidence: Board a11y transcript — before/after tile state, band headings, keyboard walk</summary>

<code>BEFORE (base ff288c2)&#10;checkboxes on the board: 2 -&gt; Only show what Ana is missing (3/5), Only show what you&#39;re missing (2/4)&#10;ticking both boxes: 9 tiles -&gt; 5 tiles (swaps the child was allowed to make disappear)&#10;trade-theirs-orion disabled=True aria-disabled=None &#34;Orion, Rare, new for you&#34;&#10;&#10;AFTER (f460c7d)&#10;checkboxes on the board: 0 &lt;label&gt; elements: []&#10;tiles on screen: 9 (whole inventory, nothing narrowed)&#10;bands: 🎁 New for Ana (3) / 🔥 One more and Ana can burn it (1) / Ana already has these (1)&#10;🆕 New for you (2) / 🔥 One more and you can burn it (1) / You already have these (1)&#10;trade-theirs-orion disabled=False aria-disabled=true dimmed=True &#34;Orion, Rare, new for you, needs a Epic to swap&#34;&#10;keyboard: 9 Tab presses reach the locked tile trade-theirs-orion&#10;clicking that locked tile: aria-pressed count 2 -&gt; 2, confirm bar shown: False&#10;clicking the matching-rarity tile (Titan, Epic): confirm bar shown: True</code>

```text
Swap board — #111, real TradeBoard rendered in Chrome (Next dev, fixture inventory).
Board state: I picked Comet (Epic) in my column; Ana's column is under the rarity lock.

BEFORE (base ff288c2)
  checkboxes on the board: 2  ->  Only show what Ana is missing (3/5), Only show what you're missing (2/4)
  ticking both boxes: 9 tiles -> 5 tiles (swaps the child was allowed to make disappear)
  tiles once a pick is made:
    trade-mine-quasar      disabled=False aria-disabled=None   "Quasar, Legendary, new for Ana"
    trade-mine-comet       disabled=False aria-disabled=None   "Comet, Epic, new for Ana"
    trade-mine-meteor      disabled=False aria-disabled=None   "Meteor, Common, new for Ana"
    trade-mine-nebula      disabled=False aria-disabled=None   "Nebula, Rare, one more and Ana can burn it"
    trade-mine-pluto       disabled=False aria-disabled=None   "Pluto, Common, Ana already has this"
    trade-theirs-titan     disabled=False aria-disabled=None   "Titan, Epic, new for you"
    trade-theirs-orion     disabled=True  aria-disabled=None   "Orion, Rare, new for you"
    trade-theirs-nebula    disabled=True  aria-disabled=None   "Nebula, Rare, one more and you can burn it"
    trade-theirs-pluto     disabled=True  aria-disabled=None   "Pluto, Common, you already have this"
  -> the 3 mismatched tiles use the disabled attribute: out of the tab order, and their name says nothing about the lock.

AFTER (f460c7d)
  checkboxes on the board: 0   <label> elements: []
  tiles on screen: 9 (whole inventory, nothing narrowed)
  band headings (the tier, said once, with its count):
    trade-band-mine-new :: 🎁 New for Ana (3)
    trade-band-mine-one-away :: 🔥 One more and Ana can burn it (1)
    trade-band-mine-rest :: Ana already has these (1)
    trade-band-theirs-new :: 🆕 New for you (2)
    trade-band-theirs-one-away :: 🔥 One more and you can burn it (1)
    trade-band-theirs-rest :: You already have these (1)
  tiles once a pick is made:
    trade-mine-quasar      disabled=False aria-disabled=false dimmed=False "Quasar, Legendary, new for Ana"
    trade-mine-comet       disabled=False aria-disabled=false dimmed=False "Comet, Epic, new for Ana"
    trade-mine-meteor      disabled=False aria-disabled=false dimmed=False "Meteor, Common, new for Ana"
    trade-mine-nebula      disabled=False aria-disabled=false dimmed=False "Nebula, Rare, one more and Ana can burn it"
    trade-mine-pluto       disabled=False aria-disabled=false dimmed=False "Pluto, Common, Ana already has this"
    trade-theirs-titan     disabled=False aria-disabled=false dimmed=False "Titan, Epic, new for you"
    trade-theirs-orion     disabled=False aria-disabled=true  dimmed=True  "Orion, Rare, new for you, needs a Epic to swap"
    trade-theirs-nebula    disabled=False aria-disabled=true  dimmed=True  "Nebula, Rare, one more and you can burn it, needs a Epic to swap"
    trade-theirs-pluto     disabled=False aria-disabled=true  dimmed=True  "Pluto, Common, you already have this, needs a Epic to swap"

  keyboard: 9 Tab presses reach the locked tile trade-theirs-orion
            focused name: "Orion, Rare, new for you, needs a Epic to swap"
  clicking that locked tile: aria-pressed count 2 -> 2, confirm bar shown: False
  clicking the matching-rarity tile (Titan, Epic): confirm bar shown: True
```
</details>
<details>
<summary>Evidence: Raw DOM report from the browser run</summary>

```text
{
  "before_checkbox_labels": "[\"Only show what Ana is missing (3/5)\",\"Only show what you're missing (2/4)\"]",
  "before_checkbox_count": 2,
  "before_tiles_with_filters_on": 5,
  "before_after_pick": [
    {
      "testid": "trade-mine-quasar",
      "label": "Quasar, Legendary, new for Ana",
      "disabledAttr": false,
      "ariaDisabled": null,
      "focusable": true,
      "dimmed": false
    },
    {
      "testid": "trade-mine-comet",
      "label": "Comet, Epic, new for Ana",
      "disabledAttr": false,
      "ariaDisabled": null,
      "focusable": true,
      "dimmed": false
    },
    {
      "testid": "trade-mine-meteor",
      "label": "Meteor, Common, new for Ana",
      "disabledAttr": false,
      "ariaDisabled": null,
      "focusable": true,
      "dimmed": false
    },
    {
      "testid": "trade-mine-nebula",
      "label": "Nebula, Rare, one more and Ana can burn it",
      "disabledAttr": false,
      "ariaDisabled": null,
      "focusable": true,
      "dimmed": false
    },
    {
      "testid": "trade-mine-pluto",
      "label": "Pluto, Common, Ana already has this",
      "disabledAttr": false,
      "ariaDisabled": null,
      "focusable": true,
      "dimmed": false
    },
    {
      "testid": "trade-theirs-titan",
      "label": "Titan, Epic, new for you",
      "disabledAttr": false,
      "ariaDisabled": null,
      "focusable": true,
      "dimmed": false
    },
    {
      "testid": "trade-theirs-orion",
      "label": "Orion, Rare, new for you",
      "disabledAttr": true,
      "ariaDisabled": null,
      "focusable": false,
      "dimmed": false
    },
    {
      "testid": "trade-theirs-nebula",
      "label": "Nebula, Rare, one more and you can burn it",
      "disabledAttr": true,
      "ariaDisabled": null,
      "focusable": false,
      "dimmed": false
    },
    {
      "testid": "trade-theirs-pluto",
      "label": "Pluto, Common, you already have this",
      "disabledAttr": true,
      "ariaDisabled": null,
      "focusable": false,
      "dimmed": false
    }
  ],
  "after_checkbox_count": 0,
  "after_labels": "[]",
  "after_band_headings": "[\"trade-band-mine-new :: 🎁 New for Ana (3)\",\"trade-band-mine-one-away :: 🔥 One more and Ana can burn it (1)\",\"trade-band-mine-rest :: Ana already has these (1)\",\"trade-band-theirs-new :: 🆕 New for you (2)\",\"trade-band-theirs-one-away :: 🔥 One more and you can burn it (1)\",\"trade-band-theirs-rest :: You already have these (1)\"]",
  "after_tile_count": 9,
  "after_pick": [
    {
      "testid": "trade-mine-quasar",
      "label": "Quasar, Legendary, new for Ana",
      "disabledAttr": false,
      "ariaDisabled": "false",
      "focusable": true,
      "dimmed": false
    },
    {
      "testid": "trade-mine-comet",
      "label": "Comet, Epic, new for Ana",
      "disabledAttr": false,
      "ariaDisabled": "false",
      "focusable": true,
      "dimmed": false
    },
    {
      "testid": "trade-mine-meteor",
      "label": "Meteor, Common, new for Ana",
      "disabledAttr": false,
      "ariaDisabled": "false",
      "focusable": true,
      "dimmed": false
    },
    {
      "testid": "trade-mine-nebula",
      "label": "Nebula, Rare, one more and Ana can burn it",
      "disabledAttr": false,
      "ariaDisabled": "false",
      "focusable": true,
      "dimmed": false
    },
    {
      "testid": "trade-mine-pluto",
      "label": "Pluto, Common, Ana already has this",
      "disabledAttr": false,
      "ariaDisabled": "false",
      "focusable": true,
      "dimmed": false
    },
    {
      "testid": "trade-theirs-titan",
      "label": "Titan, Epic, new for you",
      "disabledAttr": false,
      "ariaDisabled": "false",
      "focusable": true,
      "dimmed": false
    },
    {
      "testid": "trade-theirs-orion",
      "label": "Orion, Rare, new for you, needs a Epic to swap",
      "disabledAttr": false,
      "ariaDisabled": "true",
      "focusable": true,
      "dimmed": true
    },
    {
      "testid": "trade-theirs-nebula",
      "label": "Nebula, Rare, one more and you can burn it, needs a Epic to swap",
      "disabledAttr": false,
      "ariaDisabled": "true",
      "focusable": true,
      "dimmed": true
    },
    {
      "testid": "trade-theirs-pluto",
      "label": "Pluto, Common, you already have this, needs a Epic to swap",
      "disabledAttr": false,
      "ariaDisabled": "true",
      "focusable": true,
      "dimmed": true
    }
  ],
  "tab_hops_to_locked_tile": 9,
  "focused_locked_tile": "trade-theirs-orion",
  "focused_locked_label": "Orion, Rare, new for you, needs a Epic to swap",
  "pressed_before_locked_click": 2,
  "pressed_after_locked_click": 2,
  "confirm_bar_visible": false,
  "confirm_bar_after_valid_pick": true
}
```
</details>
- Outcome: ⚠️ 1 info across 1 run (9m6s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `src/features/trade/TradeBoard.tsx:346` - The new `focus-visible:shadow-[var(--ring-focus)]` (3px) is painted underneath `ring-4 ring-[color:var(--brand-1)]` (4px): Tailwind v4 composes box-shadow as `--tw-ring-shadow, --tw-shadow`, so the ring renders on top and fully covers the narrower focus shadow. A keyboard user who presses Enter on a tile keeps focus on it, and from that point the tile shows no focus-specific indication — only the selection ring, which is present whether or not it is focused. Every other tile in the column gets a visible ring, so the child&#39;s own current pick is the one tile they cannot see focus on. Fix by widening the focus shadow past 4px or giving it a ring-offset so it sits outside the selection ring.
- ℹ️ `src/features/trade/TradeBoard.tsx:351` - Moving `opacity-25 grayscale` from the button onto an inner wrapper span (needed so the focus shadow isn&#39;t dimmed with the art) also stops the tile&#39;s `border-2` rarity frame and `bg-white/10` from dimming. A locked tile now shows a full-brightness rarity-coloured frame around 25%-opacity greyscale art, so the visual &#39;this is out of reach&#39; cue is weaker than before the change. Worth confirming at the visual check step in the build-and-test doc, which asserts mismatched tiles &#39;go dim/grey&#39;.
- ℹ️ `aidlc-docs/inception/requirements/increment22-trade-sacrifice-requirements.md:75` - The build-and-test doc was updated for #111, but three other aidlc-docs still describe the removed filter as shipped: FR5 here specifies the per-column checkbox with its live count and empty hint; application-design lines 87/99/110-111 list `newToOther` and `applyMissingFilter` in the module contract; and code-summary lines 25 and 52-53 claim FR4/FR5 are covered by PBT over `newToOther` and `applyMissingFilter`, tests this branch deletes. FR4&#39;s row was already stale after #110, so this is a pre-existing drift pattern (cf. open issue #132) rather than something this change introduced, but the filter removal makes the FR5 row assert coverage that no longer exists. Decide whether these increment-22 artefacts are point-in-time records or living spec.

🔧 Fix: make tile focus outline clear the selection ring; dim locked frame
2 infos still open:
- ℹ️ `src/features/trade/TradeBoard.tsx:346` - The fix commit is titled &#39;make tile focus outline clear the selection ring&#39;, but `outline-offset-2` with `outline-[3px]` puts the outline across 2px–5px outward from the border box, while `ring-4` spans 0–4px — so the outline overlaps the ring rather than clearing it. Both are `var(--brand-1)` (#ffd45e, opaque), so on a selected tile focus renders as a solid gold band of 5px instead of 4px: a 1px, same-colour difference that reads as no focus change at all. Unselected and locked tiles do now get a clear outline, so this is only the selected tile — the child&#39;s own current pick. `outline-offset-4` would leave a visible gap outside the ring (a recognisable double-ring focus pattern); a focus colour distinct from the selection colour would separate the two states outright.
- ℹ️ `aidlc-docs/construction/increment22-trade-sacrifice/code/code-summary.md:53` - This was accepted for fix in the previous round but no doc changed — `f460c7d` touches only TradeBoard.tsx, and the branch&#39;s only doc edit is still the build-and-test file. Row 5 here claims FR5 is covered by `code + PBT (applyMissingFilter)`, and line 25 lists `applyMissingFilter` as an export of board.ts; both the helper and its PBT block are deleted by this branch. Also stale: requirements FR5 (line 75) specifying the per-column checkbox with live count and empty hint, application-design lines 73/87/99/109-111, and the code-generation plan lines 58/62-63/78. FR4&#39;s row was already stale after #110 (cf. open issue #132), so this is an existing drift pattern rather than something this change created — but the FR5 row now asserts test coverage that no longer exists.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `src/features/trade/band-copy.ts:105` - The new lock reason in tileLabel uses a fixed article, so a screen reader announces &#34;needs a Epic to swap&#34; for Epic picks. src/features/trade/band-copy.ts:105 — cosmetic copy issue in the accessible name, not a behaviour defect.
- <code>`npx vitest run tests/trade-band-copy.pbt.test.ts tests/trade-board.pbt.test.ts tests/trade-logic.pbt.test.ts` — 36 passing property tests covering the new `tileLabel` and the `newToOther` → `tier === &#34;new&#34;` collapse</code>
- <code>Manual: throwaway Next dev harness (`app/dev111` head, `app/dev111-base` from base ff288c2) rendering the real `TradeBoard` with a fixture inventory and a stubbed `getTradeBoardAction`, driven over CDP in headless Chrome; harness and the temporary next.config webpack patch removed afterwards (worktree verified clean)</code>
- `Manual: base board — counted 2 filter checkboxes, ticked both, observed 9 tiles collapse to 5 (screenshots 01, 02)`
- <code>Manual: head board — counted 0 checkboxes / 0 `&lt;label&gt;`s, 9 tiles across all six tier band headings with counts (screenshot 04)</code>
- <code>Manual: picked Comet (Epic) on both builds and dumped every tile&#39;s `disabled` / `aria-disabled` / dim class / aria-label — base uses `disabled` with no lock reason, head uses `aria-disabled` plus &#34;needs a … to swap&#34; (screenshots 03, 05; a11y-transcript.txt)</code>
- <code>Manual: pressed Tab 9 times on the head board to land focus on the locked `trade-theirs-orion` tile and captured the visible focus outline (screenshot 06)</code>
- `Manual: clicked the locked tile — aria-pressed count unchanged (2 → 2), no confirm bar; then clicked the matching-rarity Titan (Epic) — confirm bar appears (screenshot 07)`
- `Manual: compared friend-strip rendering before/after — same order, only the 🎁 missing-count pill, no tier-2 companion pill`
- <code>`grep -rn &#34;newToOther|applyMissingFilter|trade-filter&#34; src app tests docs` — no surviving readers of the dropped field or filter</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `aidlc-docs/inception/requirements/increment22-trade-sacrifice-requirements.md:75` - The Increment 22 AI-DLC stage records still describe the removed features: requirements FR4 (per-tile &#39;New&#39; badges) and FR5 (&#39;Only show what&#39;s missing&#39; checkbox), the design doc&#39;s module signature block (`applyMissingFilter`, `BoardCard.newToOther` and their stated properties), the code-generation plan, the increment-22 code-summary FR table, and the Increment 22 line in aidlc-docs/aidlc-state.md. I deliberately did not update them: repo precedent is that issue-driven work after an increment closes updates only the live docs (#128 and #125 both touched CONTEXT.md and vision-document.md and left the aidlc-docs stage records untouched, which is why the design doc has said &#39;Drives the badge (FR4)&#39; since #110 removed badges). Treating them as frozen stage records is the reading that keeps this change to one authoritative edit per fact; if the owner instead considers them live specifications, a separate follow-up should reconcile increment 22&#39;s FR4/FR5 with what #110/#111 shipped rather than doing it piecemeal here.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trade boards now show complete inventories organized into tier bands: new items, one-away items, and existing items.
  * Added clearer accessibility labels describing card rarity, tier, and swap requirements.

* **Bug Fixes**
  * Mismatched-rarity cards remain keyboard accessible while clearly indicating that selection is unavailable.
  * Invalid selections now provide visible focus feedback and an audio denial cue.

* **Documentation**
  * Updated visual-check guidance to reflect the new tier-band layout and accessibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->