### PR TITLE
feat(seed): give every theme its own cover art (#122, PR 1 of 2)

### DIFF
--- a/scripts/contact-sheet/index.ts
+++ b/scripts/contact-sheet/index.ts
@@ -2,6 +2,7 @@
  * Build the review contact sheet for one theme — runbook Step 7, CHECKPOINT 2.
  *
  *   pnpm contact-sheet "Ocean Machines"
+ *   pnpm contact-sheet --covers        # every theme's cover, one page (#122)
  *
  * Writes seed/review/<theme-slug>-review.html: one row per subject, one column
  * per registered provider, the `--sync` pick outlined (#63's subject x provider
@@ -18,8 +19,13 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { loadSeed } from "@/features/pool/loader";
+import type { SeedFile } from "@/features/pool/seed-schema";
 import { slug } from "@/features/pool/keys";
-import { planContactSheet, renderContactSheet } from "@/features/pool/contact-sheet";
+import {
+  planContactSheet,
+  planCoverSheet,
+  renderContactSheet,
+} from "@/features/pool/contact-sheet";
 import { parseSidecar } from "@/features/pool/review-files";
 import { PROVIDERS } from "@/features/pool/providers";
 
@@ -31,6 +37,7 @@ function main() {
   if (!themeName) {
     console.error(
       `Usage: pnpm contact-sheet "<Theme Name>"\n` +
+        `       pnpm contact-sheet --covers\n` +
         `   The name must match seed/cards.json exactly.`,
     );
     process.exitCode = 1;
@@ -38,6 +45,12 @@ function main() {
   }
 
   const seed = loadSeed(SEED_PATH);
+
+  if (themeName === "--covers") {
+    coversSheet(seed.themes);
+    return;
+  }
+
   const theme = seed.themes.find((t) => t.name === themeName);
   if (!theme) {
     console.error(
@@ -107,6 +120,59 @@ function main() {
     console.warn(
       `⚠️  ${sheet.orphans.length} file(s) belong to no registered provider:\n` +
         sheet.orphans.map((f) => `   ${f}`).join("\n"),
+    );
+  }
+}
+
+/**
+ * Every theme's cover on ONE page (#122).
+ *
+ * The per-theme sheet is right for a new theme and wrong for backfilling covers
+ * onto themes that already shipped: it renders 30 blank rows for published cards
+ * and buries the row that matters. This is also the only view that answers the
+ * question the covers actually have to pass — whether they read as N DIFFERENT
+ * places. A cover judged alone can look fine and still be the third grassy
+ * hilltop in the grid.
+ */
+function coversSheet(themes: SeedFile["themes"]): void {
+  if (!existsSync(REVIEW_DIR)) {
+    console.error(`⛔ ${REVIEW_DIR} does not exist. Run \`pnpm seed --review\` first.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const sheet = planCoverSheet(themes, PROVIDERS, {
+    exists: (f) => existsSync(join(REVIEW_DIR, f)),
+    readSidecar: (f) => {
+      try {
+        return parseSidecar(readFileSync(join(REVIEW_DIR, f), "utf8"));
+      } catch {
+        return undefined;
+      }
+    },
+    listFiles: () => readdirSync(REVIEW_DIR),
+  });
+
+  const out = join(REVIEW_DIR, "covers-review.html");
+  writeFileSync(out, renderContactSheet(sheet));
+
+  // Counted from the cells themselves, not as `cells - missing`. `missing`
+  // deliberately excludes an escape hatch's blanks (#71), so subtracting it
+  // reports every hatch column as full — 48 of 48 where 32 have an image.
+  const cells = sheet.rows.length * sheet.providerIds.length;
+  const present = sheet.rows.reduce(
+    (n, r) => n + r.candidates.filter((c) => c.present).length,
+    0,
+  );
+  console.log(
+    `→ ${out}\n` +
+      `   ${sheet.rows.length} cover(s) x ${sheet.providerIds.length} provider(s) ` +
+      `= ${cells} cell(s), ${present} with an image.`,
+  );
+  if (sheet.unpicked > 0) {
+    console.warn(
+      `⚠️  ${sheet.unpicked} theme(s) have no provider chosen. \`--sync\` will refuse\n` +
+        `   their covers until a \`provider\` is set on the theme — no cover, no publish.`,
     );
   }
 }

--- a/scripts/seed/index.ts
+++ b/scripts/seed/index.ts
@@ -85,9 +85,8 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { loadSeed } from "@/features/pool/loader";
-import { buildPrompt } from "@/features/pool/prompt";
 import { uploadImage } from "@/features/pool/image";
-import { blobKey } from "@/features/pool/keys";
+import { blobKey, coverBlobKey } from "@/features/pool/keys";
 import { runBakeOff, makeGate, withRetry, type BakeOffJob } from "@/features/pool/bake-off";
 import {
   buildSidecar,
@@ -98,7 +97,7 @@ import {
   resolveProviderId,
   sidecarFileName,
   unknownProviders,
-  type NamedCard,
+  missingCoverReviews,
   type ReviewSidecar,
 } from "@/features/pool/review-files";
 import {
@@ -123,9 +122,18 @@ import {
   type ImageProvider,
 } from "@/features/pool/providers";
 import { planInserts, cardKey } from "@/features/pool/publish-plan";
+import {
+  COVER_SUBJECT_NAME,
+  buildCoverPrompt,
+  buildPrompt,
+  cardSubject,
+  coverSubject,
+  type Subject,
+} from "@/features/pool/prompt";
 import { comparePoolShape } from "@/features/pool/completeness";
 import {
   listPublishedCardKeys,
+  listPublishedCoverThemes,
   readPublishedImages,
   readPublishedShape,
 } from "@/features/pool/pool-reads";
@@ -140,6 +148,7 @@ import {
 } from "@/features/pool/blob-budget";
 import {
   upsertTheme,
+  setThemeCover,
   insertCardIfNew,
   resetPool,
   updateCardMeta,
@@ -175,8 +184,8 @@ const PUBLISH_CONCURRENCY = intEnv("SEED_CONCURRENCY", 4);
 type Mode = "review" | "publish" | "sync";
 
 /** Absolute path of one bake-off candidate. */
-function reviewPath(themeName: string, card: NamedCard, provider: ImageProvider): string {
-  return join(REVIEW_DIR, reviewFileName(themeName, card, provider));
+function reviewPath(themeName: string, subject: Subject, provider: ImageProvider): string {
+  return join(REVIEW_DIR, reviewFileName(themeName, subject, provider));
 }
 
 /**
@@ -438,12 +447,21 @@ async function main() {
   const planned = new Set(plan.map((p) => cardKey(p.theme, p.card)));
   const themes: readonly ThemeSeed[] = seed.themes;
 
+  // Which themes already have a cover (#122)? Read alongside the card plan and
+  // for the same reason it is read here rather than earlier: --reset clears
+  // `cover_url` with the row, so a set read before it would let the guard below
+  // pass on covers that no longer exist.
+  const publishedCovers = await listPublishedCoverThemes();
+  const coversToPublish = new Set(
+    themes.filter((t) => !publishedCovers.has(t.name)).map((t) => t.name),
+  );
+
   // ── --review: the eager bake-off. Lane-major, so it does not share the
   // publish path's per-theme loop — nothing here writes to the database, and a
   // lane spans every theme in one queue so its pacing is spent on generating
   // rather than on waiting at theme boundaries.
   if (mode === "review") {
-    await review(themes, planned, lanes);
+    await review(themes, planned, publishedCovers, lanes);
     return;
   }
 
@@ -481,20 +499,31 @@ async function main() {
     return;
   }
 
-  const unreviewed = missingReviews(themes, planned, providerById, (name) =>
-    existsSync(join(REVIEW_DIR, name)),
-  );
+  const reviewExists = (name: string) => existsSync(join(REVIEW_DIR, name));
+  // Cards and covers audited together and refused together (#122). The
+  // guarantee they serve carries no qualifier — "no unreviewed image reaches a
+  // child, ever" — and a theme cover is now the FIRST picture a child sees of a
+  // category, so it is the last thing that should have a weaker gate than the
+  // cards behind it. `missingCoverReviews` names its rows `<theme> / Cover`, so
+  // the report below renders both shapes unchanged.
+  const unreviewed = [
+    ...missingReviews(themes, planned, providerById, reviewExists),
+    ...missingCoverReviews(themes, coversToPublish, providerById, reviewExists),
+  ];
   if (unreviewed.length > 0 && !process.argv.includes("--allow-unreviewed")) {
     console.error(
-      `\n⛔ ${unreviewed.length} card(s) would be inserted with no reviewed image:\n`,
+      `\n⛔ ${unreviewed.length} image(s) would be published with no reviewed art:\n`,
     );
     for (const p of unreviewed) {
       console.error(`   ${p.theme} / ${p.card} — ${p.reason}`);
     }
     console.error(
       `\n   Nothing has been written. Run \`pnpm seed --review\` first, and look at\n` +
-        `   every image. Cards marked "no provider chosen" need a \`provider\` on the\n` +
+        `   every image. Rows marked "no provider chosen" need a \`provider\` on the\n` +
         `   card or its theme in seed/cards.json — that is the bake-off pick.\n` +
+        `   A \`${COVER_SUBJECT_NAME}\` row is a theme with no cover art: no cover, no\n` +
+        `   publish, because a category has to be recognisable before a child owns\n` +
+        `   anything in it.\n` +
         `   \`--allow-unreviewed\` exists but defeats the guarantee that no unreviewed\n` +
         `   image reaches a child.\n`,
     );
@@ -503,7 +532,7 @@ async function main() {
   }
   if (unreviewed.length > 0) {
     console.warn(
-      `⚠️  --allow-unreviewed: publishing ${unreviewed.length} card(s) no human has seen.`,
+      `⚠️  --allow-unreviewed: publishing ${unreviewed.length} image(s) no human has seen.`,
     );
   }
 
@@ -514,6 +543,7 @@ async function main() {
 
   const report = {
     inserted: 0,
+    covers: 0,
     updated: 0,
     skipped: 0,
     failed: 0,
@@ -526,6 +556,56 @@ async function main() {
   // seed/cards.json makes it the most recent (Inc21 FR2).
   for (const [sortOrder, theme] of themes.entries()) {
     const themeId = await upsertTheme(theme.name, sortOrder);
+
+    // The theme's cover (#122), before its cards. A theme row with no
+    // `cover_url` is a category the picker cannot draw a tile for, so it is the
+    // first thing published rather than the last — a run that dies partway
+    // leaves a recognisable half-theme rather than a nameless one.
+    //
+    // Published-once, like a card: an existing cover is never regenerated or
+    // re-uploaded, because it is a LANDMARK. Refreshing it on every sync would
+    // reintroduce exactly the instability #122 removed from the borrowed-card
+    // cover, one level up. Changing a theme's `coverPrompt` therefore does not
+    // republish it — clear `cover_url` to do that deliberately.
+    if (coversToPublish.has(theme.name)) {
+      try {
+        const provider = theme.provider ? providerById(theme.provider) : undefined;
+        const subject = coverSubject(theme);
+        const file = provider ? reviewPath(theme.name, subject, provider) : undefined;
+        let bytes: Uint8Array;
+        if (provider && file && existsSync(file)) {
+          bytes = new Uint8Array(readFileSync(file));
+          report.reused++;
+        } else {
+          // --allow-unreviewed only; the guard above refuses this path otherwise.
+          if (!provider) {
+            throw new Error(
+              `no provider resolved (set \`provider\` on the theme; registered: ${PROVIDER_IDS.join(", ")})`,
+            );
+          }
+          if (!provider.isConfigured()) {
+            throw new Error(
+              `provider ${provider.id} is not configured (set ${provider.requiredEnv.join(" and ")})`,
+            );
+          }
+          console.log(`🖼️  generating cover: ${theme.name} [${provider.id}]…`);
+          const gate = publishGate(provider);
+          const image = await withRetry(
+            provider,
+            () => gate().then(() => provider.generate(buildCoverPrompt(theme), CARD_SIZE)),
+            { retries: RETRIES },
+          );
+          bytes = image.bytes;
+        }
+        const coverUrl = await uploadImage(coverBlobKey(theme.name), bytes, "covers");
+        await setThemeCover(themeId, coverUrl);
+        report.covers++;
+        console.log(`✓ cover ${theme.name}`);
+      } catch (err) {
+        report.failed++;
+        console.error(`✗ ${theme.name} / ${COVER_SUBJECT_NAME}: ${String(err)}`);
+      }
+    }
 
     await runPool(theme.cards, PUBLISH_CONCURRENCY, async (card) => {
       try {
@@ -555,7 +635,9 @@ async function main() {
         // an optimisation — it re-opens the gap where the parent reviewed image A
         // and the child received image B.
         const provider = resolveProvider(theme, card);
-        const reviewFile = provider ? reviewPath(theme.name, card, provider) : undefined;
+        const reviewFile = provider
+          ? reviewPath(theme.name, cardSubject(card), provider)
+          : undefined;
 
         let bytes: Uint8Array;
         // What drew these bytes, for the durable record (#75). Undefined only
@@ -568,7 +650,7 @@ async function main() {
         if (provider && reviewFile && existsSync(reviewFile)) {
           bytes = new Uint8Array(readFileSync(reviewFile));
           reviewed = true;
-          sidecar = readSidecar(theme.name, card, provider);
+          sidecar = readSidecar(theme.name, cardSubject(card), provider);
           if (!sidecar) {
             console.warn(
               `⚠️  ${theme.name} / ${card.name}: no readable sidecar beside the reviewed image — ` +
@@ -628,7 +710,7 @@ async function main() {
               card: card.name,
               provenance: toProvenance(
                 sidecar,
-                reviewStem(theme.name, card, provider),
+                reviewStem(theme.name, cardSubject(card), provider),
                 reviewed,
               ),
             });
@@ -714,26 +796,36 @@ async function main() {
 async function review(
   themes: readonly ThemeSeed[],
   planned: ReadonlySet<string>,
+  publishedCovers: ReadonlySet<string>,
   lanes: readonly ImageProvider[],
 ): Promise<void> {
-  const jobs: BakeOffJob<SeedCard>[] = [];
+  const jobs: BakeOffJob<Subject>[] = [];
   let alreadyPublished = 0;
   for (const theme of themes) {
+    // A theme's cover rides the SAME bake-off as its cards (#122): one lane
+    // fan-out, one contact sheet, one checkpoint. It is a `Subject` like every
+    // card here — the only difference is which style `coverSubject` appended.
+    if (!publishedCovers.has(theme.name)) {
+      jobs.push({ theme: theme.name, card: coverSubject(theme) });
+    }
     for (const card of theme.cards) {
-      if (planned.has(cardKey(theme.name, card.name))) jobs.push({ theme: theme.name, card });
-      else alreadyPublished++;
+      if (planned.has(cardKey(theme.name, card.name))) {
+        jobs.push({ theme: theme.name, card: cardSubject(card) });
+      } else alreadyPublished++;
     }
   }
 
+  const coverJobs = jobs.filter((j) => j.card.name === COVER_SUBJECT_NAME).length;
   console.log(
-    `${jobs.length} new card(s) x ${lanes.length} provider(s) = ${jobs.length * lanes.length} image(s); ` +
+    `${jobs.length} new subject(s) (${jobs.length - coverJobs} card(s) + ${coverJobs} cover(s)) ` +
+      `x ${lanes.length} provider(s) = ${jobs.length * lanes.length} image(s); ` +
       `${alreadyPublished} already-published card(s) skipped.`,
   );
 
   const outcomes = await runBakeOff(jobs, lanes, {
     size: CARD_SIZE,
     retries: RETRIES,
-    buildPrompt: (card) => buildPrompt(card),
+    buildPrompt: (subject) => subject.prompt,
     isReviewed: (job, provider) => existsSync(reviewPath(job.theme, job.card, provider)),
     save: (job, provider, image) => {
       writeFileSync(reviewPath(job.theme, job.card, provider), image.bytes);
@@ -804,10 +896,10 @@ function loadProvenance(): ProvenanceFile {
  */
 function readSidecar(
   themeName: string,
-  card: NamedCard,
+  subject: Subject,
   provider: ImageProvider,
 ): ReviewSidecar | undefined {
-  const path = join(REVIEW_DIR, sidecarFileName(themeName, card, provider));
+  const path = join(REVIEW_DIR, sidecarFileName(themeName, subject, provider));
   if (!existsSync(path)) return undefined;
   // Missing a record is a cost; failing to publish a reviewed card over a
   // malformed file in scratch would not be. `parseSidecar` swallows both.

--- a/seed/NEW-THEME-RUNBOOK.md
+++ b/seed/NEW-THEME-RUNBOOK.md
@@ -13,7 +13,7 @@ This file supersedes the old `seed/AUTHORING_PROMPT.md`. It is the only card-aut
 | | |
 |---|---|
 | **Input** | A theme name. Nothing else. Any extra steer from the human (e.g. "lean historical") overrides this document's defaults where they conflict. |
-| **Output** | 30 published cards, images reviewed, the winning provider recorded in `seed/cards.json`, committed on a branch, a PR open. |
+| **Output** | 30 published cards **and the theme's cover art**, images reviewed, the winning provider recorded in `seed/cards.json`, committed on a branch, a PR open. |
 | **Human checkpoints** | Exactly **two**: the 30-name list (Step 3), and the image contact sheet (Step 7). Still two — the bake-off did **not** add a third; it changed what the second one *is*, from approve/reject to **choose among N candidates**. Stop dead at both — do not proceed on silence, and never answer them yourself. |
 | **Blast radius** | `pnpm seed --sync` writes to the **production** Neon DB and Blob store that the children play against. `--check-urls`, `--check-images` and `--review` do not write to it. |
 | **Session** | One theme per run. Do not batch two themes. |
@@ -30,6 +30,10 @@ half-authored theme cannot be committed or published. You do not get to "fix it 
 3. **Card names unique across the entire pool**, not just within the theme. This is the rule a long
    authoring session breaks by accident, and the one with no other backstop.
 4. **`eduText` ≤ 120 characters**, `sourceUrl` a well-formed URL.
+5. **A `coverPrompt` on every theme** (#122). It is required, exactly like the 30 `imagePrompt`s and for
+   the same reason: it is authored text, written at Step 4, so there is no window in which a theme is
+   legitimately without one. Contrast `provider`, which is optional because it records a bake-off pick
+   that cannot exist while the theme is being authored.
 
 Reachability of `sourceUrl` is *not* schema-checked — that is `--check-urls` (Step 5).
 
@@ -114,6 +118,38 @@ Card shape (all five fields required):
 
 A sixth field, `provider`, is optional and is **not** authored here: it records the bake-off winner and is
 added at Step 6, on the theme and — sparsely — on individual cards.
+
+Theme shape — `name`, **`coverPrompt`**, then `cards`:
+
+```json
+{
+  "name": "Flying Machines",
+  "coverPrompt": "a grassy airfield at golden hour with a windsock, runway markings and open sky",
+  "cards": [ … 30 … ]
+}
+```
+
+### `coverPrompt` — a place, never a specimen (#122)
+
+This is the picture that fronts the theme's tile in the binder's category picker, and the thumbnail on
+the place bar once the child is inside it. It is a **landmark**: the same picture every time, so a child
+navigating 25+ categories can find this one by sight rather than by reading its name.
+
+Three rules, and they are not stylistic:
+
+- **Depict the theme's *place*, not one of its 30 subjects.** A category's front door showing card art
+  leaks what `CardSlot` keeps behind `❔` until it is earned (U5-Q5). Check the 30 names you just wrote,
+  and check the other themes' too — *Fern* is a Special Plants card, so "ferns" is not scenery.
+- **Exclude by omission, never by negation.** Do not write "no animals", "no people", "not a card". #81
+  measured that naming a depictable noun puts it in the picture whatever polarity you name it in; "no
+  border" is a *border cue*. If a subject must not appear, the fix is to not mention it.
+- **No art-style words.** `buildCoverPrompt()` appends `COVER_STYLE` — the scenery style, deliberately
+  different from the card style so a cover cannot be mistaken for a card you could own.
+
+A cover that is genuinely hard to write is a real signal, not a blocker: a theme whose subjects are
+*people* has no obvious place, and the honest answer is the room or landscape they belong to rather than
+a person nobody can collect. A picture that looks like a card but is not on the card list is a **phantom
+card** — the child will hunt for it and never find it.
 
 - **Theme name** — short, title-case, matching the existing set (*Animals*, *Mythic Creatures*,
   *Dinosaurs*, *Superheroes*, *Country*, *Famous People*, *Weird Insects*, *Special Plants*,
@@ -244,16 +280,19 @@ its ceiling is the **Hobby** allowance hardcoded; if the plan has changed since,
 
 ```bash
 git add seed/cards.json && git commit -m "feat(seed): add the <Theme> theme"
-pnpm seed --review         # generates images for NEW cards only, into seed/review/
+pnpm seed --review         # generates the cover + NEW cards only, into seed/review/
 ```
 
 `--review` needs `DATABASE_URL` (it reads the pool to scope itself to unpublished cards) but writes
 nothing to it. It skips cards already published and already-reviewed prompts, so an interrupted or
 rate-limited run resumes rather than restarting.
 
-`--review` is a **bake-off** (#63): it generates each new card from **every registered lane**, in parallel,
-so a human can compare candidates side by side and pick the best draughtsman per subject. A 30-card theme is
-30 images *per lane* — 60 today, on `pollinations` and `cloudflare-sdxl`. The lanes run alongside each other
+`--review` is a **bake-off** (#63): it generates each new subject from **every registered lane**, in
+parallel, so a human can compare candidates side by side and pick the best draughtsman per subject. A new
+theme is 30 cards **plus its cover** (#122) — 31 images *per lane*, 62 today on `pollinations` and
+`cloudflare-sdxl`. The cover rides the same run rather than a lighter one of its own: a *place* is the one
+prompt shape this repo has no measurements for, every number here having been taken on single-subject card
+art, so it is the strongest case for a bake-off rather than the weakest. The lanes run alongside each other
 and pace themselves independently, so the wall-clock is the slowest lane, not the sum: expect ~8 minutes,
 set by Pollinations. `ai-horde` is an **escape hatch**, not a lane, and sits out unless named (below).
 
@@ -436,13 +475,18 @@ One HTML page: **one row per subject, one column per provider**, so the human co
 opening a folder. Each cell is labelled with the model that actually answered, and the cell `--sync` would
 publish is outlined.
 
+**The first row is the theme's cover** (#122), then the 30 cards, legendary first. The cover leads because
+it is the picture a child meets *first*, and because it can only really be judged against the cards it
+fronts: the thing to check is that the cover reads as a **place** and the cards read as **specimens**. A
+cover that looks like it belongs in the grid below it has failed even if it is a lovely picture.
+
 The page states three things rather than hiding them, and so does the command:
 
 - **MISSING cells** — that *lane* produced nothing for that card. A dead lane or a narrowed run, *not* a
   provider that drew badly. An escape-hatch column (`ai-horde`) is labelled as such and blank by default —
   that is the arrangement working, so it is not counted here.
-- **cards with no pick** — expected at this point, since the picking happens *here*. `--sync` refuses every
-  one of them until Step 8 sets a `provider` on the card or its theme.
+- **subjects with no pick** — expected at this point, since the picking happens *here*. `--sync` refuses
+  every one of them, the cover row included, until Step 8 sets a `provider` on the card or its theme.
 - **orphan files** — candidates on disk from a provider no longer registered.
 
 **This checkpoint is a choice, not a yes/no.** The human is picking a provider per row, so give them what a
@@ -543,7 +587,8 @@ Abort the run and report. Do not improvise past any of these.
 | Signal | Why you stop |
 |---|---|
 | `--sync` reports a pending **prune**, or asks you to type a collection-row count | Something was renamed or dropped in the seed file. A prune deletes cards **out of the children's collections**. Fix the file. **Never pass `--allow-prune`.** |
-| `--sync` refuses: "would be inserted with no reviewed image" | Run `--review` first. **Never pass `--allow-unreviewed`** — it defeats the guarantee that no unreviewed image reaches a child. |
+| `--sync` refuses: "would be published with no reviewed art" | Run `--review` first. **Never pass `--allow-unreviewed`** — it defeats the guarantee that no unreviewed image reaches a child. |
+| `--sync` refuses a row named **`<Theme> / Cover`** | **No cover, no publish** (#122). The theme has no reviewed cover art, and a theme without one is a tile the child cannot tell apart from every other unstarted category. Same remedy as any other unreviewed row — `--review`, then judge the cover row at checkpoint 2. Never route around it. |
 | `--sync` refuses: "no provider chosen (bake-off not judged)" | The pick was never recorded. Go back to Step 8 — the human's choice, written into `seed/cards.json`. Never route around it with `--allow-unreviewed`. |
 | `--sync` refuses: "name a provider that is not registered" | A typo, or an adapter that was retired. Fix the `provider` value; re-running `--review` cannot satisfy this one. |
 | `--sync` refuses: "seed/provenance.json is unreadable" | The generated provenance record was hand-edited or truncated. Nothing has been written. Restore it with `git checkout seed/provenance.json`; never repair it by hand. |
@@ -570,6 +615,12 @@ Abort the run and report. Do not improvise past any of these.
 - Never delete a current candidate to narrow a row. A missing cell means a lane failed; making a rival
   disappear is answering checkpoint 2 for the human.
 - Never edit `src/features/pool/seed-schema.ts` to make a theme fit. The theme bends, not the pyramid.
+- **Never put one of the theme's own 30 subjects in its `coverPrompt`** (#122). A cover depicts the
+  theme's *place*, never a specimen: card art on the front door of a category leaks what `❔` keeps
+  hidden until it is earned. And never name an excluded subject *in order to forbid it* — "no dinosaurs"
+  draws dinosaurs, for the reason #81 measured on "no border". You exclude by omission.
+- Never point a theme's cover at a different provider from its cards. A cover inherits the theme's pick,
+  so one bake-off judgement covers the whole theme.
 - **Never hand-write or hand-edit `seed/provenance.json`.** It is what a publish *observed*, and a line
   typed into it by hand is indistinguishable from one the pipeline recorded. A card with no entry has no
   witness, and that is a true statement worth keeping.

--- a/seed/NEW-THEME-RUNBOOK.md
+++ b/seed/NEW-THEME-RUNBOOK.md
@@ -469,7 +469,14 @@ human's choice, recorded in Step 8.
 
 ```bash
 pnpm contact-sheet "<Theme Name>"      # exact theme name, e.g. "Ocean Machines"
+pnpm contact-sheet --covers            # every theme's cover on ONE page (#122)
 ```
+
+`--covers` is for **backfilling** covers onto themes that already shipped, not for a new theme — a new
+theme's cover is the first row of its own sheet. It exists because the per-theme sheet renders a blank row
+for every already-published card and would bury the one row being judged, and because sixteen covers can
+only be judged for *distinctness* side by side: a cover that looks fine alone can still be the third grassy
+hilltop in the grid.
 
 One HTML page: **one row per subject, one column per provider**, so the human compares a row rather than
 opening a folder. Each cell is labelled with the model that actually answered, and the cell `--sync` would

--- a/seed/cards.json
+++ b/seed/cards.json
@@ -2,6 +2,7 @@
   "themes": [
     {
       "name": "Animals",
+      "coverPrompt": "a sunlit forest clearing with a winding stream, tall grass and wildflowers",
       "cards": [
         {
           "name": "Red Fox",
@@ -217,6 +218,7 @@
     },
     {
       "name": "Mythic Creatures",
+      "coverPrompt": "a misty mountain valley with an ancient mossy stone archway and a winding path",
       "cards": [
         {
           "name": "Griffin",
@@ -432,6 +434,7 @@
     },
     {
       "name": "Dinosaurs",
+      "coverPrompt": "a wide prehistoric valley of tall leafy plants and steaming hills under a warm orange sky",
       "cards": [
         {
           "name": "Triceratops",
@@ -647,6 +650,7 @@
     },
     {
       "name": "Superheroes",
+      "coverPrompt": "a bright city of tall towers at sunrise seen from an empty rooftop",
       "cards": [
         {
           "name": "Captain Kindness",
@@ -862,6 +866,7 @@
     },
     {
       "name": "Country",
+      "coverPrompt": "a winding road through green hills with signposts pointing many directions and colourful flags",
       "cards": [
         {
           "name": "Eiffel Tower (France)",
@@ -1077,6 +1082,7 @@
     },
     {
       "name": "Famous People",
+      "coverPrompt": "a warm library reading room with tall bookshelves, a wooden ladder and an open notebook on a desk",
       "cards": [
         {
           "name": "Albert Einstein",
@@ -1292,6 +1298,7 @@
     },
     {
       "name": "Weird Insects",
+      "coverPrompt": "a close-up garden floor of mossy stones, dewy clover and curled bark",
       "cards": [
         {
           "name": "Ladybug",
@@ -1507,6 +1514,7 @@
     },
     {
       "name": "Special Plants",
+      "coverPrompt": "a bright greenhouse with glass panes, clay pots on wooden benches and hanging watering cans",
       "cards": [
         {
           "name": "Venus Flytrap",
@@ -1722,6 +1730,7 @@
     },
     {
       "name": "Spooky Legends",
+      "coverPrompt": "a friendly moonlit path winding between crooked fences and bare twisted trees under purple fog",
       "cards": [
         {
           "name": "Ghost",
@@ -1937,6 +1946,7 @@
     },
     {
       "name": "Deep Sea Creatures",
+      "coverPrompt": "a deep ocean trench with shafts of blue light and glowing coral ridges",
       "cards": [
         {
           "name": "Anglerfish",
@@ -2152,6 +2162,7 @@
     },
     {
       "name": "Flying Machines",
+      "coverPrompt": "a grassy airfield at golden hour with a windsock, runway markings and open sky",
       "cards": [
         {
           "name": "Hot Air Balloon",
@@ -2367,6 +2378,7 @@
     },
     {
       "name": "Ocean Machines",
+      "coverPrompt": "a busy harbour dock with wooden piers, coiled ropes, buoys and calm water",
       "cards": [
         {
           "name": "Sailboat",
@@ -2582,6 +2594,7 @@
     },
     {
       "name": "Warriors",
+      "coverPrompt": "a quiet stone fortress courtyard with hanging banners and worn flagstones",
       "cards": [
         {
           "name": "Samurai",
@@ -2797,6 +2810,7 @@
     },
     {
       "name": "Artillery",
+      "coverPrompt": "a grassy hilltop fort of earth walls and wooden crates, with a flag and a wide valley beyond",
       "provider": "cloudflare-sdxl",
       "cards": [
         {
@@ -3014,6 +3028,7 @@
     },
     {
       "name": "Outer Space",
+      "coverPrompt": "a rocket launch pad at dawn with tall gantry towers, drifting steam and an open sky",
       "cards": [
         {
           "name": "The Moon",
@@ -3235,6 +3250,7 @@
     },
     {
       "name": "Land Machines",
+      "coverPrompt": "a sunny construction yard with sand piles, traffic cones and a wide open road",
       "cards": [
         {
           "name": "Fire Engine",

--- a/seed/cards.json
+++ b/seed/cards.json
@@ -3,6 +3,7 @@
     {
       "name": "Animals",
       "coverPrompt": "a sunlit forest clearing with a winding stream, tall grass and wildflowers",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Red Fox",
@@ -219,6 +220,7 @@
     {
       "name": "Mythic Creatures",
       "coverPrompt": "a misty mountain valley with an ancient mossy stone archway and a winding path",
+      "provider": "pollinations",
       "cards": [
         {
           "name": "Griffin",
@@ -435,6 +437,7 @@
     {
       "name": "Dinosaurs",
       "coverPrompt": "a wide prehistoric valley of tall leafy plants and steaming hills under a warm orange sky",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Triceratops",
@@ -651,6 +654,7 @@
     {
       "name": "Superheroes",
       "coverPrompt": "a bright city of tall towers at sunrise seen from an empty rooftop",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Captain Kindness",
@@ -867,6 +871,7 @@
     {
       "name": "Country",
       "coverPrompt": "a winding road through green hills with signposts pointing many directions and colourful flags",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Eiffel Tower (France)",
@@ -1083,6 +1088,7 @@
     {
       "name": "Famous People",
       "coverPrompt": "a warm library reading room with tall bookshelves, a wooden ladder and an open notebook on a desk",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Albert Einstein",
@@ -1299,6 +1305,7 @@
     {
       "name": "Weird Insects",
       "coverPrompt": "a close-up garden floor of mossy stones, dewy clover and curled bark",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Ladybug",
@@ -1515,6 +1522,7 @@
     {
       "name": "Special Plants",
       "coverPrompt": "a bright greenhouse with glass panes, clay pots on wooden benches and hanging watering cans",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Venus Flytrap",
@@ -1731,6 +1739,7 @@
     {
       "name": "Spooky Legends",
       "coverPrompt": "a friendly moonlit path winding between crooked fences and bare twisted trees under purple fog",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Ghost",
@@ -1947,6 +1956,7 @@
     {
       "name": "Deep Sea Creatures",
       "coverPrompt": "a deep ocean trench with shafts of blue light and glowing coral ridges",
+      "provider": "pollinations",
       "cards": [
         {
           "name": "Anglerfish",
@@ -2162,7 +2172,8 @@
     },
     {
       "name": "Flying Machines",
-      "coverPrompt": "a grassy airfield at golden hour with a windsock, runway markings and open sky",
+      "coverPrompt": "a wide runway curving across a grassy airfield at golden hour, with marker lights and open sky",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Hot Air Balloon",
@@ -2379,6 +2390,7 @@
     {
       "name": "Ocean Machines",
       "coverPrompt": "a busy harbour dock with wooden piers, coiled ropes, buoys and calm water",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Sailboat",
@@ -2595,6 +2607,7 @@
     {
       "name": "Warriors",
       "coverPrompt": "a quiet stone fortress courtyard with hanging banners and worn flagstones",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Samurai",
@@ -3029,6 +3042,7 @@
     {
       "name": "Outer Space",
       "coverPrompt": "a rocket launch pad at dawn with tall gantry towers, drifting steam and an open sky",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "The Moon",
@@ -3245,12 +3259,12 @@
           "imagePrompt": "a broad glowing band of pale starlight arching across a dark blue night sky above low rolling green hills",
           "sourceUrl": "https://en.wikipedia.org/wiki/Milky_Way"
         }
-      ],
-      "provider": "cloudflare-sdxl"
+      ]
     },
     {
       "name": "Land Machines",
       "coverPrompt": "a sunny construction yard with sand piles, traffic cones and a wide open road",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Fire Engine",
@@ -3471,11 +3485,12 @@
           "sourceUrl": "https://en.wikipedia.org/wiki/Bagger_288",
           "provider": "pollinations"
         }
-      ],
-      "provider": "cloudflare-sdxl"
+      ]
     },
     {
       "name": "Rocks and Gems",
+      "coverPrompt": "a sunlit slope of loose grey pebbles and rounded boulders with tufts of dry grass, under a clear blue sky",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Diamond",
@@ -3690,11 +3705,12 @@
           "imagePrompt": "a single tall sea cliff standing at the edge of calm blue water under a clear sky, its rough face striped with level layers of cream and dark grey stone, seen from a distance so the whole cliff, the water below it and the sky above it are all in the picture",
           "sourceUrl": "https://en.wikipedia.org/wiki/Cliffed_coast"
         }
-      ],
-      "provider": "cloudflare-sdxl"
+      ]
     },
     {
       "name": "Trees",
+      "coverPrompt": "a view looking straight up into a sunlit green canopy with bright sky breaking through the leaves",
+      "provider": "cloudflare-sdxl",
       "cards": [
         {
           "name": "Cherry Blossom Tree",
@@ -3907,8 +3923,7 @@
           "imagePrompt": "a single short angsana branch with a few small green leaflets and two clusters of tiny bright yellow flowers, the bare brown branch clearly visible along its whole length, with plain blue sky all around it",
           "sourceUrl": "https://en.wikipedia.org/wiki/Pterocarpus_indicus"
         }
-      ],
-      "provider": "cloudflare-sdxl"
+      ]
     }
   ]
 }

--- a/src/db/migrations/0010_theme_cover_url.sql
+++ b/src/db/migrations/0010_theme_cover_url.sql
@@ -1,0 +1,14 @@
+-- #122: give a theme its own cover art.
+--
+-- The binder's category picker used to front each tile with the child's rarest
+-- OWNED card. That is a trophy, not a landmark — it changed whenever they
+-- pulled something better, and a category they had not started showed a neutral
+-- placeholder, so the newest theme was the least recognisable tile on a screen
+-- built for a child who navigates by picture.
+--
+-- Nullable for exactly one migration. Every theme is required to have a cover
+-- (`coverPrompt` is required by the seed schema, and `seed --sync` refuses to
+-- publish a theme whose cover has no reviewed image), so this column is
+-- nullable only while the 16 pre-existing themes are backfilled. It tightens to
+-- NOT NULL in the follow-up that makes the picker read it.
+ALTER TABLE "themes" ADD COLUMN "cover_url" text;

--- a/src/db/migrations/meta/0010_snapshot.json
+++ b/src/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,738 @@
+{
+  "id": "3a14e1c7-50de-4bd8-8957-2bcbc1cc2476",
+  "prevId": "bca6a048-c87f-4334-8e78-0704b9d0b23a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_credentials": {
+      "name": "admin_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_credentials_credential_id_idx": {
+          "name": "admin_credentials_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_credentials_parent_idx": {
+          "name": "admin_credentials_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cards": {
+      "name": "cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "rarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edu_text": {
+          "name": "edu_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "cards_theme_idx": {
+          "name": "cards_theme_idx",
+          "columns": [
+            {
+              "expression": "theme_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cards_theme_id_themes_id_fk": {
+          "name": "cards_theme_id_themes_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "themes",
+          "columnsFrom": [
+            "theme_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.children": {
+      "name": "children",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_tokens": {
+          "name": "pull_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "easter_egg_tickets": {
+          "name": "easter_egg_tickets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pull_tokens_non_negative": {
+          "name": "pull_tokens_non_negative",
+          "value": "\"children\".\"pull_tokens\" >= 0"
+        },
+        "easter_egg_tickets_non_negative": {
+          "name": "easter_egg_tickets_non_negative",
+          "value": "\"children\".\"easter_egg_tickets\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collection_rewards": {
+      "name": "collection_rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "rarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "collection_rewards_child_theme_rarity_idx": {
+          "name": "collection_rewards_child_theme_rarity_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "theme_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rarity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_rewards_child_idx": {
+          "name": "collection_rewards_child_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_rewards_child_id_children_id_fk": {
+          "name": "collection_rewards_child_id_children_id_fk",
+          "tableFrom": "collection_rewards",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_rewards_theme_id_themes_id_fk": {
+          "name": "collection_rewards_theme_id_themes_id_fk",
+          "tableFrom": "collection_rewards",
+          "tableTo": "themes",
+          "columnsFrom": [
+            "theme_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_rewards_card_id_cards_id_fk": {
+          "name": "collection_rewards_card_id_cards_id_fk",
+          "tableFrom": "collection_rewards",
+          "tableTo": "cards",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "collections_child_card_idx": {
+          "name": "collections_child_card_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collections_child_idx": {
+          "name": "collections_child_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_child_id_children_id_fk": {
+          "name": "collections_child_id_children_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collections_card_id_cards_id_fk": {
+          "name": "collections_card_id_cards_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "cards",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collections_child_id_card_id_pk": {
+          "name": "collections_child_id_card_id_pk",
+          "columns": [
+            "child_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "count_at_least_one": {
+          "name": "count_at_least_one",
+          "value": "\"collections\".\"count\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quiz_completions": {
+      "name": "quiz_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct": {
+          "name": "correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded": {
+          "name": "awarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quiz_completions_child_created_idx": {
+          "name": "quiz_completions_child_created_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_completions_child_id_children_id_fk": {
+          "name": "quiz_completions_child_id_children_id_fk",
+          "tableFrom": "quiz_completions",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_seen_questions": {
+      "name": "quiz_seen_questions",
+      "schema": "",
+      "columns": {
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_seen_questions_child_id_children_id_fk": {
+          "name": "quiz_seen_questions_child_id_children_id_fk",
+          "tableFrom": "quiz_seen_questions",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "quiz_seen_questions_child_id_topic_question_id_pk": {
+          "name": "quiz_seen_questions_child_id_topic_question_id_pk",
+          "columns": [
+            "child_id",
+            "topic",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.themes": {
+      "name": "themes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "themes_name_unique": {
+          "name": "themes_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.rarity": {
+      "name": "rarity",
+      "schema": "public",
+      "values": [
+        "common",
+        "rare",
+        "epic",
+        "legendary"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1787411934834,
       "tag": "0009_children_archived_at",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1788017423448,
+      "tag": "0010_theme_cover_url",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -29,6 +29,20 @@ export const themes = pgTable("themes", {
   // Display order, lowest = oldest (Inc21 FR1). Written from the theme's
   // position in seed/cards.json, so a newly appended theme is the most recent.
   sortOrder: integer("sort_order").notNull().default(0),
+  /**
+   * The theme's own cover art (#122) — what fronts its tile in the binder's
+   * category picker, and the thumbnail on the place bar inside it.
+   *
+   * The picker used to borrow the child's rarest owned card. That is a trophy,
+   * not a landmark: it changes on a legendary pull, and a category the child has
+   * not started showed a neutral placeholder — so the newest theme, the one they
+   * most want to find, was the least recognisable thing on the screen.
+   *
+   * Nullable for one migration only. Every theme is required to have one and
+   * `seed --sync` refuses to publish a theme whose cover has no reviewed image;
+   * the column tightens to NOT NULL once the 16 pre-existing themes are filled.
+   */
+  coverUrl: text("cover_url"),
 });
 
 /** Cards — shared library. */

--- a/src/features/pool/contact-sheet.ts
+++ b/src/features/pool/contact-sheet.ts
@@ -223,6 +223,74 @@ export function planContactSheet(
 }
 
 /** Render a contact sheet as markdown for the bake-off review comment. */
+/**
+ * One sheet of COVERS across many themes (#122) — the backfill's checkpoint 2.
+ *
+ * `planContactSheet` is per-theme, which is right for a new theme: 31 rows, all
+ * of them freshly generated. It is wrong for filling in covers for themes that
+ * already shipped, where it renders 30 blank rows for published cards it cannot
+ * know are published, and buries the one row that matters. Sixteen of those is
+ * not a checkpoint anyone can actually read.
+ *
+ * So the covers get one page: one row per theme, one column per provider, which
+ * is also the only way to see the thing that most needs seeing here — whether
+ * sixteen covers read as sixteen DIFFERENT places. A cover judged alone can look
+ * fine and still be the third grassy hilltop in the grid.
+ *
+ * Same `ContactSheet` shape, so `renderContactSheet` is untouched: `name` is the
+ * theme, `rarity` is the literal subject name, and `eduText` carries the
+ * authored prompt so a human can see the words each picture answers.
+ *
+ * Orphans are not computed. Detection is per-theme-prefix and this sheet spans
+ * every theme, so every theme's files would claim every other's; the per-theme
+ * sheet remains the place that question is asked.
+ */
+export function planCoverSheet(
+  themes: readonly SheetTheme[],
+  providers: readonly SheetProvider[],
+  deps: SheetDeps,
+): ContactSheet {
+  let missing = 0;
+  let unpicked = 0;
+
+  const rows: SheetRow[] = themes.map((theme) => {
+    const resolved = theme.provider;
+    if (resolved === undefined) unpicked++;
+    const subject = coverSubject(theme);
+
+    return {
+      name: theme.name,
+      rarity: COVER_SUBJECT_NAME.toLowerCase(),
+      eduText: theme.coverPrompt,
+      resolvedProvider: resolved,
+      candidates: providers.map((provider): SheetCandidate => {
+        const fileName = reviewFileName(theme.name, subject, provider);
+        const present = deps.exists(fileName);
+        if (!present && provider.role === "lane") missing++;
+        return {
+          providerId: provider.id,
+          fileName,
+          present,
+          model: present
+            ? deps.readSidecar(fileName.replace(/\.[^.]+$/, ".json"))?.model
+            : undefined,
+          isPick: provider.id === resolved,
+        };
+      }),
+    };
+  });
+
+  return {
+    theme: `${themes.length} theme cover(s)`,
+    providerIds: providers.map((p) => p.id),
+    escapeHatchIds: providers.filter((p) => p.role === "escape-hatch").map((p) => p.id),
+    rows,
+    missing,
+    unpicked,
+    orphans: [],
+  };
+}
+
 export function renderContactSheet(sheet: ContactSheet): string {
   const cols = sheet.providerIds.length;
   const banner = [

--- a/src/features/pool/contact-sheet.ts
+++ b/src/features/pool/contact-sheet.ts
@@ -43,6 +43,12 @@
  */
 import { slug } from "./keys";
 import { reviewFileName, resolveProviderId, type NamingProvider } from "./review-files";
+import {
+  COVER_SUBJECT_NAME,
+  cardSubject,
+  coverSubject,
+  type Subject,
+} from "./prompt";
 import type { ProviderRole } from "./providers/provider";
 
 /**
@@ -74,6 +80,8 @@ export interface SheetCard {
 export interface SheetTheme {
   name: string;
   provider?: string;
+  /** The theme's cover prompt (#122) — screened as the sheet's first row. */
+  coverPrompt: string;
   cards: readonly SheetCard[];
 }
 
@@ -136,14 +144,36 @@ export function planContactSheet(
   let missing = 0;
   let unpicked = 0;
 
-  const rows: SheetRow[] = [...theme.cards]
-    .sort((a, b) => (RARITY_ORDER[a.rarity] ?? 9) - (RARITY_ORDER[b.rarity] ?? 9))
-    .map((card) => {
-      const resolved = resolveProviderId(theme, card);
+  // The cover leads the sheet (#122). It is screened by the same human in the
+  // same sitting as the 30 cards, and it is the picture a child meets FIRST, so
+  // it is the first row rather than an appendix — and it is judged against the
+  // cards it will front rather than in isolation, which is the only way to see
+  // that a cover reads as a place and its cards read as specimens.
+  //
+  // It has no rarity, so it sorts nowhere: it is prepended rather than mixed in,
+  // and `rarity` carries the literal subject name so the rendered sheet labels
+  // the row instead of showing an empty rarity cell.
+  const subjects: Array<{ row: Omit<SheetRow, "candidates" | "resolvedProvider">; subject: Subject; provider?: string }> = [
+    {
+      row: { name: COVER_SUBJECT_NAME, rarity: COVER_SUBJECT_NAME.toLowerCase(), eduText: theme.coverPrompt },
+      subject: coverSubject(theme),
+      provider: theme.provider,
+    },
+    ...[...theme.cards]
+      .sort((a, b) => (RARITY_ORDER[a.rarity] ?? 9) - (RARITY_ORDER[b.rarity] ?? 9))
+      .map((card) => ({
+        row: { name: card.name, rarity: card.rarity, eduText: card.eduText },
+        subject: cardSubject(card),
+        provider: resolveProviderId(theme, card),
+      })),
+  ];
+
+  const rows: SheetRow[] = subjects
+    .map(({ row, subject, provider: resolved }) => {
       if (resolved === undefined) unpicked++;
 
       const candidates = providers.map((provider): SheetCandidate => {
-        const fileName = reviewFileName(theme.name, card, provider);
+        const fileName = reviewFileName(theme.name, subject, provider);
         expected.add(fileName);
         const present = deps.exists(fileName);
         // A hatch's blank is not a gap — see the header note.
@@ -159,13 +189,7 @@ export function planContactSheet(
         };
       });
 
-      return {
-        name: card.name,
-        rarity: card.rarity,
-        eduText: card.eduText,
-        resolvedProvider: resolved,
-        candidates,
-      };
+      return { ...row, resolvedProvider: resolved, candidates };
     });
 
   // Orphans are found by scanning rather than by column, because a column can

--- a/src/features/pool/image.ts
+++ b/src/features/pool/image.ts
@@ -18,6 +18,17 @@ import { contentTypeFor, readImageSize } from "./image-size";
 /**
  * Upload bytes to Vercel Blob; returns the public URL.
  *
+ * `prefix` selects the namespace: `cards/` for a card, `covers/` for a theme's
+ * cover art (#122). It defaults to `cards` so the ~390 existing call sites and
+ * published names are untouched, and it is a closed union rather than a free
+ * string because a typo would silently publish into a third namespace that
+ * nothing reconciles — `--blob-budget` walks the store by prefix.
+ *
+ * A cover is a separate namespace rather than a card named "Cover": card names
+ * are unique pool-wide and nothing stops a future theme shipping one, which
+ * would publish over a theme's cover with no error at either end. See
+ * `coverBlobKey`.
+ *
  * The pathname keeps its `.jpg` suffix whatever the bytes actually are. That is
  * not a format claim — it is the name ~360 already-published objects carry, and
  * changing it would re-point every existing card's URL for no benefit. The real
@@ -47,6 +58,7 @@ import { contentTypeFor, readImageSize } from "./image-size";
 export async function uploadImage(
   key: string,
   bytes: Uint8Array,
+  prefix: "cards" | "covers" = "cards",
 ): Promise<string> {
   const measured = readImageSize(bytes);
   if (!measured) {
@@ -66,7 +78,7 @@ export async function uploadImage(
   // headers, different published name. `tests/blob-naming.test.ts` (#102) pins
   // the version so it fails instead. Whether the default is the right one — and
   // what happens to the ~390 URLs already written under version 9's — is #91's.
-  const { url } = await put(`cards/${key}.jpg`, Buffer.from(bytes), {
+  const { url } = await put(`${prefix}/${key}.jpg`, Buffer.from(bytes), {
     access: "public",
     contentType: contentTypeFor(measured.format),
   });

--- a/src/features/pool/keys.ts
+++ b/src/features/pool/keys.ts
@@ -14,8 +14,7 @@
  * uses, and FR7 changes exactly one of them.
  */
 import { createHash } from "node:crypto";
-import { buildPrompt } from "./prompt";
-import type { SeedCard } from "./seed-schema";
+import type { Subject } from "./prompt";
 
 /** Lowercase, non-alphanumerics collapsed to "-", no leading/trailing dash. */
 export function slug(s: string): string {
@@ -35,16 +34,43 @@ export function blobKey(themeName: string, cardName: string): string {
 }
 
 /**
+ * Pathname for a theme's cover object (#122). Its own namespace — `uploadImage`
+ * prefixes `covers/`, not `cards/`.
+ *
+ * A cover is NOT filed as `blobKey(theme, "Cover")` under `cards/`, even though
+ * the slug would read the same. Card names are unique across the whole pool and
+ * nothing stops a future theme shipping a card called "Cover", which would then
+ * publish over a theme's cover with no error at either end — one object, two
+ * owners. A separate prefix makes that collision unrepresentable rather than
+ * unlikely.
+ *
+ * This is a NEW namespace, not a change to an existing one, so it is
+ * independent of #91's open question about what the ~390 `cards/` URLs are
+ * actually named under the store's version-9 random-suffix default.
+ */
+export function coverBlobKey(themeName: string): string {
+  return slug(themeName);
+}
+
+/**
  * First 8 hex chars of sha256 over the prompt actually sent to the image service.
  *
- * Hashes `buildPrompt(card)`, NOT `card.imagePrompt` (D4): buildPrompt appends
- * ART_STYLE, so changing ART_STYLE changes what every card renders as. Hashing the
- * raw imagePrompt would leave that change invisible to the review gate — the exact
- * failure mode FR7 exists to remove. The cost is that an ART_STYLE edit invalidates
- * every review file and forces a full re-review, which is the correct consequence.
+ * Hashes the FULL prompt, not the authored fragment (D4): the style constant is
+ * appended before it gets here, so changing `ART_STYLE` — or `COVER_STYLE` —
+ * changes what every affected subject renders as. Hashing the raw authored
+ * prompt would leave that change invisible to the review gate, the exact failure
+ * mode FR7 exists to remove. The cost is that a style edit invalidates every
+ * review file and forces a full re-review, which is the correct consequence.
+ *
+ * It takes the built string rather than a card (#122). It used to call
+ * `buildPrompt` itself, which hard-wired "the card style" into the hash and left
+ * a theme cover — which needs `COVER_STYLE` — with no way through this function
+ * except a style parameter threaded down four signatures. `Subject` decides the
+ * style once, at construction. Card hashes are unchanged: the same string is
+ * still what gets hashed, which `keys.test.ts` pins by value.
  */
-export function promptHash(card: Pick<SeedCard, "imagePrompt">): string {
-  return createHash("sha256").update(buildPrompt(card)).digest("hex").slice(0, 8);
+export function promptHash(prompt: string): string {
+  return createHash("sha256").update(prompt).digest("hex").slice(0, 8);
 }
 
 /**
@@ -72,8 +98,8 @@ export function promptHash(card: Pick<SeedCard, "imagePrompt">): string {
  */
 export function reviewKey(
   themeName: string,
-  card: Pick<SeedCard, "name" | "imagePrompt">,
+  subject: Subject,
   providerSegment: string,
 ): string {
-  return `${slug(`${themeName}-${card.name}`)}-${promptHash(card)}-${providerSegment}`;
+  return `${slug(`${themeName}-${subject.name}`)}-${promptHash(subject.prompt)}-${providerSegment}`;
 }

--- a/src/features/pool/pool-reads.ts
+++ b/src/features/pool/pool-reads.ts
@@ -35,6 +35,25 @@ export async function listPublishedCardKeys(): Promise<Set<string>> {
 }
 
 /**
+ * Theme names that already have a cover published (#122).
+ *
+ * The cover equivalent of `listPublishedCardKeys`, and read the same way and for
+ * the same reason: `--review` needs to know which covers to generate and the
+ * publish guard needs to know which to demand, and the two must agree. A theme
+ * that does not exist yet contributes nothing, so its cover falls into the plan
+ * alongside all 30 of its cards.
+ *
+ * Keyed by NAME, not id, because that is what the seed file has and what
+ * `--review` can use without writing a theme row to find out.
+ */
+export async function listPublishedCoverThemes(): Promise<Set<string>> {
+  const rows = await db
+    .select({ theme: themes.name, cover: themes.coverUrl })
+    .from(themes);
+  return new Set(rows.filter((r) => r.cover !== null).map((r) => r.theme));
+}
+
+/**
  * Every published card's art, as `(theme, card, imageUrl)` in display order.
  *
  * Read-only, and the only consumer is `--check-images` (#78): a published card's

--- a/src/features/pool/prompt.ts
+++ b/src/features/pool/prompt.ts
@@ -108,3 +108,72 @@ export const ART_STYLE =
 export function buildPrompt(card: Pick<SeedCard, "imagePrompt">): string {
   return `${card.imagePrompt}, ${ART_STYLE}`;
 }
+
+/**
+ * Kid-friendly art style appended to every THEME COVER prompt (#122).
+ *
+ * A cover is not a card and must not look like one. #122 decided the picker's
+ * tile is a **landmark** — the same picture every time, so a child can find
+ * Dinosaurs among 30 tiles — and that a cover therefore depicts the theme's
+ * **place**, never one of its 30 subjects: putting a card's art on the door of
+ * the category that contains it leaks what U5-Q5 keeps behind `❔`. A separate
+ * style is what keeps the two readable apart at a glance; running a place
+ * through `ART_STYLE` would draw a specimen-shaped picture of it.
+ *
+ * Every word here is a PROPERTY, deliberately. #81's lesson above is about the
+ * noun, not the negation: naming something depictable puts it in the picture
+ * whatever polarity you name it in. So this cannot say "no animals", "no
+ * people", "no card" — those are the exact shape of "no border", which #81
+ * measured as a border *cue*. The exclusions live in the authored `coverPrompt`
+ * by omission instead, and a cover prompt that names an excluded subject in
+ * order to forbid it is an authoring bug, not a safeguard.
+ *
+ * "no text" carries over from `ART_STYLE` on the same reasoning it survives
+ * there: text is not a thing a model can draw a picture OF, so it is a property
+ * rather than a noun.
+ */
+export const COVER_STYLE =
+  "vibrant kid-friendly cartoon scenery illustration, wide open view, " +
+  "bright colors, friendly, soft depth, no text";
+
+/** Build the full prompt for a theme's cover (pure). */
+export function buildCoverPrompt(theme: { coverPrompt: string }): string {
+  return `${theme.coverPrompt}, ${COVER_STYLE}`;
+}
+
+/**
+ * What the naming stack (`keys.ts`, `review-files.ts`) and the bake-off runner
+ * see: a **named, fully-styled prompt**.
+ *
+ * The stack used to take a `SeedCard` and call `buildPrompt` itself, which meant
+ * "which style applies" was decided deep inside `promptHash`. A cover needs a
+ * different style, and threading a style argument through `reviewKey` →
+ * `reviewStem` → `reviewFileName` → `sidecarFileName` would put that decision in
+ * four signatures instead of one. Deciding it once, here, leaves every one of
+ * those functions style-agnostic and lets a cover be named by exactly the
+ * machinery a card is.
+ *
+ * `prompt` is the string actually sent to the provider — the same string
+ * `promptHash` content-addresses — so the review-staleness guarantee (D4) is
+ * unchanged in substance: edit `ART_STYLE`, `COVER_STYLE` or an authored prompt
+ * and every affected filename moves.
+ */
+export interface Subject {
+  /** Human-readable, and the slug half of every filename. */
+  name: string;
+  /** The full prompt, style already appended. */
+  prompt: string;
+}
+
+/** The subject name a theme's cover is filed under. */
+export const COVER_SUBJECT_NAME = "Cover";
+
+/** A card as the naming stack sees it. */
+export function cardSubject(card: Pick<SeedCard, "name" | "imagePrompt">): Subject {
+  return { name: card.name, prompt: buildPrompt(card) };
+}
+
+/** A theme's cover as the naming stack sees it. */
+export function coverSubject(theme: { coverPrompt: string }): Subject {
+  return { name: COVER_SUBJECT_NAME, prompt: buildCoverPrompt(theme) };
+}

--- a/src/features/pool/review-files.ts
+++ b/src/features/pool/review-files.ts
@@ -11,6 +11,12 @@
 import { z } from "zod";
 import { EXTENSIONS } from "./image-size";
 import { reviewKey } from "./keys";
+import {
+  COVER_SUBJECT_NAME,
+  cardSubject,
+  coverSubject,
+  type Subject,
+} from "./prompt";
 import { cardKey } from "./publish-plan";
 import {
   providerSegment,
@@ -19,7 +25,13 @@ import {
 } from "./providers/provider";
 import type { SeedCard } from "./seed-schema";
 
-/** Minimal shape a card needs to be named. */
+/**
+ * Minimal shape a card needs to be named.
+ *
+ * Kept as the type callers hold a *card* in; `cardSubject` turns it into the
+ * `Subject` the naming functions below take. Since #122 those functions name a
+ * theme cover with the same machinery, so they cannot take a card.
+ */
 export type NamedCard = Pick<SeedCard, "name" | "imagePrompt">;
 
 /** The adapter facts a filename depends on. */
@@ -37,10 +49,10 @@ export type NamingProvider = Pick<ImageProvider, "id" | "params" | "format">;
  */
 export function reviewStem(
   themeName: string,
-  card: NamedCard,
+  subject: Subject,
   provider: NamingProvider,
 ): string {
-  return reviewKey(themeName, card, providerSegment(provider));
+  return reviewKey(themeName, subject, providerSegment(provider));
 }
 
 /**
@@ -53,10 +65,10 @@ export function reviewStem(
  */
 export function reviewFileName(
   themeName: string,
-  card: NamedCard,
+  subject: Subject,
   provider: NamingProvider,
 ): string {
-  return `${reviewStem(themeName, card, provider)}.${EXTENSIONS[provider.format]}`;
+  return `${reviewStem(themeName, subject, provider)}.${EXTENSIONS[provider.format]}`;
 }
 
 /**
@@ -74,10 +86,10 @@ export function reviewFileName(
  */
 export function sidecarFileName(
   themeName: string,
-  card: NamedCard,
+  subject: Subject,
   provider: NamingProvider,
 ): string {
-  return `${reviewStem(themeName, card, provider)}.json`;
+  return `${reviewStem(themeName, subject, provider)}.json`;
 }
 
 const reviewSidecarSchema = z.object({
@@ -150,6 +162,8 @@ export function buildSidecar(
 export interface AuditTheme {
   name: string;
   provider?: string;
+  /** The authored place-prompt for this theme's cover (#122). */
+  coverPrompt: string;
   cards: readonly (NamedCard & { provider?: string })[];
 }
 
@@ -225,13 +239,68 @@ export function missingReviews(
         });
         continue;
       }
-      if (!exists(reviewFileName(theme.name, card, provider))) {
+      if (!exists(reviewFileName(theme.name, cardSubject(card), provider))) {
         missing.push({
           theme: theme.name,
           card: card.name,
           reason: `no reviewed image from ${provider.id}`,
         });
       }
+    }
+  }
+  return missing;
+}
+
+/**
+ * Themes whose cover would be published with no reviewed image (#122) — the
+ * hard stop that makes "every category is recognisable before you own anything
+ * in it" a guarantee rather than an aspiration.
+ *
+ * A sibling of `missingReviews` rather than another branch inside it, because
+ * the two audits are keyed differently: a card is planned per `(theme, card)`,
+ * a cover per theme, so folding them together would mean one function taking two
+ * planned-sets and reporting rows of two shapes. They share the machinery that
+ * matters — `reviewFileName`, `resolveProviderId`, the same `exists` — so they
+ * cannot disagree about which file a reviewed image lives in, which is the only
+ * agreement FR9 actually needs.
+ *
+ * `card` on the returned row is the literal subject name a cover is filed under,
+ * so the CLI's existing `theme / card — reason` report renders it unchanged and
+ * a human reads "Animals / Cover — no reviewed image from pollinations".
+ *
+ * A cover has no per-subject provider override: it inherits the theme's pick,
+ * which is the same bake-off judgement its 30 cards ride on. There is no case
+ * for one lane drawing a theme's cards and another its cover — that is the
+ * mixed-lane incoherence #77 is already worried about, inside a single theme.
+ */
+export function missingCoverReviews(
+  themes: readonly AuditTheme[],
+  plannedCovers: ReadonlySet<string>,
+  lookup: (id: string) => NamingProvider | undefined,
+  exists: (fileName: string) => boolean,
+): UnreviewedCard[] {
+  const missing: UnreviewedCard[] = [];
+  for (const theme of themes) {
+    if (!plannedCovers.has(theme.name)) continue;
+    const id = theme.provider;
+    const provider = id === undefined ? undefined : lookup(id);
+    if (!provider) {
+      missing.push({
+        theme: theme.name,
+        card: COVER_SUBJECT_NAME,
+        reason:
+          id === undefined
+            ? "no provider chosen (bake-off not judged)"
+            : `unknown provider "${id}"`,
+      });
+      continue;
+    }
+    if (!exists(reviewFileName(theme.name, coverSubject(theme), provider))) {
+      missing.push({
+        theme: theme.name,
+        card: COVER_SUBJECT_NAME,
+        reason: `no reviewed image from ${provider.id}`,
+      });
     }
   }
   return missing;

--- a/src/features/pool/seed-schema.ts
+++ b/src/features/pool/seed-schema.ts
@@ -64,6 +64,23 @@ export const themeSeedSchema = z
   .object({
     name: z.string().trim().min(1),
     cards: z.array(seedCardSchema).min(1),
+    /**
+     * The theme's cover art prompt — a **place**, never one of its 30 subjects
+     * (#122). The picker's tile is a landmark a child navigates 25+ categories
+     * by, so it has to be the same picture every time and has to exist before
+     * they own anything here; `buildCoverPrompt` appends `COVER_STYLE` rather
+     * than `ART_STYLE` so a cover cannot be mistaken for a card.
+     *
+     * REQUIRED, unlike `provider` — and the difference is which step of the
+     * runbook writes it. `provider` records a bake-off pick that by definition
+     * does not exist while a theme is being authored, so requiring it would make
+     * a half-authored theme unloadable. `coverPrompt` is authored text, written
+     * at Step 4 alongside 30 `imagePrompt`s, so it is available exactly when the
+     * rest of the file is. Making it required is what turns "every theme has a
+     * cover" into something the schema enforces on every seed command instead of
+     * something the publish step hopes for.
+     */
+    coverPrompt: z.string().trim().min(1),
     /** Default provider for this theme's cards; a card's own `provider` wins (#63). */
     provider: z.string().trim().min(1).optional(),
   })

--- a/src/features/pool/writer.ts
+++ b/src/features/pool/writer.ts
@@ -44,6 +44,21 @@ export async function upsertTheme(
   return row.id;
 }
 
+/**
+ * Point a theme at its published cover art (#122).
+ *
+ * Separate from `upsertTheme` rather than another argument to it, because the
+ * two run at different times and under different guarantees: `upsertTheme` runs
+ * for every theme on every publish and must not need a cover in hand, while this
+ * runs only after a reviewed cover's bytes have actually been uploaded. Folding
+ * them together would mean passing `coverUrl: undefined` on every ordinary sync
+ * and deciding, inside the upsert, whether undefined means "leave it" or "clear
+ * it" — the ambiguity that loses a cover on an unrelated run.
+ */
+export async function setThemeCover(themeId: string, coverUrl: string): Promise<void> {
+  await db.update(themes).set({ coverUrl }).where(eq(themes.id, themeId));
+}
+
 /** True if a card with this theme+name already exists. */
 export async function cardExists(
   themeId: string,

--- a/tests/contact-sheet.test.ts
+++ b/tests/contact-sheet.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   planContactSheet,
+  planCoverSheet,
   renderContactSheet,
   type SheetDeps,
   type SheetTheme,
@@ -105,6 +106,48 @@ describe("planContactSheet — the grid (#63)", () => {
       .find((r) => r.name === "Longbowman")!
       .candidates.find((c) => c.providerId === "pollinations")!;
     expect(cell.model).toBe("sana");
+  });
+});
+
+describe("planCoverSheet — every theme's cover on one page (#122)", () => {
+  const themes: SheetTheme[] = [
+    { name: "Warriors", provider: "pollinations", coverPrompt: "a stone courtyard", cards },
+    { name: "Ocean", provider: "cloudflare-sdxl", coverPrompt: "a harbour dock", cards },
+  ];
+  const coverFiles = (ts: SheetTheme[]) =>
+    ts.flatMap((t) => PROVIDERS.map((p) => reviewFileName(t.name, coverSubject(t), p)));
+
+  it("is one row per theme and no card rows at all", () => {
+    const sheet = planCoverSheet(themes, PROVIDERS, deps(coverFiles(themes)));
+    expect(sheet.rows.map((r) => r.name)).toEqual(["Warriors", "Ocean"]);
+  });
+
+  // The reason this sheet exists. Per-theme sheets would render 30 blank rows
+  // for already-published cards and bury the one row being judged; sixteen of
+  // those is not a checkpoint anyone can read.
+  it("counts no cards as missing, however many the theme has", () => {
+    const sheet = planCoverSheet(themes, PROVIDERS, deps(coverFiles(themes)));
+    expect(sheet.missing).toBe(0);
+  });
+
+  it("names each row's file from ITS OWN theme, not a shared prefix", () => {
+    const sheet = planCoverSheet(themes, PROVIDERS, deps(coverFiles(themes)));
+    expect(sheet.rows[0].candidates[0].fileName).toContain("warriors-cover-");
+    expect(sheet.rows[1].candidates[0].fileName).toContain("ocean-cover-");
+  });
+
+  it("marks the theme's provider as the pick, and counts a theme with none", () => {
+    const unjudged = [{ ...themes[0], provider: undefined }];
+    const sheet = planCoverSheet(unjudged, PROVIDERS, deps(coverFiles(unjudged)));
+    expect(sheet.unpicked).toBe(1);
+    expect(sheet.rows[0].candidates.some((c) => c.isPick)).toBe(false);
+  });
+
+  // Orphan detection is per-theme-prefix and this sheet spans every theme, so
+  // each theme's files would claim every other's. The per-theme sheet keeps it.
+  it("reports no orphans, because it cannot tell whose they are", () => {
+    const sheet = planCoverSheet(themes, PROVIDERS, deps([...coverFiles(themes), "stray.png"]));
+    expect(sheet.orphans).toEqual([]);
   });
 });
 

--- a/tests/contact-sheet.test.ts
+++ b/tests/contact-sheet.test.ts
@@ -6,6 +6,7 @@ import {
   type SheetTheme,
 } from "@/features/pool/contact-sheet";
 import { reviewFileName } from "@/features/pool/review-files";
+import { cardSubject, coverSubject } from "@/features/pool/prompt";
 import { fakeProvider } from "@/features/pool/providers/fake";
 
 /**
@@ -36,16 +37,21 @@ function deps(onDisk: readonly string[], sidecars: Record<string, { model?: stri
   };
 }
 
+const COVER = "a quiet stone fortress courtyard";
+
+/** Every candidate the sheet expects — the cover row included (#122). */
 function allFiles(theme: SheetTheme): string[] {
-  return theme.cards.flatMap((c) => PROVIDERS.map((p) => reviewFileName(theme.name, c, p)));
+  const subjects = [coverSubject(theme), ...theme.cards.map(cardSubject)];
+  return subjects.flatMap((sub) => PROVIDERS.map((p) => reviewFileName(theme.name, sub, p)));
 }
 
 describe("planContactSheet — the grid (#63)", () => {
-  const theme: SheetTheme = { name: "Warriors", provider: "pollinations", cards };
+  const theme: SheetTheme = { name: "Warriors", provider: "pollinations", coverPrompt: COVER, cards };
 
   it("gives every card a cell for every provider", () => {
     const sheet = planContactSheet(theme, PROVIDERS, deps(allFiles(theme)));
-    expect(sheet.rows).toHaveLength(2);
+    // Two cards plus the theme's cover, which leads the sheet (#122).
+    expect(sheet.rows).toHaveLength(3);
     for (const row of sheet.rows) expect(row.candidates.map((c) => c.providerId)).toEqual([
       "pollinations",
       "cloudflare-sdxl",
@@ -63,9 +69,11 @@ describe("planContactSheet — the grid (#63)", () => {
     expect(sheet.rows.every((r) => r.candidates.every((c) => c.present))).toBe(true);
   });
 
-  it("orders rows legendary first", () => {
+  it("leads with the cover, then orders cards legendary first", () => {
     const sheet = planContactSheet(theme, PROVIDERS, deps(allFiles(theme)));
-    expect(sheet.rows.map((r) => r.name)).toEqual(["Paladin", "Longbowman"]);
+    // The cover has no rarity, so it does not sort — it is prepended. It is the
+    // first picture a child meets, and it is judged against the cards it fronts.
+    expect(sheet.rows.map((r) => r.name)).toEqual(["Cover", "Paladin", "Longbowman"]);
   });
 
   it("marks the candidate --sync would publish", () => {
@@ -88,7 +96,7 @@ describe("planContactSheet — the grid (#63)", () => {
   });
 
   it("labels a cell with the model the response NAMED (#64)", () => {
-    const file = reviewFileName("Warriors", cards[0], jpegProvider);
+    const file = reviewFileName("Warriors", cardSubject(cards[0]), jpegProvider);
     const sheet = planContactSheet(theme, PROVIDERS, {
       ...deps(allFiles(theme)),
       readSidecar: (f) => (f === file.replace(/\.jpg$/, ".json") ? { model: "sana" } : undefined),
@@ -101,15 +109,19 @@ describe("planContactSheet — the grid (#63)", () => {
 });
 
 describe("planContactSheet — the three absences it must not hide", () => {
-  const theme: SheetTheme = { name: "Warriors", provider: "pollinations", cards };
+  const theme: SheetTheme = { name: "Warriors", provider: "pollinations", coverPrompt: COVER, cards };
 
   it("counts a provider that produced nothing, rather than omitting its column", () => {
     // A lane that died or was never run must be visibly empty. Omitting it would
     // read as a bake-off that never meant to include it.
-    const onlyJpeg = theme.cards.map((c) => reviewFileName(theme.name, c, jpegProvider));
+    // Every subject the sheet expects — the cover row and both cards — but from
+    // one lane only, so the other lane's column is entirely empty.
+    const onlyJpeg = [coverSubject(theme), ...theme.cards.map(cardSubject)].map((sub) =>
+      reviewFileName(theme.name, sub, jpegProvider),
+    );
     const sheet = planContactSheet(theme, PROVIDERS, deps(onlyJpeg));
     expect(sheet.providerIds).toContain("cloudflare-sdxl");
-    expect(sheet.missing).toBe(2);
+    expect(sheet.missing).toBe(3);
     const cf = sheet.rows.flatMap((r) => r.candidates.filter((c) => c.providerId === "cloudflare-sdxl"));
     expect(cf.every((c) => !c.present)).toBe(true);
   });
@@ -126,7 +138,7 @@ describe("planContactSheet — the three absences it must not hide", () => {
     expect(sheet.providerIds).toContain("ai-horde");
     expect(sheet.missing).toBe(0);
     const cells = sheet.rows.flatMap((r) => r.candidates.filter((c) => c.providerId === "ai-horde"));
-    expect(cells).toHaveLength(2);
+    expect(cells).toHaveLength(3);
     expect(cells.every((c) => !c.present)).toBe(true);
   });
 
@@ -134,15 +146,18 @@ describe("planContactSheet — the three absences it must not hide", () => {
     // The exemption is about the hatch, not about the sheet giving up on
     // counting. A dead lane must still be reported while a hatch sits out.
     const hatch = { ...fakeProvider({ id: "ai-horde", role: "escape-hatch" }), format: "webp" as const };
-    const onlyJpeg = theme.cards.map((c) => reviewFileName(theme.name, c, jpegProvider));
+    const onlyJpeg = [coverSubject(theme), ...theme.cards.map(cardSubject)].map((sub) =>
+      reviewFileName(theme.name, sub, jpegProvider),
+    );
     const sheet = planContactSheet(theme, [...PROVIDERS, hatch], deps(onlyJpeg));
-    expect(sheet.missing).toBe(2);
+    expect(sheet.missing).toBe(3);
   });
 
   it("counts cards with no pick — the ones --sync will refuse", () => {
-    const unjudged: SheetTheme = { name: "Warriors", cards };
+    const unjudged: SheetTheme = { name: "Warriors", coverPrompt: COVER, cards };
     const sheet = planContactSheet(unjudged, PROVIDERS, deps(allFiles(unjudged)));
-    expect(sheet.unpicked).toBe(2);
+    // Three subjects with no pick: the cover row and both cards (#122).
+    expect(sheet.unpicked).toBe(3);
     expect(sheet.rows.every((r) => r.resolvedProvider === undefined)).toBe(true);
   });
 
@@ -173,7 +188,7 @@ describe("planContactSheet — the three absences it must not hide", () => {
     // both admit dashes, so nothing in the name alone separates them. Told about
     // the sibling, the shorter theme stops reporting the longer one's candidates
     // as its own orphans.
-    const ocean: SheetTheme = { name: "Ocean", provider: "pollinations", cards };
+    const ocean: SheetTheme = { name: "Ocean", provider: "pollinations", coverPrompt: COVER, cards };
     const sibling = "ocean-machines-alvin-deadbeef-pollinations-1234.jpg";
     const own = "ocean-stray-deadbeef-pollinations-1234.jpg";
 
@@ -186,7 +201,7 @@ describe("planContactSheet — the three absences it must not hide", () => {
 });
 
 describe("renderContactSheet", () => {
-  const theme: SheetTheme = { name: "Warriors", provider: "pollinations", cards };
+  const theme: SheetTheme = { name: "Warriors", provider: "pollinations", coverPrompt: COVER, cards };
 
   it("renders one column per provider and marks the pick", () => {
     const html = renderContactSheet(planContactSheet(theme, PROVIDERS, deps(allFiles(theme))));
@@ -198,7 +213,7 @@ describe("renderContactSheet", () => {
   });
 
   it("puts each absence on the page, not just in the console", () => {
-    const unjudged: SheetTheme = { name: "Warriors", cards };
+    const unjudged: SheetTheme = { name: "Warriors", coverPrompt: COVER, cards };
     const html = renderContactSheet(
       planContactSheet(unjudged, PROVIDERS, deps(["nope.png", "warriors-stray-a-b-c.png"])),
     );
@@ -212,6 +227,7 @@ describe("renderContactSheet", () => {
     const nasty: SheetTheme = {
       name: "Warriors",
       provider: "pollinations",
+      coverPrompt: COVER,
       cards: [{ name: "<script>x</script>", rarity: "common", eduText: "a & b", imagePrompt: "p" }],
     };
     const html = renderContactSheet(planContactSheet(nasty, PROVIDERS, deps([])));

--- a/tests/keys.test.ts
+++ b/tests/keys.test.ts
@@ -1,9 +1,24 @@
 import { describe, it, expect } from "vitest";
 import { createHash } from "node:crypto";
-import { slug, blobKey, promptHash, reviewKey } from "@/features/pool/keys";
-import { buildPrompt, ART_STYLE } from "@/features/pool/prompt";
+import {
+  slug,
+  blobKey,
+  coverBlobKey,
+  promptHash,
+  reviewKey,
+} from "@/features/pool/keys";
+import {
+  buildPrompt,
+  buildCoverPrompt,
+  cardSubject,
+  coverSubject,
+  ART_STYLE,
+  COVER_STYLE,
+  COVER_SUBJECT_NAME,
+} from "@/features/pool/prompt";
 
 const card = { name: "SR-71 Blackbird", imagePrompt: "a sleek black jet" };
+const subject = cardSubject(card);
 
 describe("slug / blobKey (Inc24 FR7 — unchanged behaviour)", () => {
   it("lowercases and collapses non-alphanumerics", () => {
@@ -19,7 +34,7 @@ describe("slug / blobKey (Inc24 FR7 — unchanged behaviour)", () => {
   it("blobKey keeps the pre-Inc24 shape — the hash has no job in Blob (Q6=A)", () => {
     expect(blobKey("Ocean Machines", "Alvin")).toBe("ocean-machines-alvin");
     expect(blobKey("Ocean Machines", "Alvin")).not.toContain(
-      promptHash({ imagePrompt: "x" }),
+      promptHash(buildPrompt({ imagePrompt: "x" })),
     );
   });
 });
@@ -30,8 +45,8 @@ describe("promptHash (D4 — hashes the FULL prompt, not the raw imagePrompt)", 
       .update(buildPrompt(card))
       .digest("hex")
       .slice(0, 8);
-    expect(promptHash(card)).toBe(expected);
-    expect(promptHash(card)).toMatch(/^[0-9a-f]{8}$/);
+    expect(promptHash(subject.prompt)).toBe(expected);
+    expect(promptHash(subject.prompt)).toMatch(/^[0-9a-f]{8}$/);
   });
 
   it("is NOT sha256 over the bare imagePrompt", () => {
@@ -42,18 +57,18 @@ describe("promptHash (D4 — hashes the FULL prompt, not the raw imagePrompt)", 
       .update(card.imagePrompt)
       .digest("hex")
       .slice(0, 8);
-    expect(promptHash(card)).not.toBe(bare);
+    expect(promptHash(subject.prompt)).not.toBe(bare);
     expect(buildPrompt(card)).toContain(ART_STYLE);
   });
 
   it("changes when the imagePrompt changes", () => {
-    expect(promptHash({ imagePrompt: "a red plane" })).not.toBe(
-      promptHash({ imagePrompt: "a blue plane" }),
+    expect(promptHash(buildPrompt({ imagePrompt: "a red plane" }))).not.toBe(
+      promptHash(buildPrompt({ imagePrompt: "a blue plane" })),
     );
   });
 
   it("is deterministic", () => {
-    expect(promptHash(card)).toBe(promptHash({ ...card }));
+    expect(promptHash(subject.prompt)).toBe(promptHash(cardSubject({ ...card }).prompt));
   });
 });
 
@@ -61,43 +76,85 @@ describe("reviewKey (FR7 content-addressed, #67 provider-segmented)", () => {
   const SEG = "pollinations-7f3a";
 
   it("is the blob slug, the prompt hash, then the provider segment", () => {
-    expect(reviewKey("Flying Machines", card, SEG)).toBe(
-      `${blobKey("Flying Machines", card.name)}-${promptHash(card)}-${SEG}`,
+    expect(reviewKey("Flying Machines", subject, SEG)).toBe(
+      `${blobKey("Flying Machines", card.name)}-${promptHash(subject.prompt)}-${SEG}`,
     );
   });
 
   it("changes when the imagePrompt changes — so an edited prompt can never reuse a stale review", () => {
-    const before = reviewKey("Flying Machines", card, SEG);
-    const after = reviewKey("Flying Machines", {
-      ...card,
-      imagePrompt: "a sleek black jet on a runway",
-    }, SEG);
+    const before = reviewKey("Flying Machines", subject, SEG);
+    const after = reviewKey(
+      "Flying Machines",
+      cardSubject({ ...card, imagePrompt: "a sleek black jet on a runway" }),
+      SEG,
+    );
     expect(after).not.toBe(before);
   });
 
   it("changes when the card or theme name changes", () => {
-    expect(reviewKey("Flying Machines", card, SEG)).not.toBe(
-      reviewKey("Ocean Machines", card, SEG),
+    expect(reviewKey("Flying Machines", subject, SEG)).not.toBe(
+      reviewKey("Ocean Machines", subject, SEG),
     );
-    expect(reviewKey("Flying Machines", card, SEG)).not.toBe(
-      reviewKey("Flying Machines", { ...card, name: "Concorde" }, SEG),
+    expect(reviewKey("Flying Machines", subject, SEG)).not.toBe(
+      reviewKey("Flying Machines", cardSubject({ ...card, name: "Concorde" }), SEG),
     );
   });
 
   // The #67 mechanism: switching provider must make --sync miss the file, which
   // is what makes FR9 refuse rather than republish art nobody reviewed.
   it("changes when the provider segment changes", () => {
-    expect(reviewKey("Flying Machines", card, "pollinations-7f3a")).not.toBe(
-      reviewKey("Flying Machines", card, "cloudflare-sdxl-9b21"),
+    expect(reviewKey("Flying Machines", subject, "pollinations-7f3a")).not.toBe(
+      reviewKey("Flying Machines", subject, "cloudflare-sdxl-9b21"),
     );
   });
 
   // ...but the hash itself must NOT, or the contact sheet has no key to group a
   // subject's candidates into one row (#63's subject x provider grid).
   it("keeps ONE promptHash across providers, so bake-off candidates share a row", () => {
-    const a = reviewKey("Flying Machines", card, "pollinations-7f3a");
-    const b = reviewKey("Flying Machines", card, "cloudflare-sdxl-9b21");
-    expect(a).toContain(promptHash(card));
-    expect(b).toContain(promptHash(card));
+    const a = reviewKey("Flying Machines", subject, "pollinations-7f3a");
+    const b = reviewKey("Flying Machines", subject, "cloudflare-sdxl-9b21");
+    expect(a).toContain(promptHash(subject.prompt));
+    expect(b).toContain(promptHash(subject.prompt));
+  });
+});
+
+describe("theme covers (#122)", () => {
+  const theme = { name: "Dinosaurs", coverPrompt: "a wide prehistoric valley" };
+
+  // The reason #122 could take `promptHash` from a card to a string at all: the
+  // string hashed is unchanged, so no published card's review file moves and no
+  // re-review is forced. Pinned by VALUE rather than by re-deriving it, because
+  // a test that recomputes the thing it is checking would follow a regression.
+  it("leaves a card's hash exactly where it was", () => {
+    // Derived from origin/main's ART_STYLE, not from this branch's code.
+    expect(promptHash(buildPrompt(card))).toBe("7dfdd51a");
+  });
+
+  it("a cover carries COVER_STYLE, never ART_STYLE", () => {
+    expect(buildCoverPrompt(theme)).toContain(COVER_STYLE);
+    expect(buildCoverPrompt(theme)).not.toContain(ART_STYLE);
+  });
+
+  it("a cover and a card with the SAME authored words hash differently", () => {
+    // The whole point of a separate style: a place run through the card style is
+    // a different picture, so it must be a different review file.
+    const words = "a wide prehistoric valley";
+    expect(promptHash(coverSubject({ coverPrompt: words }).prompt)).not.toBe(
+      promptHash(cardSubject({ name: "x", imagePrompt: words }).prompt),
+    );
+  });
+
+  it("names a cover under the theme, in its own blob namespace", () => {
+    expect(coverSubject(theme).name).toBe(COVER_SUBJECT_NAME);
+    expect(coverBlobKey("Ocean Machines")).toBe("ocean-machines");
+  });
+
+  // A card called "Cover" would slug to the same `cards/<theme>-cover` a naive
+  // cover key would, and publish over it silently. Different namespaces make the
+  // collision unrepresentable — this pins that they stay different.
+  it("cannot collide with a card that happens to be named Cover", () => {
+    expect(coverBlobKey("Ocean Machines")).not.toBe(
+      blobKey("Ocean Machines", COVER_SUBJECT_NAME),
+    );
   });
 });

--- a/tests/pool.test.ts
+++ b/tests/pool.test.ts
@@ -27,7 +27,7 @@ function validTheme(name = "Animals", cardPrefix = name) {
       sourceUrl: `https://example.com/${rarity}/${i}`,
     })),
   );
-  return { name, cards };
+  return { name, coverPrompt: `a wide open ${name} place`, cards };
 }
 
 const validFile = () => ({ themes: [validTheme()] });

--- a/tests/provenance.test.ts
+++ b/tests/provenance.test.ts
@@ -16,6 +16,7 @@ import {
   reviewStem,
   type ReviewSidecar,
 } from "@/features/pool/review-files";
+import { cardSubject } from "@/features/pool/prompt";
 import { fakeProvider } from "@/features/pool/providers/fake";
 
 const witnessed: ReviewSidecar = {
@@ -182,10 +183,10 @@ describe("the record and the candidate it describes (#75)", () => {
     // ART_STYLE) and WHICH parameter bag drew the bytes. If it ever named
     // something other than the file that was reviewed, the record would point at
     // a candidate that never existed.
-    const stem = reviewStem("Warriors", card, provider);
+    const stem = reviewStem("Warriors", cardSubject(card), provider);
     const sidecar = buildSidecar(provider, { bytes: new Uint8Array([1]), format: "png" });
     const rec = toProvenance(sidecar, stem, true);
-    expect(`${rec.reviewKey}.png`).toBe(reviewFileName("Warriors", card, provider));
+    expect(`${rec.reviewKey}.png`).toBe(reviewFileName("Warriors", cardSubject(card), provider));
   });
 
   it("survives the trip the sidecar actually makes: buildSidecar -> JSON -> parseSidecar", () => {

--- a/tests/review-files.test.ts
+++ b/tests/review-files.test.ts
@@ -6,9 +6,11 @@ import {
   resolveProviderId,
   sidecarFileName,
   unknownProviders,
+  missingCoverReviews,
   type AuditTheme,
 } from "@/features/pool/review-files";
 import { promptHash } from "@/features/pool/keys";
+import { cardSubject, coverSubject } from "@/features/pool/prompt";
 import { cardKey } from "@/features/pool/publish-plan";
 import { fakeProvider } from "@/features/pool/providers/fake";
 import {
@@ -23,12 +25,14 @@ import {
 } from "@/features/pool/providers";
 
 const card = { name: "Longbowman", imagePrompt: "an English longbowman" };
+const subject = cardSubject(card);
+const COVER = "a quiet stone fortress courtyard";
 
 describe("reviewFileName (#63, #67)", () => {
   it("is theme-card-promptHash-provider-paramHash, with the provider's own extension", () => {
     const p = fakeProvider({ id: "cloudflare-sdxl", params: { steps: 20 } });
-    expect(reviewFileName("Warriors", card, p)).toBe(
-      `warriors-longbowman-${promptHash(card)}-cloudflare-sdxl-${paramHash({ steps: 20 })}.png`,
+    expect(reviewFileName("Warriors", subject, p)).toBe(
+      `warriors-longbowman-${promptHash(subject.prompt)}-cloudflare-sdxl-${paramHash({ steps: 20 })}.png`,
     );
   });
 
@@ -37,39 +41,39 @@ describe("reviewFileName (#63, #67)", () => {
     // disk and would make the contact sheet depend on a browser ignoring it.
     const png = fakeProvider({ id: "a" });
     const jpg = { ...fakeProvider({ id: "b" }), format: "jpeg" as const };
-    expect(reviewFileName("Warriors", card, png).endsWith(".png")).toBe(true);
-    expect(reviewFileName("Warriors", card, jpg).endsWith(".jpg")).toBe(true);
+    expect(reviewFileName("Warriors", subject, png).endsWith(".png")).toBe(true);
+    expect(reviewFileName("Warriors", subject, jpg).endsWith(".jpg")).toBe(true);
   });
 
   it("changes when a provider's params drift — D4's hole, closed one level down", () => {
     // Bumping SDXL's steps changes what the card renders as just as completely
     // as editing ART_STYLE does, and appears in no prompt. Without this, every
     // review file would still match.
-    const before = reviewFileName("Warriors", card, fakeProvider({ id: "cf", params: { steps: 20 } }));
-    const after = reviewFileName("Warriors", card, fakeProvider({ id: "cf", params: { steps: 30 } }));
+    const before = reviewFileName("Warriors", subject, fakeProvider({ id: "cf", params: { steps: 20 } }));
+    const after = reviewFileName("Warriors", subject, fakeProvider({ id: "cf", params: { steps: 30 } }));
     expect(after).not.toBe(before);
   });
 
   it("does NOT change when params are merely reordered", () => {
-    const a = reviewFileName("Warriors", card, fakeProvider({ id: "cf", params: { steps: 20, seed: 42 } }));
-    const b = reviewFileName("Warriors", card, fakeProvider({ id: "cf", params: { seed: 42, steps: 20 } }));
+    const a = reviewFileName("Warriors", subject, fakeProvider({ id: "cf", params: { steps: 20, seed: 42 } }));
+    const b = reviewFileName("Warriors", subject, fakeProvider({ id: "cf", params: { seed: 42, steps: 20 } }));
     expect(a).toBe(b);
   });
 
   it("keeps one promptHash across providers, so a bake-off row is groupable", () => {
     // #63 turned review into a subject x provider grid; a grid needs a key that
     // groups a row. Folding the provider into promptHash would destroy it.
-    const a = reviewFileName("Warriors", card, fakeProvider({ id: "alpha" }));
-    const b = reviewFileName("Warriors", card, fakeProvider({ id: "beta" }));
-    expect(a).toContain(promptHash(card));
-    expect(b).toContain(promptHash(card));
+    const a = reviewFileName("Warriors", subject, fakeProvider({ id: "alpha" }));
+    const b = reviewFileName("Warriors", subject, fakeProvider({ id: "beta" }));
+    expect(a).toContain(promptHash(subject.prompt));
+    expect(b).toContain(promptHash(subject.prompt));
     expect(a).not.toBe(b);
   });
 
   it("puts the sidecar on the same stem, as .json", () => {
     const p = fakeProvider({ id: "alpha" });
-    expect(sidecarFileName("Warriors", card, p)).toBe(
-      reviewFileName("Warriors", card, p).replace(/\.png$/, ".json"),
+    expect(sidecarFileName("Warriors", subject, p)).toBe(
+      reviewFileName("Warriors", subject, p).replace(/\.png$/, ".json"),
     );
   });
 });
@@ -99,6 +103,7 @@ describe("the FR9 audit (#67 — what --sync refuses, and why)", () => {
 
   const theme = (over: Partial<AuditTheme> = {}): AuditTheme => ({
     name: "Warriors",
+    coverPrompt: COVER,
     cards: [card, { name: "Halberdier", imagePrompt: "a halberdier" }],
     ...over,
   });
@@ -130,11 +135,15 @@ describe("the FR9 audit (#67 — what --sync refuses, and why)", () => {
   it("refuses after a provider switch — the mechanism, not 'nobody will do that'", () => {
     // Reviewed under alpha, then the theme is repointed at beta. The resolved
     // filename changes, so nothing on disk matches and the insert is refused.
-    const onDisk = new Set([reviewFileName("Warriors", card, alpha)]);
+    const onDisk = new Set([reviewFileName("Warriors", subject, alpha)]);
     const beta = fakeProvider({ id: "beta" });
     const twoProviders = (id: string) => ({ alpha, beta })[id as "alpha" | "beta"];
     const planned = new Set([cardKey("Warriors", "Longbowman")]);
-    const oneCard = { name: "Warriors", cards: [card] };
+    const oneCard = {
+      name: "Warriors",
+      coverPrompt: COVER,
+      cards: [card],
+    };
 
     expect(
       missingReviews([{ ...oneCard, provider: "alpha" }], planned, twoProviders, (f) => onDisk.has(f)),
@@ -149,9 +158,14 @@ describe("the FR9 audit (#67 — what --sync refuses, and why)", () => {
     // came from 20 steps, the adapter now asks for 30.
     const before = fakeProvider({ id: "alpha", params: { steps: 20 } });
     const after = fakeProvider({ id: "alpha", params: { steps: 30 } });
-    const onDisk = new Set([reviewFileName("Warriors", card, before)]);
+    const onDisk = new Set([reviewFileName("Warriors", subject, before)]);
     const planned = new Set([cardKey("Warriors", "Longbowman")]);
-    const oneCard = { name: "Warriors", provider: "alpha", cards: [card] };
+    const oneCard = {
+      name: "Warriors",
+      provider: "alpha",
+      coverPrompt: COVER,
+      cards: [card],
+    };
 
     expect(missingReviews([oneCard], planned, () => before, (f) => onDisk.has(f))).toEqual([]);
     expect(missingReviews([oneCard], planned, () => after, (f) => onDisk.has(f))).toHaveLength(1);
@@ -165,7 +179,7 @@ describe("the FR9 audit (#67 — what --sync refuses, and why)", () => {
 
   it("honours a per-card override over the theme default", () => {
     const found = missingReviews(
-      [{ name: "Warriors", provider: "alpha", cards: [{ ...card, provider: "ghost" }] }],
+      [{ name: "Warriors", provider: "alpha", coverPrompt: COVER, cards: [{ ...card, provider: "ghost" }] }],
       new Set([cardKey("Warriors", "Longbowman")]),
       lookup,
       everythingOnDisk,
@@ -173,11 +187,74 @@ describe("the FR9 audit (#67 — what --sync refuses, and why)", () => {
     expect(found[0].reason).toContain('unknown provider "ghost"');
   });
 
+  // ── The #122 hard stop: no cover, no publish ───────────────────────────────
+  describe("cover reviews (#122)", () => {
+    const allCovers = new Set(["Warriors"]);
+
+    it("refuses a theme whose cover has no reviewed image, naming it as Cover", () => {
+      const found = missingCoverReviews(
+        [theme({ provider: "alpha" })],
+        allCovers,
+        lookup,
+        nothingOnDisk,
+      );
+      expect(found).toEqual([
+        { theme: "Warriors", card: "Cover", reason: "no reviewed image from alpha" },
+      ]);
+    });
+
+    it("refuses a theme whose bake-off was never judged", () => {
+      const found = missingCoverReviews([theme()], allCovers, lookup, everythingOnDisk);
+      expect(found[0].reason).toContain("no provider chosen");
+    });
+
+    // The guarantee is that a theme cannot reach a child unrecognisable. A cover
+    // already published is not re-demanded, exactly as an already-published card
+    // is not — the audit is publish-scoped, not a back-fill of seed/review/.
+    it("ignores a theme whose cover is already published", () => {
+      expect(
+        missingCoverReviews([theme({ provider: "alpha" })], new Set(), lookup, nothingOnDisk),
+      ).toEqual([]);
+    });
+
+    it("accepts a theme whose cover candidate is on disk", () => {
+      const alphaTheme = theme({ provider: "alpha" });
+      const onDisk = new Set([
+        reviewFileName("Warriors", coverSubject(alphaTheme), alpha),
+      ]);
+      expect(
+        missingCoverReviews([alphaTheme], allCovers, lookup, (f) => onDisk.has(f)),
+      ).toEqual([]);
+    });
+
+    // A cover is named by the SAME machinery a card is, which is the only
+    // agreement FR9 needs between the two audits — and the reason a cover cannot
+    // be satisfied by a card's file that happens to sit in the same folder.
+    it("is not satisfied by a card's reviewed image", () => {
+      const alphaTheme = theme({ provider: "alpha" });
+      const onDisk = new Set([reviewFileName("Warriors", subject, alpha)]);
+      expect(
+        missingCoverReviews([alphaTheme], allCovers, lookup, (f) => onDisk.has(f)),
+      ).toHaveLength(1);
+    });
+
+    // Editing the authored place-prompt moves the filename, same as D4 does for
+    // a card: a cover reviewed against words that no longer exist is stale.
+    it("refuses after the coverPrompt is edited", () => {
+      const before = theme({ provider: "alpha" });
+      const onDisk = new Set([reviewFileName("Warriors", coverSubject(before), alpha)]);
+      const after = theme({ provider: "alpha", coverPrompt: "a different courtyard" });
+      expect(
+        missingCoverReviews([after], allCovers, lookup, (f) => onDisk.has(f)),
+      ).toHaveLength(1);
+    });
+  });
+
   it("reports an unregistered provider separately from a missing image", () => {
     // Different mistakes, different fixes: a typo is not solved by re-running
     // --review, and saying "no reviewed image" would send the author to do just
     // that.
-    const themes = [{ name: "Warriors", provider: "ghost", cards: [card] }];
+    const themes = [{ name: "Warriors", provider: "ghost", coverPrompt: COVER, cards: [card] }];
     const planned = new Set([cardKey("Warriors", "Longbowman")]);
     expect(unknownProviders(themes, planned, lookup)).toEqual([
       { theme: "Warriors", card: "Longbowman", providerId: "ghost" },

--- a/tests/seed-rules.pbt.test.ts
+++ b/tests/seed-rules.pbt.test.ts
@@ -30,7 +30,7 @@ type Card = {
   imagePrompt: string;
   sourceUrl: string;
 };
-type Theme = { name: string; cards: Card[] };
+type Theme = { name: string; coverPrompt: string; cards: Card[] };
 type File = { themes: Theme[] };
 
 const clone = (f: File): File => JSON.parse(JSON.stringify(f)) as File;
@@ -62,6 +62,9 @@ const themeArb = (i: number) =>
     )
     .map(([rarities, texts]) => ({
       name: `Theme ${i}`,
+      // Required since #122 — a theme with no cover prompt is not a valid theme,
+      // because the picker has no landmark to draw its tile with.
+      coverPrompt: `a wide open place ${i}`,
       cards: rarities.map((rarity, j) => ({
         name: `t${i}c${j}`,
         rarity: rarity as string,


### PR DESCRIPTION
PR 1 of 2 for #122 — **covers exist**. Nothing the child sees changes here; the picker still
borrows the rarest owned card. PR2 flips the UI over to these covers and deletes the borrowing.

## Why a theme needs its own art

The picker fronts each tile with the child's **rarest owned card**. That is a trophy, not a
landmark: it changes whenever they pull something better, and a category they have not started
shows a neutral 🪐. So the newest theme — the one they most want to find, and there is a new one
every runbook — is the least recognisable tile on a screen built for a child who navigates by
picture rather than by reading names.

Full reasoning, including the three options that lost, is on
[the ticket](https://github.com/nywleswoey/kids-collection/issues/122#issuecomment-5463206525).

## What lands

- **`themes.cover_url`** (migration `0010`), nullable for exactly this one migration.
- **`coverPrompt` required on every theme**, with all 16 backfilled. Required unlike `provider`,
  and the difference is which runbook step writes it: `provider` records a bake-off pick that
  cannot exist while a theme is being authored; `coverPrompt` is authored text written at Step 4
  beside 30 `imagePrompt`s.
- **`COVER_STYLE`** beside `ART_STYLE` — a scenery style, so a cover cannot be mistaken for a card
  you could own.
- **The naming stack takes a `Subject`** — a named, fully-styled prompt — instead of a `SeedCard`.
  It used to call `buildPrompt` itself, hard-wiring "the card style" into `promptHash`; a cover
  needs a different style, and threading a style argument would put that decision in four
  signatures. Card hashes are unchanged, pinned by value in `keys.test.ts` against `origin/main`'s
  `ART_STYLE`, so **no published card's review file moves and no re-review is forced**.
- **The hard stop: no cover, no publish.** `missingCoverReviews` refuses a theme whose cover has no
  reviewed image, reported alongside the card audit and refused with it.
- **`pnpm contact-sheet --covers`** — every theme's cover on one page.
- **All 16 covers published** to production Blob and `cover_url`, from reviewed bytes (`reused: 16`,
  nothing generated at publish time).

## A cover depicts a place, never a specimen

Card art on a category's front door leaks what `CardSlot` keeps behind `❔` until it is earned
(U5-Q5). Every prompt was checked against **every** theme's card names, not just its own — *Fern* is
a Special Plants card, *Will-o'-the-Wisp* is Spooky Legends', and nearly every obvious space place
(*The Moon*, *Saturn*, *Orion Nebula*, *Telescope*, *Observatory*) is an Outer Space card, which is
why that one is a launch pad. Nothing names an excluded subject in order to forbid it: #81 measured
that "no border" is a *border cue*, and the same holds for any depictable noun.

## What the bake-off found, which the card measurements could not

The picks are **cloudflare-sdxl for fourteen**, **pollinations for Mythic Creatures and Deep Sea
Creatures**. That reverses the incumbent — all ~360 published cards came from pollinations — and the
reason is specific to *places*, the one prompt shape this repo had no measurements for:

- **pollinations drifts photoreal on landscapes**, which #77 rules out. Its Famous People library and
  Ocean Machines harbour read as photographs.
- **its valleys collapse into each other.** Its Dinosaurs, Country, Artillery and Warriors are four
  green valleys under blue sky — the exact failure covers exist to prevent, and invisible on
  anything but a single page. That is what `--covers` is for.

It still won two rows outright: cloudflare missed Mythic Creatures' archway entirely, and put a
water *surface* in the Deep Sea trench so it reads as a cavern.

**Flying Machines was re-prompted, not re-rolled.** "Windsock" drew a hot-air balloon, and *Hot Air
Balloon* is a card in that theme — precisely the specimen leak the rule exists to stop. The runway
carries the airfield without naming anything collectable.

## Blast radius

`--publish`, not `--sync`: 16 covers inserted, **480 cards skipped, 0 updated, 0 pruned**. Covers go
to their own `covers/` blob namespace — a card named "Cover" would otherwise slug onto
`cards/<theme>-cover` and publish over a theme's cover with no error at either end. New namespace,
so independent of #91.

## Follow-up in PR2

`CategoryPicker` and `PlaceBar` read the cover, `category-cover.ts` and 🪐 are deleted, and the
column tightens to NOT NULL.

Part of [#122](https://github.com/nywleswoey/kids-collection/issues/122), on map
[#106](https://github.com/nywleswoey/kids-collection/issues/106).

https://claude.ai/code/session_016x8aFuw1mfKgEYwbn1XJSg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated cover artwork for every theme.
  * Cover images are generated, reviewed, published, and stored separately from card artwork.
  * Added a cross-theme cover contact sheet with `--covers`.
  * Added cover prompts and image-provider settings to theme data.

* **Bug Fixes**
  * Publishing now prevents themes from being released without reviewed cover art.

* **Documentation**
  * Updated the new-theme runbook with cover creation, review, and backfill guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->