### PR TITLE
Trees: 30 street, storybook and record trees (#119, #124)

### DIFF
--- a/seed/cards.json
+++ b/seed/cards.json
@@ -3748,7 +3748,8 @@
           "rarity": "rare",
           "eduText": "Ginkgos have grown on Earth for over 200 million years, so dinosaurs walked under trees like this.",
           "imagePrompt": "a single short ginkgo branch with small fan-shaped leaves turned golden yellow, its whole length visible from end to end, with nothing behind it but plain blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Ginkgo_biloba"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Ginkgo_biloba",
+          "provider": "pollinations"
         },
         {
           "name": "Holly",
@@ -3769,7 +3770,8 @@
           "rarity": "rare",
           "eduText": "The shiny brown conker inside the spiky case is a seed, not a nut, and it is too bitter to eat.",
           "imagePrompt": "a single short horse chestnut branch with a spiky green case split open to show two shiny brown conkers inside, its whole length visible from end to end, with nothing behind it but plain blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Aesculus_hippocastanum"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Aesculus_hippocastanum",
+          "provider": "pollinations"
         },
         {
           "name": "Olive Tree",
@@ -3890,7 +3892,8 @@
           "imagePrompt": "a single short angsana branch with a few small green leaflets and two clusters of tiny bright yellow flowers, the bare brown branch clearly visible along its whole length, with plain blue sky all around it",
           "sourceUrl": "https://en.wikipedia.org/wiki/Pterocarpus_indicus"
         }
-      ]
+      ],
+      "provider": "cloudflare-sdxl"
     }
   ]
 }

--- a/seed/cards.json
+++ b/seed/cards.json
@@ -3725,7 +3725,7 @@
         {
           "name": "Cannonball Tree",
           "rarity": "epic",
-          "eduText": "Its heavy round fruit grow straight out of the trunk instead of the branches, and they smell sweet.",
+          "eduText": "Its heavy round fruit grow straight out of the trunk instead of the branches, and when ripe, they release a repugnant odor—unlike its fragrant flowers.",
           "imagePrompt": "a single tree with one thick straight trunk, dozens of large round brown fruit growing in tight clusters directly on the trunk bark all the way from the ground up to the branches, green leaves above, on green grass under a blue sky",
           "sourceUrl": "https://en.wikipedia.org/wiki/Couroupita_guianensis"
         },

