### PR TITLE
feat(seed): add the Rocks and Gems theme

### DIFF
--- a/seed/cards.json
+++ b/seed/cards.json
@@ -3457,6 +3457,221 @@
         }
       ],
       "provider": "cloudflare-sdxl"
+    },
+    {
+      "name": "Rocks and Gems",
+      "cards": [
+        {
+          "name": "Diamond",
+          "rarity": "legendary",
+          "eduText": "Diamond is the hardest natural material on Earth. Only another diamond can scratch it.",
+          "imagePrompt": "a single clear colourless diamond gemstone cut with many flat sparkling facets and a pointed base, on green grass, seen from the side, its whole outline visible against the grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Diamond"
+        },
+        {
+          "name": "Giant's Causeway",
+          "rarity": "legendary",
+          "eduText": "About 40,000 stone columns formed here when a thick lava flow cooled and cracked into six-sided shapes.",
+          "imagePrompt": "a rocky headland made of thousands of tall six-sided stone columns packed tightly together, stepping down into calm blue sea under a clear sky, seen from a distance so the whole formation, the water and the sky are all in the picture",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Giant%27s_Causeway"
+        },
+        {
+          "name": "Crystal Cave",
+          "rarity": "epic",
+          "eduText": "In Mexico's Cave of the Crystals, some crystals grew longer than a bus over half a million years.",
+          "imagePrompt": "the inside of a rocky cave with tall pointed pale purple crystals growing out of its floor and walls",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Cave_of_the_Crystals"
+        },
+        {
+          "name": "Geode",
+          "rarity": "epic",
+          "eduText": "A geode looks like a plain round rock until you crack it open and find crystals lining the inside.",
+          "imagePrompt": "a single hollow round geode rock split open to show the purple crystal points lining its inside, on green grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Geode"
+        },
+        {
+          "name": "Opal",
+          "rarity": "epic",
+          "eduText": "Opal holds water inside it, and tiny stacked spheres split the light into flashes of rainbow colour.",
+          "imagePrompt": "a single smooth rounded opal gemstone with rainbow colours flashing inside its polished top, on green grass, seen from the side, its whole outline visible against the grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Opal"
+        },
+        {
+          "name": "Stone Arch",
+          "rarity": "epic",
+          "eduText": "Wind and rain wear away the softer rock underneath, leaving a bridge of hard stone standing above.",
+          "imagePrompt": "a natural orange stone arch standing on dry desert ground, seen from one side so both of its rock legs and the thick span of rock above them are in the picture, low desert hills and blue sky behind it",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Natural_arch"
+        },
+        {
+          "name": "Gold Bar",
+          "rarity": "epic",
+          "eduText": "Gold never rusts or tarnishes, so gold buried in ancient tombs still shines when it is dug up.",
+          "imagePrompt": "a single shiny gold gold metal ingot with flat sides, rounded corners, lying on green grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Gold_bar"
+        },
+        {
+          "name": "Topaz",
+          "rarity": "rare",
+          "eduText": "Topaz is one of the hardest gemstones. It can scratch steel and glass without being marked itself.",
+          "imagePrompt": "a single golden-yellow topaz gemstone cut with many flat sparkling facets and a pointed base, on green grass, seen from the side, its whole outline visible against the grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Topaz"
+        },
+        {
+          "name": "Onyx",
+          "rarity": "rare",
+          "eduText": "Onyx grows in flat bands of black and white, and carvers cut down through them to make tiny pictures.",
+          "imagePrompt": "a single glossy black onyx gemstone cut with many flat sparkling facets and a pointed base, on green grass, seen from the side, its whole outline visible against the grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Onyx"
+        },
+        {
+          "name": "Marble",
+          "rarity": "rare",
+          "eduText": "Marble starts as limestone, then heat and pressure deep underground squeeze it into smooth hard stone.",
+          "imagePrompt": "a single flat oval slab of polished white marble lying alone on green grass seen from above, its whole rounded edge visible, bold dark grey veins running across its smooth face",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Marble"
+        },
+        {
+          "name": "Rose Quartz",
+          "rarity": "rare",
+          "eduText": "Rose quartz gets its soft pink colour from tiny threads of another mineral tangled up inside it.",
+          "imagePrompt": "a single grey rock with a group of pointed pale pink rose quartz crystals growing out of the top of it, on green grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Rose_quartz"
+        },
+        {
+          "name": "Bronze Bar",
+          "rarity": "rare",
+          "eduText": "Bronze is copper mixed with tin. It was so useful that a whole age of history is named after it.",
+          "imagePrompt": "a single bronze metal ingot with a warm reddish-brown metallic surface, flat sides and rounded corners, lying alone on green grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Bronze"
+        },
+        {
+          "name": "Lava Tube",
+          "rarity": "rare",
+          "eduText": "When a river of lava cools hard on the outside and drains away inside, it leaves a long hollow tunnel.",
+          "imagePrompt": "the inside of a long round lava tube cave with smooth dark rock walls curving all around it, a bright daylight opening at the far end, seen from inside the tunnel",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Lava_tube"
+        },
+        {
+          "name": "Hoodoo",
+          "rarity": "rare",
+          "eduText": "A hard cap of rock shelters the softer stone beneath it, leaving a thin tower standing on its own.",
+          "imagePrompt": "a single tall thin rock spire with a wide flat capstone balanced on top, standing alone on dry desert ground under a clear blue sky, seen from a distance so the whole spire and the ground it stands on are in the picture",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Hoodoo_(geology)"
+        },
+        {
+          "name": "Slot Canyon",
+          "rarity": "rare",
+          "eduText": "Flash floods carve slot canyons so narrow you can touch both walls, and so deep the sky is a stripe.",
+          "imagePrompt": "the inside of a narrow slot canyon with tall smooth wavy orange rock walls close on both sides, a thin strip of blue sky far above and sunlight falling to the sandy floor",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Slot_canyon"
+        },
+        {
+          "name": "Granite",
+          "rarity": "common",
+          "eduText": "Granite cools slowly deep underground, which gives its crystals time to grow big enough to see.",
+          "imagePrompt": "a single large grey granite boulder with a finely speckled grainy surface, resting on short green grass, seen from the side with its whole rounded outline visible against a plain background",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Granite"
+        },
+        {
+          "name": "Silver Bar",
+          "rarity": "common",
+          "eduText": "Silver carries electricity better than any other metal, so it hides inside phones and computers.",
+          "imagePrompt": "a single shiny silver silver metal ingot with flat sides, sloping bevelled edges and rounded corners, lying on green grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Silver"
+        },
+        {
+          "name": "Copper Bar",
+          "rarity": "common",
+          "eduText": "Copper slowly turns green in the weather, which is why the Statue of Liberty is not copper-coloured.",
+          "imagePrompt": "a single shiny orange-brown copper metal ingot with flat sides, rounded corners, lying on green grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Copper"
+        },
+        {
+          "name": "Amethyst",
+          "rarity": "common",
+          "eduText": "Amethyst is purple quartz. Iron trapped inside the crystal is what gives it the colour.",
+          "imagePrompt": "a single grey rock with a group of tall pointed purple amethyst crystals growing out of the top of it, on green grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Amethyst"
+        },
+        {
+          "name": "Pyrite",
+          "rarity": "common",
+          "eduText": "Pyrite is nicknamed fool's gold. Its shiny golden cubes fooled miners who were hunting for real gold.",
+          "imagePrompt": "one grey rock lying alone on green grass, a few sharp shiny golden cubes set into its top surface, its whole rounded outline visible against the grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Pyrite"
+        },
+        {
+          "name": "Ruby",
+          "rarity": "common",
+          "eduText": "Ruby and sapphire are the same mineral. A trace of chromium is what turns one of them red.",
+          "imagePrompt": "a single deep red ruby gemstone cut with many flat sparkling facets and a pointed base, on green grass, seen from the side, its whole outline visible against the grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Ruby"
+        },
+        {
+          "name": "Emerald",
+          "rarity": "common",
+          "eduText": "Almost every emerald has tiny cracks and specks inside it, which jewellers call its garden.",
+          "imagePrompt": "a single deep green emerald gemstone cut with many flat sparkling facets and a pointed base, on green grass, seen from the side, its whole outline visible against the grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Emerald"
+        },
+        {
+          "name": "Sapphire",
+          "rarity": "common",
+          "eduText": "Sapphires are not only blue. The very same mineral also grows pink, yellow, green and orange.",
+          "imagePrompt": "a single deep blue sapphire gemstone cut with many flat sparkling facets and a pointed base, on green grass, seen from the side, its whole outline visible against the grass",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Sapphire"
+        },
+        {
+          "name": "Agate",
+          "rarity": "common",
+          "eduText": "An agate's stripes are layers that filled a hollow in the rock slowly, one band of colour at a time.",
+          "imagePrompt": "a single round polished agate slab lying flat on green grass seen from above, its whole rounded edge visible, wavy orange and white bands across its smooth face",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Agate"
+        },
+        {
+          "name": "Turquoise",
+          "rarity": "common",
+          "eduText": "Turquoise forms in deserts, where water trickles through copper-rich rock and dries in the cracks.",
+          "imagePrompt": "a single flat slab of polished turquoise stone lying on green grass seen from above, its whole rounded edge visible, a smooth sky-blue face crossed by thin dark brown veins",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Turquoise"
+        },
+        {
+          "name": "Limestone Cave",
+          "rarity": "common",
+          "eduText": "Dripping water leaves a tiny ring of stone behind. A stalactite grows about a centimetre a century.",
+          "imagePrompt": "the inside of a limestone cave with pale stone icicles hanging from its roof and matching stone spikes rising from its floor, softly lit, the floor and the roof both in the picture",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Solutional_cave"
+        },
+        {
+          "name": "Gold Mine",
+          "rarity": "common",
+          "eduText": "The deepest gold mines reach four kilometres down, so far below the surface that the rock is warm.",
+          "imagePrompt": "a rock wall at the far end of a short underground mine tunnel, seen from inside the tunnel with its dark walls and roof framing the view on all sides, wooden support beams and a rail track on the tunnel floor leading up to it, a bright seam of gold ore across the cut stone",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Gold_mining"
+        },
+        {
+          "name": "Quarry",
+          "rarity": "common",
+          "eduText": "Quarries cut stone in giant blocks. The marble for many famous statues came out of one in Italy.",
+          "imagePrompt": "a wide empty stone quarry pit with bare stepped ledges of pale rock cut into its walls going down to a flat stone floor, seen from the rim so the whole pit, its far wall and the sky above are all in the picture",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Quarry"
+        },
+        {
+          "name": "River Canyon",
+          "rarity": "common",
+          "eduText": "A river cuts down a little every year. Given millions of years it can saw a canyon a mile deep.",
+          "imagePrompt": "a tall canyon wall of layered orange and red rock rising above a blue river winding along the canyon floor, seen from the canyon floor in daylight, its horizontal rock layers clearly visible from top to bottom",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Canyon"
+        },
+        {
+          "name": "Sea Cliff",
+          "rarity": "common",
+          "eduText": "Waves undercut the bottom of a cliff until the rock above topples, so the coastline creeps inland.",
+          "imagePrompt": "a single tall sea cliff standing at the edge of calm blue water under a clear sky, its rough face striped with level layers of cream and dark grey stone, seen from a distance so the whole cliff, the water below it and the sky above it are all in the picture",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Cliffed_coast"
+        }
+      ]
     }
   ]
 }

