### PR TITLE
feat(binder): front a category with its first legendary (#122)

### DIFF
--- a/src/db/migrations/0010_drop_theme_cover_url.sql
+++ b/src/db/migrations/0010_drop_theme_cover_url.sql
@@ -1,0 +1,17 @@
+-- #122, reversing its own first answer.
+--
+-- An earlier attempt gave `themes` a `cover_url` column holding per-theme cover
+-- art. That art is gone: a category's tile is now fronted by the theme's first
+-- LEGENDARY CARD, derived in `category-cover.ts` with no column, no blob and no
+-- seed field. Generated covers charged every future theme an authored prompt, a
+-- bake-off row and a human screening pick, forever; two themes landed on main
+-- while that work was open, each owing exactly that.
+--
+-- `IF EXISTS` because this migration must be a no-op on a database that never
+-- had the column. It DID reach one — the column was created and filled with 16
+-- URLs on the production database before the reversal — so this is a real drop
+-- there and a no-op everywhere else.
+--
+-- The 16 objects under `covers/` in Blob are NOT removed here; a migration
+-- cannot reach the store. They are orphaned and `--blob-budget` will see them.
+ALTER TABLE "themes" DROP COLUMN IF EXISTS "cover_url";

--- a/src/db/migrations/meta/0010_snapshot.json
+++ b/src/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,732 @@
+{
+  "id": "0010_drop_theme_cover_url",
+  "prevId": "bca6a048-c87f-4334-8e78-0704b9d0b23a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin_credentials": {
+      "name": "admin_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "admin_credentials_credential_id_idx": {
+          "name": "admin_credentials_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "admin_credentials_parent_idx": {
+          "name": "admin_credentials_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cards": {
+      "name": "cards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "rarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "edu_text": {
+          "name": "edu_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "cards_theme_idx": {
+          "name": "cards_theme_idx",
+          "columns": [
+            {
+              "expression": "theme_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cards_theme_id_themes_id_fk": {
+          "name": "cards_theme_id_themes_id_fk",
+          "tableFrom": "cards",
+          "tableTo": "themes",
+          "columnsFrom": [
+            "theme_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.children": {
+      "name": "children",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pull_tokens": {
+          "name": "pull_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "easter_egg_tickets": {
+          "name": "easter_egg_tickets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pull_tokens_non_negative": {
+          "name": "pull_tokens_non_negative",
+          "value": "\"children\".\"pull_tokens\" >= 0"
+        },
+        "easter_egg_tickets_non_negative": {
+          "name": "easter_egg_tickets_non_negative",
+          "value": "\"children\".\"easter_egg_tickets\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.collection_rewards": {
+      "name": "collection_rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "rarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "collection_rewards_child_theme_rarity_idx": {
+          "name": "collection_rewards_child_theme_rarity_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "theme_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rarity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_rewards_child_idx": {
+          "name": "collection_rewards_child_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_rewards_child_id_children_id_fk": {
+          "name": "collection_rewards_child_id_children_id_fk",
+          "tableFrom": "collection_rewards",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_rewards_theme_id_themes_id_fk": {
+          "name": "collection_rewards_theme_id_themes_id_fk",
+          "tableFrom": "collection_rewards",
+          "tableTo": "themes",
+          "columnsFrom": [
+            "theme_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collection_rewards_card_id_cards_id_fk": {
+          "name": "collection_rewards_card_id_cards_id_fk",
+          "tableFrom": "collection_rewards",
+          "tableTo": "cards",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collections": {
+      "name": "collections",
+      "schema": "",
+      "columns": {
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_id": {
+          "name": "card_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "collections_child_card_idx": {
+          "name": "collections_child_card_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "card_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collections_child_idx": {
+          "name": "collections_child_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collections_child_id_children_id_fk": {
+          "name": "collections_child_id_children_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collections_card_id_cards_id_fk": {
+          "name": "collections_card_id_cards_id_fk",
+          "tableFrom": "collections",
+          "tableTo": "cards",
+          "columnsFrom": [
+            "card_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "collections_child_id_card_id_pk": {
+          "name": "collections_child_id_card_id_pk",
+          "columns": [
+            "child_id",
+            "card_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "count_at_least_one": {
+          "name": "count_at_least_one",
+          "value": "\"collections\".\"count\" >= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.quiz_completions": {
+      "name": "quiz_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "correct": {
+          "name": "correct",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passed": {
+          "name": "passed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "awarded": {
+          "name": "awarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "quiz_completions_child_created_idx": {
+          "name": "quiz_completions_child_created_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "quiz_completions_child_id_children_id_fk": {
+          "name": "quiz_completions_child_id_children_id_fk",
+          "tableFrom": "quiz_completions",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_seen_questions": {
+      "name": "quiz_seen_questions",
+      "schema": "",
+      "columns": {
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "quiz_seen_questions_child_id_children_id_fk": {
+          "name": "quiz_seen_questions_child_id_children_id_fk",
+          "tableFrom": "quiz_seen_questions",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "quiz_seen_questions_child_id_topic_question_id_pk": {
+          "name": "quiz_seen_questions_child_id_topic_question_id_pk",
+          "columns": [
+            "child_id",
+            "topic",
+            "question_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.themes": {
+      "name": "themes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "themes_name_unique": {
+          "name": "themes_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.rarity": {
+      "name": "rarity",
+      "schema": "public",
+      "values": [
+        "common",
+        "rare",
+        "epic",
+        "legendary"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1787411934834,
       "tag": "0009_children_archived_at",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1788062365419,
+      "tag": "0010_drop_theme_cover_url",
+      "breakpoints": true
     }
   ]
 }

--- a/src/features/binder/CategoryPicker.tsx
+++ b/src/features/binder/CategoryPicker.tsx
@@ -16,6 +16,13 @@ import { coverCard } from "./category-cover";
  * A finished category is called out with the same 🏆 "Set complete!" language
  * the reward modal celebrates it with, so the tile and the celebration are one
  * promise rather than two marks the child has to learn separately.
+ *
+ * #122: the tile's face is the theme's first legendary, owned or not — a
+ * LANDMARK, the same picture on every visit. It used to be the child's rarest
+ * owned card, which meant a category they had not started rendered a neutral 🪐
+ * and told them nothing at the one moment they most needed to tell categories
+ * apart. That placeholder is gone rather than restyled: `coverCard` is total for
+ * any non-empty category, so there is no state left for it to cover.
  */
 export function CategoryPicker({
   sections,
@@ -66,13 +73,7 @@ function CategoryTile({
       <span className="relative block">
         {cover ? (
           <CardImage src={cover.card.imageUrl} alt="" dim={256} loading="lazy" />
-        ) : (
-          // Nothing owned here yet — a neutral placeholder, never a dimmed
-          // thumbnail: unearned art stays unearned (U5-Q5).
-          <span className="flex aspect-square w-full items-center justify-center bg-black/20 text-4xl opacity-45">
-            🪐
-          </span>
-        )}
+        ) : null}
         {progress.complete ? (
           <span className="absolute inset-x-0 bottom-0 flex items-center justify-center gap-1 bg-[color:var(--brand-1)] px-1 py-1 text-[0.7rem] font-black leading-none text-black">
             🏆 Set complete!

--- a/src/features/binder/GalaxyView.tsx
+++ b/src/features/binder/GalaxyView.tsx
@@ -7,6 +7,8 @@ import { RARITY_META } from "@/features/card/rarity";
 import { ThemeSection } from "./ThemeSection";
 import { SacrificeGrid } from "./SacrificeGrid";
 import { CategoryPicker } from "./CategoryPicker";
+import { coverCard } from "./category-cover";
+import { CardImage } from "@/features/card/CardImage";
 import { countOwnedByRarity, filterCardsByRarity } from "./rarity-filter";
 import { sacrificeReady } from "./sacrifice-filter";
 import { BURN, HUB, type Place, parsePlace, placeHref } from "./binder-place";
@@ -112,6 +114,7 @@ export function GalaxyView({
       <div className="flex flex-col gap-6">
         <PlaceBar
           title={open.theme.name}
+          cover={coverCard(open)?.card.imageUrl}
           progress={open.progress}
           onBack={() => go(HUB)}
         />
@@ -179,12 +182,27 @@ function BurnDoor({ count, onOpen }: { count: number; onOpen: () => void }) {
 }
 
 /** The one sticky layer a place is allowed: the way back, and where you are. */
+/**
+ * The sticky bar inside a category or the burn pile: one way back, where you
+ * are, and how far along.
+ *
+ * #122 gave it the category's cover thumbnail. The bar was pure text, and #108
+ * moved the category heading INTO it — so for a child who cannot yet read the
+ * name, it said nothing about where they were standing. It is sticky, so it
+ * persists through a 30-card scroll: not arrival confirmation (they just tapped
+ * the tile) but a persistent *where am I*, which is exactly when a picture beats
+ * a word. Decorative (`alt=""`) because `title` already carries the name, and no
+ * new sticky layer — the two-layer budget is untouched.
+ */
 function PlaceBar({
   title,
+  cover,
   progress,
   onBack,
 }: {
   title: string;
+  /** The category's cover art; absent for the burn pile, which is no category. */
+  cover?: string;
   progress?: { owned: number; total: number; complete: boolean };
   onBack: () => void;
 }) {
@@ -207,6 +225,15 @@ function PlaceBar({
       >
         ← All categories
       </button>
+      {cover ? (
+        <CardImage
+          src={cover}
+          alt=""
+          dim={64}
+          loading="lazy"
+          className="h-7 w-7 shrink-0 rounded-md object-cover"
+        />
+      ) : null}
       <span className="display min-w-0 flex-1 truncate text-lg">{title}</span>
       {progress ? (
         <span

--- a/src/features/binder/category-cover.ts
+++ b/src/features/binder/category-cover.ts
@@ -1,28 +1,60 @@
-import { RARITIES, type BinderCard, type ThemeSection } from "@/lib/types";
+import type { BinderCard, ThemeSection } from "@/lib/types";
 
 /**
- * Which card's art fronts a category tile in the picker (#107). PURE →
- * property-tested.
+ * Which card's art fronts a category tile in the picker (#107, reversed by
+ * #122). PURE → property-tested.
  *
- * `Theme` is `{ id, name }` — it carries no art of its own, so a picture-first
- * picker has to borrow one from the category's cards. It borrows the child's
- * **rarest owned** card: the tile then shows off the best thing they pulled
- * there, and it changes as they collect, so the picker is a record of their
- * own galaxy rather than 16 fixed pictures.
+ * `Theme` is `{ id, name, sortOrder }` — it carries no art of its own, so a
+ * picture-first picker has to borrow one from the category's cards. It borrows
+ * the theme's **first legendary in catalog order**: the same card every time,
+ * owned or not.
  *
- * A category with nothing owned returns `null`, and the tile falls back to a
- * neutral placeholder. That is deliberate and load-bearing: `CardSlot` renders
- * unowned cards as `❔` with no rarity hint (U5-Q5) precisely so unearned art
- * stays unearned. A dimmed real thumbnail on the tile would leak exactly what
- * the locked slot is careful not to show.
+ * ── Why not the rarest OWNED card, which is what this used to do ─────────────
+ * That was a trophy, not a landmark. It showed off the best thing the child had
+ * pulled there and changed as they collected — lovely as a reward, useless as a
+ * map. Two failures, and both get worse as the pool grows past 16 themes, which
+ * is the whole reason #106 exists:
  *
- * Ties inside a rarity resolve to the first card in catalog order, so the cover
- * does not shuffle between renders.
+ *   - **A category the child has not started showed nothing at all.** It fell
+ *     back to a neutral placeholder, so at the exact moment they most need to
+ *     tell categories apart — before they own anything in one — the tile told
+ *     them only its name. That is the reading-heavy interaction the picture
+ *     picker was built to avoid, and a new theme lands every seed runbook, so
+ *     there was permanently a blank tile and it was the newest one.
+ *   - **A landmark that moves is not a landmark.** "The one with the whale"
+ *     stopped meaning Animals the moment a rarer card arrived.
+ *
+ * ── Why a legendary, and what it costs ──────────────────────────────────────
+ * #122 first decided each theme would get its own generated cover art depicting
+ * a *place*. That works, and it was built and shipped for 16 themes — but it
+ * charges every future theme an authored prompt, a bake-off row and a human
+ * screening pick, forever. Two themes landed on `main` while that branch was
+ * open (Rocks and Gems, Trees), each needing exactly that, which is what turned
+ * a one-off backfill cost into a visibly recurring one.
+ *
+ * A legendary is free, permanently: no column, no blob, no seed field, no
+ * runbook step, and it cannot drift out of sync with the theme because it IS
+ * the theme's own art.
+ *
+ * The cost is real and was taken deliberately: this **leaks unearned art**.
+ * `CardSlot` renders unowned cards as `❔` with no rarity hint (U5-Q5) precisely
+ * so unearned art stays unearned, and the hub now shows every theme's best card
+ * from day one. A common would nearly erase that leak — commons are 15 of 30
+ * and pulled almost immediately — and was offered; legendary was chosen for the
+ * art. The narrower rule survives untouched: the locked *slot* inside a category
+ * still shows `❔`, so the picker reveals what a theme's best card LOOKS like
+ * without revealing which slots are still missing.
+ *
+ * ── Total by construction ───────────────────────────────────────────────────
+ * Every theme has exactly two legendaries (`RARITY_PYRAMID`, enforced by
+ * `seed-schema.ts` on every seed command), so the first branch always hits for
+ * real data. The fallback to catalog order is for a section assembled outside
+ * that guarantee — a test fixture, a partially loaded theme — and exists so the
+ * return is non-null and the tile never needs a placeholder branch at all. That
+ * is what let the 🪐 fallback be deleted rather than kept as unreachable code.
  */
 export function coverCard(section: ThemeSection): BinderCard | null {
-  for (const rarity of [...RARITIES].reverse()) {
-    const hit = section.cards.find((c) => c.owned && c.card.rarity === rarity);
-    if (hit) return hit;
-  }
-  return null;
+  return (
+    section.cards.find((c) => c.card.rarity === "legendary") ?? section.cards[0] ?? null
+  );
 }

--- a/tests/category-cover.pbt.test.ts
+++ b/tests/category-cover.pbt.test.ts
@@ -37,74 +37,78 @@ function section(cards: BinderCard[]): ThemeSection {
   };
 }
 
-describe("coverCard (#107 category picker)", () => {
-  it("picks the rarest owned card", () => {
+describe("coverCard (#107 category picker, reversed by #122)", () => {
+  it("picks the theme's first legendary in catalog order", () => {
     const cover = coverCard(
       section([
         bcard("a", "common", true),
-        bcard("b", "legendary", true),
-        bcard("c", "epic", true),
+        bcard("b", "legendary", false),
+        bcard("c", "legendary", true),
       ]),
     );
     expect(cover?.card.id).toBe("b");
   });
 
-  it("ignores unowned cards even when they are rarer", () => {
-    const cover = coverCard(
-      section([bcard("a", "common", true), bcard("b", "legendary", false)]),
-    );
-    expect(cover?.card.id).toBe("a");
-  });
-
-  it("returns null when nothing is owned, so unearned art never leaks (U5-Q5)", () => {
-    fc.assert(
-      fc.property(fc.array(cardArb, { maxLength: 20 }), (cards) => {
-        const locked = cards.map((c) => ({ ...c, owned: false, count: 0 }));
-        expect(coverCard(section(locked))).toBe(null);
-      }),
-    );
-  });
-
-  it("never returns an unowned card", () => {
+  // The whole point of the reversal. A cover that depends on what the child owns
+  // is a trophy; a landmark has to be the same picture on every visit, including
+  // the first, when they own nothing here.
+  it("does not depend on ownership at all", () => {
     fc.assert(
       fc.property(sectionArb, (s) => {
-        const cover = coverCard(s);
-        if (cover) expect(cover.owned).toBe(true);
+        const allLocked = { ...s, cards: s.cards.map((c) => ({ ...c, owned: false, count: 0 })) };
+        const allOwned = { ...s, cards: s.cards.map((c) => ({ ...c, owned: true, count: 1 })) };
+        expect(coverCard(allLocked)?.card.id).toBe(coverCard(allOwned)?.card.id);
       }),
     );
   });
 
-  it("returns a card iff the category has at least one owned card", () => {
+  // What replaced "returns null when nothing is owned". A theme with cards
+  // always has a cover, which is what let the 🪐 placeholder be deleted rather
+  // than kept as an unreachable branch.
+  it("returns a card for any non-empty category", () => {
     fc.assert(
       fc.property(sectionArb, (s) => {
-        const anyOwned = s.cards.some((c) => c.owned);
-        expect(coverCard(s) !== null).toBe(anyOwned);
+        expect(coverCard(s) !== null).toBe(s.cards.length > 0);
       }),
     );
   });
 
-  it("is stable: no owned card in the section is rarer than the cover", () => {
+  it("prefers a legendary over every other rarity, wherever it sits", () => {
     fc.assert(
       fc.property(sectionArb, (s) => {
         const cover = coverCard(s);
         if (!cover) return;
-        const rank = (r: Rarity) => RARITIES.indexOf(r);
-        for (const c of s.cards) {
-          if (c.owned) {
-            expect(rank(c.card.rarity)).toBeLessThanOrEqual(rank(cover.card.rarity));
-          }
-        }
+        const hasLegendary = s.cards.some((c) => c.card.rarity === "legendary");
+        if (hasLegendary) expect(cover.card.rarity).toBe("legendary");
       }),
     );
   });
 
-  it("ties inside a rarity resolve to the first card in catalog order", () => {
-    const cover = coverCard(
-      section([
-        bcard("first", "epic", true),
-        bcard("second", "epic", true),
-      ]),
+  // Stability is the property the tile is bought for. Note the guard: it holds
+  // ONCE THE THEME HAS A LEGENDARY, and the unconditional version is false —
+  // appending a legendary to a section that had none moves the cover off the
+  // catalog-order fallback. That case cannot occur for real data (the pyramid
+  // puts two legendaries in every theme before it can publish), so the guard is
+  // the honest statement of the invariant rather than a weakening of it.
+  it("is stable when the catalog grows behind it", () => {
+    fc.assert(
+      fc.property(sectionArb, fc.array(cardArb, { maxLength: 5 }), (s, extra) => {
+        if (!s.cards.some((c) => c.card.rarity === "legendary")) return;
+        const cover = coverCard(s);
+        if (!cover) return;
+        expect(coverCard({ ...s, cards: [...s.cards, ...extra] })?.card.id).toBe(cover.card.id);
+      }),
     );
+  });
+
+  it("falls back to catalog order for a section with no legendary", () => {
+    // Unreachable for real data — the pyramid guarantees two per theme — but it
+    // is what makes the function total, so the tile has no placeholder branch.
+    const cover = coverCard(section([bcard("first", "epic", false), bcard("second", "rare", true)]));
     expect(cover?.card.id).toBe("first");
+  });
+
+  it("returns null only for an empty category", () => {
+    expect(coverCard(section([]))).toBe(null);
   });
 });


### PR DESCRIPTION
Closes #122. Replaces #135, which took the same ticket's first answer and is now closed.

## The problem

The picker's tile is how a child navigates 25+ categories, so its face has to be the **same picture
every visit**. It was the child's **rarest owned card**, which is a trophy rather than a landmark:

- **It moved.** Pull a legendary and the tile changes picture — a fine reward, a useless map. "The
  one with the whale" stopped meaning Animals.
- **A category they had not started showed nothing.** It fell back to a neutral 🪐, so at the exact
  moment a child most needs to tell categories apart — before they own anything in one — the tile
  gave them only a name to read. That is the reading-heavy interaction the picture picker exists to
  avoid, and a theme lands every seed runbook, so there was permanently a blank tile and it was the
  newest one.

## The change

A category is fronted by its **first legendary in catalog order**, owned or not. Free and permanent:
no column, no blob, no seed field, no runbook step, and it cannot drift out of sync with the theme
because it *is* the theme's own art.

`coverCard` is now **total** for any non-empty category, which is what let 🪐 be deleted rather than
kept as an unreachable branch. `PlaceBar` gains the cover as a 28px decorative thumbnail — that bar
was pure text, #108 moved the category heading into it, and it is *sticky*, so it is a persistent
"where am I" through a 30-card scroll rather than arrival confirmation. No new sticky layer; the
two-layer budget is untouched.

## This reverses #122's own first answer, on purpose

The ticket first decided each theme would get **generated cover art depicting a place** — landmark,
no leak, and it was built and shipped for 16 themes. What changed is a cost the original weighing
got wrong: it treated the art as a one-off backfill, when it actually charges **every future theme**
an authored prompt, a bake-off row and a human screening pick, forever. Two themes landed on `main`
while that branch was open — **Rocks and Gems (#136)** and **Trees (#137)** — and each one owed
exactly that, turning a hypothetical recurring cost into an observed one within a single session.

Rocks and Gems also showed the ceiling on the idea: **11 of its 30 cards are places** (Crystal Cave,
Slot Canyon, Stone Arch, Hoodoo, Gold Mine, Quarry, Sea Cliff, River Canyon, Limestone Cave, Lava
Tube, Giant's Causeway), so almost every rocky landscape a cover could depict was itself a
collectable card.

## What this costs, taken deliberately

**It leaks unearned art.** `CardSlot` renders unowned cards as `❔` with no rarity hint (U5-Q5)
precisely so unearned art stays unearned, and the hub now shows every theme's best card from day one.
A **common** would nearly erase the leak — 15 of 30, pulled almost immediately — and was offered;
legendary was chosen for the art.

The narrower rule survives untouched: the locked *slot* inside a category still shows `❔`, so the
picker reveals what a theme's best card **looks like** without revealing **which slots are still
missing**.

## Migration, and a production state to know about

`0010` drops `themes.cover_url`. That column is not a hypothetical: the abandoned approach created it
and filled it with 16 URLs **on the production database** before the reversal, so this is a real drop
there and — via `IF EXISTS` — a no-op anywhere that never had it. Hand-written rather than generated,
because `drizzle-kit` diffs against the repo's snapshots and cannot see a column only production has.

**16 objects under `covers/` in Blob are orphaned** by this and are not removed here — a migration
cannot reach the store. `--blob-budget` will see them; they are ~11 MB against a store reported at 3%
of its allowance, so they are not urgent.

## Tests

`category-cover.pbt.test.ts` rewritten around the new invariants: ownership-independence (the whole
point), totality for non-empty categories, legendary preference, and stability.

The stability property is **guarded on the theme having a legendary**, and that guard is load-bearing
rather than a weakening — the unconditional version is false, since appending a legendary to a
section that had none moves the cover off the catalog-order fallback. The property test found that;
the pyramid (`RARITY_PYRAMID`, enforced on every seed command) makes the case unreachable for real
data.

628 tests, typecheck clean.

Part of map [#106](https://github.com/nywleswoey/kids-collection/issues/106).

https://claude.ai/code/session_016x8aFuw1mfKgEYwbn1XJSg