--- a/seed/cards.json
+++ b/seed/cards.json
@@ -3723,11 +3723,11 @@
           "sourceUrl": "https://en.wikipedia.org/wiki/Picea_abies"
         },
         {
-          "name": "Monkey Puzzle Tree",
+          "name": "Cannonball Tree",
           "rarity": "epic",
-          "eduText": "Its leaves are so sharp and spiky that people joked even a monkey would be puzzled climbing it.",
-          "imagePrompt": "a single monkey puzzle tree with a bare straight trunk and stiff branches covered in sharp overlapping dark green triangular scales, on green grass under a blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Araucaria_araucana"
+          "eduText": "Its heavy round fruit grow straight out of the trunk instead of the branches, and they smell sweet.",
+          "imagePrompt": "a single tree with one thick straight trunk, dozens of large round brown fruit growing in tight clusters directly on the trunk bark all the way from the ground up to the branches, green leaves above, on green grass under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Couroupita_guianensis"
         },
         {
           "name": "Oak",
@@ -3770,8 +3770,7 @@
           "rarity": "rare",
           "eduText": "The shiny brown conker inside the spiky case is a seed, not a nut, and it is too bitter to eat.",
           "imagePrompt": "a single short horse chestnut branch with a spiky green case split open to show two shiny brown conkers inside, its whole length visible from end to end, with nothing behind it but plain blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Aesculus_hippocastanum",
-          "provider": "pollinations"
+          "sourceUrl": "https://en.wikipedia.org/wiki/Aesculus_hippocastanum"
         },
         {
           "name": "Olive Tree",
@@ -3802,11 +3801,11 @@
           "sourceUrl": "https://en.wikipedia.org/wiki/Terminalia_catappa"
         },
         {
-          "name": "Traveller's Palm",
+          "name": "Saga Tree",
           "rarity": "common",
-          "eduText": "Its leaves grow in one flat fan, and rainwater collects in the leaf bases for a thirsty traveller.",
-          "imagePrompt": "a single traveller's palm plant seen from directly in front, its long paddle-shaped green leaves fanning out flat in one single plane from a short central trunk like a giant open fan, standing alone on green grass with nothing behind it but plain blue sky",
-          "sourceUrl": "https://en.wikipedia.org/wiki/Ravenala"
+          "eduText": "Its bright red seeds are so alike in weight that goldsmiths once used them as tiny weighing stones.",
+          "imagePrompt": "one curled brown seed pod hanging from a short twig, split wide open along its length, six flat round glossy scarlet seeds sitting in a row inside the open pod, a few small green leaflets on the twig, with plain blue sky all around it",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Adenanthera_pavonina"
         },
         {
           "name": "Banana Tree",

--- a/seed/cards.json
+++ b/seed/cards.json
@@ -3725,7 +3725,7 @@
         {
           "name": "Cannonball Tree",
           "rarity": "epic",
-          "eduText": "Its heavy round fruit grow straight out of the trunk instead of the branches, and when ripe, they release a repugnant odor—unlike its fragrant flowers.",
+          "eduText": "Its heavy round fruit grow straight out of the trunk, not the branches. The flowers smell sweet, the fruit does not.",
           "imagePrompt": "a single tree with one thick straight trunk, dozens of large round brown fruit growing in tight clusters directly on the trunk bark all the way from the ground up to the branches, green leaves above, on green grass under a blue sky",
           "sourceUrl": "https://en.wikipedia.org/wiki/Couroupita_guianensis"
         },

--- a/seed/cards.json
+++ b/seed/cards.json
@@ -3676,6 +3676,221 @@
         }
       ],
       "provider": "cloudflare-sdxl"