--- a/seed/cards.json
+++ b/seed/cards.json
@@ -3494,7 +3494,8 @@
           "rarity": "epic",
           "eduText": "Opal holds water inside it, and tiny stacked spheres split the light into flashes of rainbow colour.",
           "imagePrompt": "a single smooth rounded opal gemstone with rainbow colours flashing inside its polished top, on green grass, seen from the side, its whole outline visible against the grass",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Opal"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Opal",
+          "provider": "pollinations"
         },
         {
           "name": "Stone Arch",
@@ -3508,7 +3509,8 @@
           "rarity": "epic",
           "eduText": "Gold never rusts or tarnishes, so gold buried in ancient tombs still shines when it is dug up.",
           "imagePrompt": "a single shiny gold gold metal ingot with flat sides, rounded corners, lying on green grass",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Gold_bar"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Gold_bar",
+          "provider": "pollinations"
         },
         {
           "name": "Topaz",
@@ -3634,7 +3636,8 @@
           "rarity": "common",
           "eduText": "Turquoise forms in deserts, where water trickles through copper-rich rock and dries in the cracks.",
           "imagePrompt": "a single flat slab of polished turquoise stone lying on green grass seen from above, its whole rounded edge visible, a smooth sky-blue face crossed by thin dark brown veins",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Turquoise"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Turquoise",
+          "provider": "pollinations"
         },
         {
           "name": "Limestone Cave",
@@ -3671,7 +3674,8 @@
           "imagePrompt": "a single tall sea cliff standing at the edge of calm blue water under a clear sky, its rough face striped with level layers of cream and dark grey stone, seen from a distance so the whole cliff, the water below it and the sky above it are all in the picture",
           "sourceUrl": "https://en.wikipedia.org/wiki/Cliffed_coast"
         }