+    },
+    {
+      "name": "Trees",
+      "cards": [
+        {
+          "name": "Cherry Blossom Tree",
+          "rarity": "legendary",
+          "eduText": "In Japan people gather under these trees each spring to watch the pink petals fall like snow.",
+          "imagePrompt": "a single cherry blossom tree with a dark curving trunk and a wide spreading crown completely covered in masses of soft pink flowers, standing alone on green grass with nothing behind it but clear blue sky, seen from a little way off so the whole tree from its trunk to the top of its crown is in the picture",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Cherry_blossom"
+        },
+        {
+          "name": "Banyan",
+          "rarity": "legendary",
+          "eduText": "A banyan drops roots from its branches. They thicken into new trunks, so one tree can spread like a forest.",
+          "imagePrompt": "a single banyan tree with one huge wide spreading crown and many thick aerial roots hanging down from its branches to the ground, standing alone on green grass with nothing behind it but clear blue sky, seen from a little way off so the whole tree from its trunk to the top of its crown is in the picture",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Banyan"
+        },
+        {
+          "name": "Weeping Willow",
+          "rarity": "epic",
+          "eduText": "Willow branches bend instead of snapping in the wind, and the tree can grow a new one from a broken twig.",
+          "imagePrompt": "a single weeping willow tree with a short thick trunk and long thin branches of narrow green leaves hanging down to the ground, standing alone on green grass with nothing behind it but clear blue sky, seen from far enough away that the whole tree and the grass under it are in the picture",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Salix_babylonica"
+        },
+        {
+          "name": "Coconut Palm",
+          "rarity": "epic",
+          "eduText": "A coconut can float across the sea for months and still sprout into a new palm when it lands.",
+          "imagePrompt": "a single coconut palm tree with one tall curving bare trunk and a crown of long feathery green fronds with green coconuts underneath, on green grass under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Coconut"
+        },
+        {
+          "name": "Joshua Tree",
+          "rarity": "epic",
+          "eduText": "This desert tree is not really a tree at all. It is a giant yucca, and it can live over 150 years.",
+          "imagePrompt": "a single joshua tree with a short thick shaggy trunk and crooked upward arms each ending in a spiky green tuft, standing alone on plain pale sandy ground with nothing behind it but clear blue sky, seen from a little way off so the whole tree from its trunk to the top of its arms is in the picture",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Yucca_brevifolia"
+        },
+        {
+          "name": "Norway Spruce",
+          "rarity": "epic",
+          "eduText": "Most Christmas trees are Norway spruces. Their cones hang down instead of standing up.",
+          "imagePrompt": "a single norway spruce tree shaped like a tall narrow pointed cone, with dense dark green needle branches reaching down to the ground, standing alone on green grass with nothing behind it but clear blue sky, seen from a little way off so the whole tree from its base to its pointed top is in the picture",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Picea_abies"
+        },
+        {
+          "name": "Monkey Puzzle Tree",
+          "rarity": "epic",
+          "eduText": "Its leaves are so sharp and spiky that people joked even a monkey would be puzzled climbing it.",
+          "imagePrompt": "a single monkey puzzle tree with a bare straight trunk and stiff branches covered in sharp overlapping dark green triangular scales, on green grass under a blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Araucaria_araucana"
+        },
+        {
+          "name": "Oak",
+          "rarity": "rare",
+          "eduText": "An oak can drop thousands of acorns in one year, and jays bury them and plant new oaks by mistake.",
+          "imagePrompt": "a single short oak branch with deeply lobed green leaves and two brown acorns, its whole length visible from end to end, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Oak"
+        },
+        {
+          "name": "Maple",
+          "rarity": "rare",
+          "eduText": "Maple seeds spin like helicopter blades as they fall, carrying them away from the parent tree.",
+          "imagePrompt": "a single short maple branch with just five flat bright red five-pointed leaves, the bare brown branch clearly visible along its whole length, with plain blue sky all around it",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Maple"
+        },
+        {
+          "name": "Ginkgo",
+          "rarity": "rare",
+          "eduText": "Ginkgos have grown on Earth for over 200 million years, so dinosaurs walked under trees like this.",
+          "imagePrompt": "a single short ginkgo branch with small fan-shaped leaves turned golden yellow, its whole length visible from end to end, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Ginkgo_biloba"
+        },
+        {
+          "name": "Holly",
+          "rarity": "rare",
+          "eduText": "Holly leaves are spikiest low down where animals can reach, and smoother higher up the tree.",
+          "imagePrompt": "a single short holly branch with dark glossy green leaves with spiky pointed edges and clusters of small bright red berries, its whole length visible from end to end, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Ilex_aquifolium"
+        },
+        {
+          "name": "Apple Tree",
+          "rarity": "rare",
+          "eduText": "Every apple in an orchard row can be a clone, grown by joining a twig onto another tree's roots.",
+          "imagePrompt": "a single short apple branch with green leaves and three round shiny red apples, its whole length visible from end to end, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Apple"
+        },
+        {
+          "name": "Horse Chestnut",
+          "rarity": "rare",
+          "eduText": "The shiny brown conker inside the spiky case is a seed, not a nut, and it is too bitter to eat.",
+          "imagePrompt": "a single short horse chestnut branch with a spiky green case split open to show two shiny brown conkers inside, its whole length visible from end to end, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Aesculus_hippocastanum"
+        },
+        {
+          "name": "Olive Tree",
+          "rarity": "rare",
+          "eduText": "Some olive trees are over a thousand years old and still grow fruit every single year.",
+          "imagePrompt": "a single short olive branch with narrow silvery grey-green leaves and a few small green olives, its whole length visible from end to end, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Olive"
+        },
+        {
+          "name": "Silver Birch",
+          "rarity": "rare",
+          "eduText": "Birch bark peels off in papery strips, and its white colour bounces sunlight away from the trunk.",
+          "imagePrompt": "one single upright silver birch trunk with smooth chalky white bark marked with black horizontal dashes and dark diamond scars, standing on green grass with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Betula_pendula"
+        },
+        {
+          "name": "Rain Tree",
+          "rarity": "common",
+          "eduText": "Its leaflets fold up at dusk and when rain comes, letting the water fall straight through to the ground.",
+          "imagePrompt": "a single short rain tree branch with just two feathery fronds of tiny paired green leaflets at its tip, the bare brown branch clearly visible along its whole length, with plain blue sky all around it",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Samanea_saman"
+        },
+        {
+          "name": "Sea Almond",
+          "rarity": "common",
+          "eduText": "Its big leaves turn red before they drop, and its seeds float on seawater to reach new beaches.",
+          "imagePrompt": "a single short sea almond branch with very large broad flat oval leaves, some deep red and some green, its whole length visible from end to end, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Terminalia_catappa"
+        },
+        {
+          "name": "Traveller's Palm",
+          "rarity": "common",
+          "eduText": "Its leaves grow in one flat fan, and rainwater collects in the leaf bases for a thirsty traveller.",
+          "imagePrompt": "a single traveller's palm plant seen from directly in front, its long paddle-shaped green leaves fanning out flat in one single plane from a short central trunk like a giant open fan, standing alone on green grass with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Ravenala"
+        },
+        {
+          "name": "Banana Tree",
+          "rarity": "common",
+          "eduText": "A banana plant is a giant herb, not a tree. Its trunk is made of tightly rolled leaf bases.",
+          "imagePrompt": "one very large bright green banana leaf with a thick pale midrib and long torn edges, its whole shape visible from base to tip, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Banana"
+        },
+        {
+          "name": "Papaya Tree",
+          "rarity": "common",
+          "eduText": "Papayas grow straight out of the trunk in a ring, right under the crown of leaves.",
+          "imagePrompt": "the top of a single papaya stem with a ring of large yellow-green oval fruit growing tightly against it under a crown of deeply cut leaves, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Papaya"
+        },
+        {
+          "name": "Mango Tree",
+          "rarity": "common",
+          "eduText": "Mango trees can keep fruiting for over 100 years, and some grow taller than a house.",
+          "imagePrompt": "a single short mango branch with long narrow dark green leaves and two large oval fruit blushed red and yellow, its whole length visible from end to end, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Mango"
+        },
+        {
+          "name": "Starfruit Tree",
+          "rarity": "common",
+          "eduText": "Slice this ridged yellow fruit across the middle and every piece comes out shaped like a star.",
+          "imagePrompt": "a single short starfruit branch with small green leaves and three waxy yellow fruit with five deep ridges down their sides, and one slice cut across showing a yellow star shape, its whole length visible from end to end, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Carambola"
+        },
+        {
+          "name": "Durian Tree",
+          "rarity": "common",
+          "eduText": "Durian smells so strong it is banned on trains and buses in some countries, but many people love it.",
+          "imagePrompt": "a single short durian branch with two big round green fruit completely covered in sharp thick spikes, its whole length visible from end to end, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Durian"
+        },
+        {
+          "name": "Rambutan Tree",
+          "rarity": "common",
+          "eduText": "Rambutan means hairy in Malay. The soft red spines peel away to reveal a sweet white fruit.",
+          "imagePrompt": "a single short rambutan branch with a cluster of round bright red fruit covered in soft green hairs, its whole length visible from end to end, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Rambutan"
+        },
+        {
+          "name": "Rubber Tree",
+          "rarity": "common",
+          "eduText": "A spiral cut in the bark lets white latex drip into a cup, and that sap becomes rubber.",
+          "imagePrompt": "one single upright rubber tree trunk seen close up, standing on green grass, one deep spiral groove cut in a long slanting line down its smooth grey bark with white sap running along inside the cut, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Hevea_brasiliensis"
+        },
+        {
+          "name": "Rainbow Eucalyptus",
+          "rarity": "common",
+          "eduText": "As its bark peels, the fresh layer underneath turns green, then orange, purple and blue.",
+          "imagePrompt": "one single upright rainbow eucalyptus trunk standing on green grass, its smooth bark streaked in bright green, orange, purple and blue, with nothing behind it but plain pale blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Eucalyptus_deglupta"
+        },
+        {
+          "name": "Mangrove",
+          "rarity": "common",
+          "eduText": "Mangroves stand on stilt roots in salty water and their seeds sprout while still on the tree.",
+          "imagePrompt": "one single mangrove tree standing on many thin arching stilt roots that lift its trunk clear above shallow still water, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Mangrove"
+        },
+        {
+          "name": "Frangipani",
+          "rarity": "common",
+          "eduText": "Frangipani flowers smell strongest at night to attract moths, though they hold no nectar at all.",
+          "imagePrompt": "a single short frangipani branch with thick bare grey stems and clusters of white five-petalled flowers with yellow centres, its whole length visible from end to end, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Plumeria"
+        },
+        {
+          "name": "Flame of the Forest",
+          "rarity": "common",
+          "eduText": "When it blooms the whole crown turns orange-red, and its seed pods can grow as long as your arm.",
+          "imagePrompt": "a single short flame tree branch covered in large bright orange-red flowers with fine feathery green leaflets behind them, its whole length visible from end to end, with nothing behind it but plain blue sky",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Delonix_regia"
+        },
+        {
+          "name": "Angsana",
+          "rarity": "common",
+          "eduText": "Every angsana in a street can burst into yellow flower on the same day, then drop them a day later.",
+          "imagePrompt": "a single short angsana branch with a few small green leaflets and two clusters of tiny bright yellow flowers, the bare brown branch clearly visible along its whole length, with plain blue sky all around it",
+          "sourceUrl": "https://en.wikipedia.org/wiki/Pterocarpus_indicus"
+        }
+      ]
     }
   ]
 }