-      ]
+      ],
+      "provider": "cloudflare-sdxl"
     }
   ]
 }

--- a/seed/provenance.json
+++ b/seed/provenance.json
@@ -1161,6 +1161,395 @@
         "reviewKey": "outer-space-venus-5ef3acea-pollinations-dff2",
         "reviewed": true
       }
+    },
+    "Rocks and Gems": {
+      "Agate": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-agate-90f11d4b-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Amethyst": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-amethyst-87d5dce2-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Bronze Bar": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-bronze-bar-596f263c-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Copper Bar": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-copper-bar-24c2a7f6-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Crystal Cave": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-crystal-cave-1cd03bda-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Diamond": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-diamond-68b7f1fc-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Emerald": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-emerald-60d50797-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Geode": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-geode-f79008d1-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Giant's Causeway": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-giant-s-causeway-da3fbdca-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Gold Bar": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "rocks-and-gems-gold-bar-868fc9c0-pollinations-dff2",
+        "reviewed": true
+      },
+      "Gold Mine": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-gold-mine-deef4a49-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Granite": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-granite-1ff5330e-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Hoodoo": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-hoodoo-d54a3755-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Lava Tube": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-lava-tube-5af18d3f-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Limestone Cave": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-limestone-cave-80a84267-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Marble": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-marble-a1d49f6d-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Onyx": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-onyx-e354194b-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Opal": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "rocks-and-gems-opal-180ba32c-pollinations-dff2",
+        "reviewed": true
+      },
+      "Pyrite": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-pyrite-af367691-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Quarry": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-quarry-b7a79339-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "River Canyon": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-river-canyon-ba3593d7-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Rose Quartz": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-rose-quartz-5519f617-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Ruby": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-ruby-cab2991f-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Sapphire": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-sapphire-32c16cea-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Sea Cliff": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-sea-cliff-aefa5eb1-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Silver Bar": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-silver-bar-16a8afd1-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Slot Canyon": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-slot-canyon-4d9c1ffc-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Stone Arch": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-stone-arch-bdab88ad-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Topaz": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "rocks-and-gems-topaz-4ee6c409-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Turquoise": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "rocks-and-gems-turquoise-52ce5950-pollinations-dff2",
+        "reviewed": true
+      }
     }
   }
 }