--- a/seed/provenance.json
+++ b/seed/provenance.json
@@ -1550,6 +1550,397 @@
         "reviewKey": "rocks-and-gems-turquoise-52ce5950-pollinations-dff2",
         "reviewed": true
       }
+    },
+    "Trees": {
+      "Angsana": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-angsana-c2aec872-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Apple Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-apple-tree-db951484-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Banana Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-banana-tree-4f885583-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Banyan": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-banyan-2d4c79dc-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Cannonball Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-cannonball-tree-9862e0fa-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Cherry Blossom Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-cherry-blossom-tree-c62a7de1-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Coconut Palm": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-coconut-palm-712d1343-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Durian Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-durian-tree-cb007bd8-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Flame of the Forest": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-flame-of-the-forest-b2c61298-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Frangipani": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-frangipani-b35f5554-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Ginkgo": {
+        "provider": "pollinations",
+        "model": "sana",
+        "params": {
+          "model": "flux",
+          "seed": 42,
+          "nologo": true
+        },
+        "format": "jpeg",
+        "reviewKey": "trees-ginkgo-e8a6f0bc-pollinations-dff2",
+        "reviewed": true
+      },
+      "Holly": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-holly-73b85ec9-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Horse Chestnut": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-horse-chestnut-7d967f06-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Joshua Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-joshua-tree-28201f58-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Mango Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-mango-tree-42b0922f-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Mangrove": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-mangrove-7749daeb-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Maple": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-maple-7ad5e4a0-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Norway Spruce": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-norway-spruce-2881b971-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Oak": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-oak-1dd65247-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Olive Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-olive-tree-8ca9bc53-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Papaya Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-papaya-tree-d9f9a9ec-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Rain Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-rain-tree-bae7591b-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Rainbow Eucalyptus": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-rainbow-eucalyptus-2e1a3d38-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Rambutan Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-rambutan-tree-5fb12e1a-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Rubber Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-rubber-tree-60c62aa1-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Saga Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-saga-tree-d7075bca-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Sea Almond": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-sea-almond-308f18d5-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Silver Birch": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-silver-birch-bb1e666d-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Starfruit Tree": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-starfruit-tree-8efe9b37-cloudflare-sdxl-2211",
+        "reviewed": true
+      },
+      "Weeping Willow": {
+        "provider": "cloudflare-sdxl",
+        "model": null,
+        "params": {
+          "model": "@cf/stabilityai/stable-diffusion-xl-base-1.0",
+          "num_steps": 20,
+          "guidance": 7.5,
+          "seed": 42
+        },
+        "format": "png",
+        "reviewKey": "trees-weeping-willow-7db0aad1-cloudflare-sdxl-2211",
+        "reviewed": true
+      }
     }
   }
 }