### PR DESCRIPTION
Adds **Rocks and Gems**, the pool's 17th theme: 30 cards, published and live.

The subject list is CHECKPOINT 1 from [#118](https://github.com/nywleswoey/kids-collection/issues/118), as amended twice — [#131](https://github.com/nywleswoey/kids-collection/issues/131) swapped `Garnet` for `Onyx` after screening found the pair drew as one card in two shades, and [#134](https://github.com/nywleswoey/kids-collection/issues/134) took metal from two cards to five and promoted `Gold Bar` to epic.

**Legendary** `Diamond`, `Giant's Causeway` · **Epic** `Crystal Cave`, `Geode`, `Opal`, `Stone Arch`, `Gold Bar` · **Rare** `Topaz`, `Onyx`, `Marble`, `Rose Quartz`, `Bronze Bar`, `Lava Tube`, `Hoodoo`, `Slot Canyon` · **Common** `Granite`, `Silver Bar`, `Copper Bar`, `Amethyst`, `Pyrite`, `Ruby`, `Emerald`, `Sapphire`, `Agate`, `Turquoise`, `Limestone Cave`, `Gold Mine`, `Quarry`, `River Canyon`, `Sea Cliff`

**The bake-off:** 60 candidates on two lanes, judged at CHECKPOINT 2. **27 cloudflare-sdxl, 3 pollinations** (`Opal`, `Turquoise`, `Gold Bar`) — Pollinations drew this theme semi-real almost everywhere, so it won only where Cloudflare misread the subject outright.

**One re-roll and one re-prompt round**, both from failures the map had already measured and named:

- `Opal` — Cloudflare returned a decorative frame ([#81](https://github.com/nywleswoey/kids-collection/issues/81)); re-rolled, frame gone.
- `Marble` — five stones on one lane, a blank white disc on the other. Re-prompted to a single slab with bold veins.
- `Bronze Bar` — Cloudflare read *golden-brown* as **gold** and drew a gold ingot, which is exactly the `Bronze`/`Gold` near-repeat #134 flagged. Re-worded to a reddish-brown metallic surface; it now separates.
- `Pyrite` — a wallpaper of rocks on one lane, a holey bread roll on the other. Both recovered.

Every `imagePrompt` in the theme carries a rule the map's prototypes measured rather than a guess: `ingot` never `bar` (`bar` drew a handrail on legs — #134), silver's bevel named, objects name their edge ([#120](https://github.com/nywleswoey/kids-collection/issues/120)), places assert their container and never their edge ([#126](https://github.com/nywleswoey/kids-collection/issues/126)), no metal given a hue adjective that is not its own, and no rock place given an architecture noun.

**Verification:** schema clean; all 510 `sourceUrl`s return 200; Blob at 8.4% before publishing, well inside budget; `--sync` inserted 30, failed 0, pruned 0; `--check-images` weighed all 510 published images and found no blank frames; `provenance.json` has 30 entries, all `reviewed: true`.

**Two art overlaps recorded rather than acted on**, both raised at CHECKPOINT 2: `Sea Cliff` sits close to Country's `Cliffs of Moher (Ireland)`, and `Granite` is a plain grey boulder against Outer Space's `Asteroid`, "a single lumpy grey potato-shaped space rock" — #131 had already found Granite's identity thin, and the lump family measured at zero across four names and three tickets.

This is the first of the two themes the map [#113](https://github.com/nywleswoey/kids-collection/issues/113) was charted for. `Trees` ([#119](https://github.com/nywleswoey/kids-collection/issues/119)) is also CHECKPOINT 1 clean and ready for its own run.

https://claude.ai/code/session_01EcdhZLhe2zq2NvqSFLqfJs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the “Rocks and Gems” theme with 30 collectible cards.
  * Introduced educational content covering rocks, minerals, gemstones, and precious materials.
  * Added card artwork and source references for the new collection.
  * Marked the new card content as reviewed and ready for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->