### PR DESCRIPTION
Adds **Trees**, the eighteenth theme, and the second half of the map
[Map: two new themes — Metals and Trees](https://github.com/nywleswoey/kids-collection/issues/113).
Published: 30 cards inserted, 0 failed, 0 pruned; the pool is now 18 themes / 540 cards.

## Where the 30 came from

CHECKPOINT 1 was passed in [#119](https://github.com/nywleswoey/kids-collection/issues/119) and corrected
by [#124](https://github.com/nywleswoey/kids-collection/issues/124), so this run started at Step 4. The
shaping decision was **whose "everyday"** — this child's street, not the picture book's — which inverts the
pyramid geographically: the 15 commons are tropical street and fruit trees, the 8 rares are the world's
storybook trees a child knows from books but has never stood under.

The theme is **split by tier**, per [#116](https://github.com/nywleswoey/kids-collection/issues/116): the
7 epics and legendaries draw as **whole trees**, the 23 commons and rares as **close crops**. That is why
the name is bare `Trees` — every qualifier picks one end of the pyramid and drops the other.

## What the bake-off found

**Cloudflare won 29 of 30 rows.** Pollinations drew whole trees where crops were asked for, groves where
one tree was, a wreath for Holly and a person in a field for Traveller's Palm. #116 had ruled it
"not the default, re-justify per theme"; at 30 rows it does not re-justify. It keeps one card — `Ginkgo`,
where it drew a full branch of fan leaves against Cloudflare's single leaf.

**#124's Weeping Willow failure is fixed.** It drew a trunk close-up on both of #124's samples; asserting
the whole tree and the ground under it produced a whole willow.

## Two subjects swapped, after the art refused them

Both failed two re-prompt rounds *and* their re-rolls, so they were swapped rather than shipped:

- **Monkey Puzzle Tree → `Cannonball Tree`** (epic). Douglas Fir is the obvious pick from #119's stock and
  is the wrong one — it lands on `Norway Spruce`, the exact collision #124 watched `Italian Cypress` lose.
  A trunk hung with fruit is instead the theme's only **trunk-first** identity, which is what #124 measured
  a whole-tree card to be read as.
- **Traveller's Palm → `Saga Tree`** (common). It collided with `Banana Tree` as generic tropical foliage —
  a subject problem no wording fixes. This is precisely the collision #119 predicted nothing would catch,
  since the 23 crops were never screened against each other. It is now the one that was.

## Step 4 wording rules carried in, and one earned here

Carried from the map's prototypes: the head noun is the fault and `"a single"` does not fix it (#120/#124);
a habitat cues a landscape, so a plain background is **asserted** (#124); an adjective can escape its
subject (#131), which is why `Rainbow Eucalyptus` binds its colours to the bark.

Earned in this run: **the crop template fails exactly where the identity is *many small repeated units*** —
scattered leaves, tiny leaflets, tiny flowers all wallpapered the frame. The fix is not a quantifier but
asserting *"the bare brown branch clearly visible along its whole length"* and capping the count. It
recovered `Maple` and `Angsana`. And for a subject whose identity is a **contained** thing, leading with
the defining object recovered `Saga Tree` where two branch-led wordings had failed.

Two frames (#81's artifact) appeared and were cleared by re-roll, not re-prompt: `Norway Spruce`,
`Horse Chestnut`.

## Known, accepted at CHECKPOINT 2

`Banyan` keeps a faint city skyline and `Joshua Tree` a full desert landscape — both are #124's measured
failures, and asserting a plain background did not clear either. `Rubber Tree`'s spiral tapping cut never
drew across three wordings. `Rain Tree` is the weakest card in the set.

## Verification

- `pnpm seed --check-urls` — 540/540 return 200
- `pnpm seed --blob-budget` — 11.4% of 1.00 GB before publishing, no warning
- `pnpm seed --check-images` — no blank frames among all 540 published images
- `seed/provenance.json` — 30 entries, all `reviewed: true`

https://claude.ai/code/session_01EcdhZLhe2zq2NvqSFLqfJs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a new **Trees** theme with 30 collectible cards spanning common through legendary rarities.
  * Added educational descriptions, artwork, and source references for each card.
  * Added provenance details for 40 tree entries, including review status and image metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->