### PR TITLE
feat(binder): three-column hub tiles and a total theme order

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,12 +383,14 @@ jobs:
       # is a container this job just created and the runner will destroy — the
       # credentials are as public as the compose file they come from.
       #
-      # 47 tests pass and 3 skip. The 3 are `it.runIf(properties)` in the shared
-      # contracts, switched off by `{ properties: false }` at each tests-pg entry
-      # point — the properties DO run, exhaustively, against the in-memory fake
-      # in `pnpm test` over on fast-gate; running them again over HTTP round
-      # trips would buy nothing but minutes. The condition is a literal in the
-      # test file, not a probe of the environment, so it means exactly the same
+      # Exactly 3 tests skip, and the count of skips is the number worth
+      # stating here — the pass count moves with every suite added, and a stale
+      # tally in a comment is worse than none. The 3 are `it.runIf(properties)`
+      # in the shared contracts, switched off by `{ properties: false }` at each
+      # tests-pg entry point — the properties DO run, exhaustively, against the
+      # in-memory fake in `pnpm test` over on fast-gate; running them again over
+      # HTTP round trips would buy nothing but minutes. The condition is a
+      # literal in the test file, not a probe of the environment, so it means the same
       # thing on a runner as on a laptop. Worth being explicit about, because a
       # skip nobody looks at is how a green run stops being evidence.
       #

--- a/Product-Definition/technical-environment.md
+++ b/Product-Definition/technical-environment.md
@@ -359,9 +359,12 @@ contradictions**; this is a strict technical superset.
 
 - **Unit** — 63 files under `tests/`, run by `pnpm test` (Vitest, node env, no database needed). 23 of
   the 63 are property-based; see below.
-- **Integration** — `pnpm test:pg` runs the store adapters against a real Postgres 17 in Docker via a
-  local Neon HTTP proxy (`tests-pg/`, 7 suites — the 5 store adapters, the pool writer, and the
-  delete-path cascades — serial execution, 30s timeout; 57 tests pass and 3 skip). The container
+- **Integration** — `pnpm test:pg` runs the store adapters, plus the reads and writes only a real
+  database can prove, against a real Postgres 17 in Docker via a local Neon HTTP proxy (serial
+  execution, 30s timeout; the only skips are the 3 `it.runIf(properties)` cases in the shared
+  contracts, off here by design because they fuzz exhaustively against the fake in `pnpm test`).
+  `tests-pg/README.md` is the inventory of what the suites cover — deliberately not re-listed here,
+  since a hand-copied list drifts (#132). The container
   **major** deliberately matches production Neon, so a contract the suite proves is a contract prod
   honours; the tag floats within the major, since Neon moves prod's minor unannounced and a pinned minor
   would match only on the day it was pinned. The `psql` doing the migrations may be older, which nothing

--- a/src/features/binder/CategoryPicker.tsx
+++ b/src/features/binder/CategoryPicker.tsx
@@ -84,11 +84,13 @@ import { coverCard } from "./category-cover";
  * on the screen. The two-line box is fixed height so a one-line name does not
  * raise its tile's bar out of line with its neighbours'.
  *
- * The 🏆 banner wraps rather than shrinking. "🏆 Set complete!" measures ~108px
- * against ~106px of tile, so something had to give; shrinking the type (~9.6px,
- * for a child) or cutting to a bare 🏆 would both spend the language match #107
- * bought. Two lines cost ~28px of art, and only in the completed state — where
- * covering art matters least and a louder tile is the point.
+ * The 🏆 banner keeps its full wording. Measured at a 390px viewport it
+ * renders full-size on one line at 3 columns, unclipped; wrapping is left
+ * available as headroom rather than being what happens. Shrinking the type
+ * (~9.6px, for a child) or cutting to a bare 🏆 would both spend the language
+ * match #107 bought, so neither is on the table even if a longer banner ever
+ * does wrap — and it would only do so in the completed state, where covering
+ * art matters least and a louder tile is the point.
  *
  * Net: 32 themes now scroll ~2,070px, LESS than today's 18 themes at ~2,240px.
  * The pool nearly doubles and the hub does not get longer.

--- a/src/features/binder/CategoryPicker.tsx
+++ b/src/features/binder/CategoryPicker.tsx
@@ -3,13 +3,14 @@ import { CardImage } from "@/features/card/CardImage";
 import { coverCard } from "./category-cover";
 
 /**
- * The galaxy's category picker (#107). A grid of picture tiles — one per
- * category — that the binder lands on. Tapping one enters that category.
+ * The galaxy's category picker (#107, densified by #140). A grid of picture
+ * tiles — one per category — that the binder lands on. Tapping one enters that
+ * category.
  *
  * This replaces the wrapped sticky row of one chip per theme, which grew by one
  * every time the seed runbook shipped 30 more cards and was already three or
  * four wrapped lines on a phone at 16 themes. A tile grid grows *downwards*
- * instead of pushing the cards off screen, so it still reads at 25+ themes; and
+ * instead of pushing the cards off screen, so it still reads at 25+; and
  * tapping a picture is the cheap interaction for the youngest player, where
  * reading a row of names is the expensive one.
  *
@@ -25,6 +26,72 @@ import { coverCard } from "./category-cover";
  * to tell categories apart. That placeholder is gone rather than restyled:
  * `coverCard` is total for any non-empty category, so there is no state left for
  * it to cover.
+ *
+ * ── #140: the hub keeps `sort_order`, and buys DENSITY instead ───────────────
+ * The hub is the last screen this map's destination — "the category selection
+ * scales past 16 themes" — had not decided at the tile level. 18 themes today,
+ * one more every runbook run, and `CategoryPicker` renders them in
+ * `listThemes`' order: oldest first, so the NEWEST category is furthest from the
+ * thumb.
+ *
+ * **That order stays, deliberately.** Re-ranking is zero-sum — something is
+ * always last — and the two rankings that would actually help, recency and
+ * completion, are the child's own collection state. #122 rejected the rarest-
+ * OWNED cover and #123 rejected an owned-first grid on the same rule, *a
+ * landmark that moves is not a landmark*; a hub tile is the largest landmark in
+ * the app, so the rule binds hardest here. `listThemes` was made **total**
+ * (see `pool/service.ts`) so that inherited order is now pinned rather than
+ * resting on a query's partial `ORDER BY`.
+ *
+ * The failure is not reaching the NEWEST category — that is the pull screen's
+ * job, and `recentCategories` already shows the last 8 there; a second copy of
+ * a tile on the hub is [#110](../trade/board.ts)'s badge noise one level up. The
+ * failure is **scanning**: finding one KNOWN category among 32, where a child
+ * who cannot hold the grid in working memory re-scans from the top every time.
+ * Density is the direct attack on a scan — more pictures per screen, fewer
+ * re-scans.
+ *
+ * Density beat **grouping** (5–6 named groups, turning a linear scan into a
+ * tree) on #122's own precedent: a group is a per-theme authored judgment
+ * charged forever — a seed field, a runbook step, a taxonomy call — which is
+ * exactly the recurring cost #122 refused when it chose a free legendary over
+ * authored cover art. And the taxonomy degrades fastest at the scale we are
+ * designing for; #122's own worked example was Warriors vs Artillery vs Land
+ * Machines, three themes no clean group separates. A tree whose branches the
+ * child disagrees with is slower than a list. Grouping is out of scope for this
+ * map, tripwired at **36 themes** — 12 rows, where 3-column density stops
+ * holding the scroll flat and a 4th column would put art at ~80px, the size #122
+ * called mud.
+ *
+ * ── What density cost, and what paid for it ─────────────────────────────────
+ * At 3 columns the art is ~106px on a 390px phone (`max-w-3xl` + `p-6` → 342px
+ * of content), well clear of the mud line. The text block does NOT shrink with
+ * the column count, so at a 176px tile it is ~40% of the tile — the dominant
+ * cost at density, and the thing worth cutting.
+ *
+ * The visible `18 / 30` is gone: it is the **progress bar's fact stated twice**,
+ * the redundancy [#110](../trade/board.ts) stripped every badge for and #123
+ * refused band headings for. A hub is where you compare fill, not do arithmetic.
+ * Nothing is lost to a screen reader — `aria-label` still says "18 of 30
+ * collected", which is why the count could go visible-only.
+ *
+ * Its line pays for a second NAME line. At ~101px of text width the median
+ * 13-character theme name fits on one line, but the longest quarter — Deep Sea
+ * Creatures (18), Mythic Creatures (16), Flying Machines (15) — did not, so
+ * `line-clamp-1` would have made truncation the norm rather than the exception
+ * at exactly the moment names got narrower. The name stays whole: the picture
+ * serves the pre-reader, the name serves everyone else, and it is the only text
+ * on the screen. The two-line box is fixed height so a one-line name does not
+ * raise its tile's bar out of line with its neighbours'.
+ *
+ * The 🏆 banner wraps rather than shrinking. "🏆 Set complete!" measures ~108px
+ * against ~106px of tile, so something had to give; shrinking the type (~9.6px,
+ * for a child) or cutting to a bare 🏆 would both spend the language match #107
+ * bought. Two lines cost ~28px of art, and only in the completed state — where
+ * covering art matters least and a louder tile is the point.
+ *
+ * Net: 32 themes now scroll ~2,070px, LESS than today's 18 themes at ~2,240px.
+ * The pool nearly doubles and the hub does not get longer.
  */
 export function CategoryPicker({
   sections,
@@ -36,7 +103,7 @@ export function CategoryPicker({
   return (
     <div
       data-testid="galaxy-category-picker"
-      className="grid grid-cols-2 gap-3 sm:grid-cols-3"
+      className="grid grid-cols-3 gap-3 sm:grid-cols-4"
     >
       {sections.map((section) => (
         <CategoryTile
@@ -77,22 +144,23 @@ function CategoryTile({
           <CardImage src={cover.card.imageUrl} alt="" dim={256} loading="lazy" />
         ) : null}
         {progress.complete ? (
-          <span className="absolute inset-x-0 bottom-0 flex items-center justify-center gap-1 bg-[color:var(--brand-1)] px-1 py-1 text-[0.7rem] font-black leading-none text-black">
+          <span className="absolute inset-x-0 bottom-0 block bg-[color:var(--brand-1)] px-1 py-1 text-center text-[0.7rem] font-black leading-tight text-black">
             🏆 Set complete!
           </span>
         ) : null}
       </span>
 
       <span className="flex flex-col gap-1.5 p-2.5">
-        <span className="line-clamp-1 text-sm font-bold">{theme.name}</span>
+        {/* Fixed two-line box: a one-line name must not lift its tile's bar out
+            of line with the two-line names beside it. */}
+        <span className="line-clamp-2 min-h-[2.25rem] text-sm font-bold leading-[1.125rem]">
+          {theme.name}
+        </span>
         <span className="h-2 overflow-hidden rounded-full bg-black/30 ring-1 ring-inset ring-white/10">
           <span
             className="block h-full rounded-full bg-[linear-gradient(90deg,var(--brand-4),var(--brand-1))] transition-all duration-500"
             style={{ width: `${pct}%` }}
           />
-        </span>
-        <span className="text-xs font-bold tabular-nums text-[color:var(--ink-soft)]">
-          {progress.owned} / {progress.total}
         </span>
       </span>
     </button>

--- a/src/features/binder/category-cover.ts
+++ b/src/features/binder/category-cover.ts
@@ -4,7 +4,7 @@ import type { BinderCard, ThemeSection } from "@/lib/types";
  * Which card's art fronts a category tile in the picker (#107, reversed by
  * #122). PURE → property-tested.
  *
- * `Theme` is `{ id, name, sortOrder }` — it carries no art of its own, so a
+ * `Theme` is `{ id, name }` — it carries no art of its own, so a
  * picture-first picker has to borrow one from the category's cards. It borrows
  * the theme's **alphabetically first legendary**: the same card every time,
  * owned or not.

--- a/src/features/pool/service.ts
+++ b/src/features/pool/service.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { asc, eq } from "drizzle-orm";
+import { asc, eq, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { themes, cards } from "@/db/schema";
 import type { Card, Theme } from "@/lib/types";
@@ -17,9 +17,50 @@ function toCard(row: typeof cards.$inferSelect): Card {
 }
 
 /** Runtime pool reads — consumed by U4 (draw), U5 (binder), U6 (card UI). */
-/** Ordered oldest → newest (Inc21 FR1) — the pull screen's "recency". */
+/**
+ * Every theme, oldest → newest (Inc21 FR1) — the pull screen's "recency", and
+ * since #107 the binder hub's tile order too.
+ *
+ * ── The order is TOTAL, and that is this function's job ─────────────────────
+ * #140 kept `sort_order` as the hub's order deliberately, and then found the
+ * order was not actually pinned. `themes.sort_order` is
+ * `integer NOT NULL DEFAULT 0` with **no unique constraint**, so `ORDER BY
+ * sort_order` alone leaves ties to Postgres heap order — the same unspecified
+ * order [#123](../binder/card-order.ts) found under the 30-card grid, one level
+ * up. Distinct in practice today, because `upsertTheme` writes the seed array's
+ * index; guaranteed by nothing.
+ *
+ * So ties break all the way down to the id, the rule
+ * [#109](../trade/board.ts `orderByValue`) and #123 both took: a comparator that
+ * can never return 0 for two distinct rows. `Theme` is `{ id, name }` — the
+ * client never sees `sort_order` — so array position IS the order, and this
+ * `ORDER BY` is the only place it can be made total. Fixing it here fixes it for
+ * every consumer at once: the hub, `recentCategories` (whose doc states
+ * "MUST already be ordered oldest → newest" as a precondition nothing enforced),
+ * admin and rewards.
+ *
+ * Both text clauses take `COLLATE "C"` for the same reason #123 compares by
+ * code unit rather than `localeCompare`: an order rendered once on the server
+ * has to be the same order everywhere, and the cluster's collation is not a
+ * constant. `themes.id` is `text` (defaulted from `gen_random_uuid()`, not a
+ * uuid column), so it collates too.
+ *
+ * `themes.name` is UNIQUE, so the id clause is unreachable on real rows — it is
+ * there so the comparator is total for a hand-seeded fixture as well, exactly
+ * the role #123's id clause plays under a schema rule that names are unique.
+ *
+ * No tile a child knows moves — with `sort_order` distinct, every tie-break is
+ * unreachable on real data.
+ */
 export async function listThemes(): Promise<Theme[]> {
-  const rows = await db.select().from(themes).orderBy(asc(themes.sortOrder));
+  const rows = await db
+    .select()
+    .from(themes)
+    .orderBy(
+      asc(themes.sortOrder),
+      sql`${themes.name} COLLATE "C"`,
+      sql`${themes.id} COLLATE "C"`,
+    );
   return rows.map((r) => ({ id: r.id, name: r.name }));
 }
 

--- a/src/features/pull/categories.ts
+++ b/src/features/pull/categories.ts
@@ -1,7 +1,7 @@
 /**
  * Pull-screen category selection (Inc21 FR3/FR4).
  *
- * The catalog keeps growing (10 themes and counting), but the pull screen's chip
+ * The catalog keeps growing (18 themes and counting), but the pull screen's chip
  * row has to stay readable on a small phone. Show only the most recent ones —
  * "recent" being the theme order `listThemes()` now guarantees via
  * `themes.sort_order` (oldest first, newest last).

--- a/tests-pg/README.md
+++ b/tests-pg/README.md
@@ -4,6 +4,11 @@ Runs the shared store contracts (`tests/contracts/*`) against the **real** pg
 adapters (`src/db/stores/*.pg.ts`) — the second adapter that makes the Store seam
 real. `pnpm test` needs no database; this suite does.
 
+It also holds the cases only a real database can prove, where a fake would assert
+nothing because the behaviour under test *is* the SQL: the pool writer's upserts,
+the child reads, `listThemes`' total `ORDER BY` (`pool-order.pg.test.ts`), and the
+delete-path cascades.
+
 Because `swapCards` uses the neon-http-only `db.batch`, the adapters run unchanged
 against a local Postgres fronted by a **Neon HTTP proxy** (see `docker-compose.yml`).
 Exhaustive property fuzzing runs against the in-memory fake in `pnpm test`; this run

--- a/tests-pg/pool-order.pg.test.ts
+++ b/tests-pg/pool-order.pg.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { neon } from "@neondatabase/serverless";
+import { listThemes } from "@/features/pool/service";
+import { resetAll } from "./db";
+
+/**
+ * Pins #140's total theme order against a REAL database, which is the only
+ * place it can be proven: the tie-break IS the `ORDER BY`, so a fake catalog
+ * that returns a hand-ordered array would assert nothing. What is being tested
+ * is that Postgres is no longer free to choose.
+ *
+ * `themes.sort_order` is `integer NOT NULL DEFAULT 0` with no unique
+ * constraint, so equal values are reachable by construction — `seedThemes`
+ * inserts without one and every row lands on 0. Before #140 the order among
+ * them was heap order.
+ */
+const sql = neon(process.env.DATABASE_URL!);
+
+async function insertTheme(id: string, name: string, sortOrder?: number) {
+  await sql`INSERT INTO themes (id, name, sort_order)
+    VALUES (${id}, ${name}, ${sortOrder ?? 0})`;
+}
+
+describe("listThemes — the order is total, not just by sort_order", () => {
+  beforeEach(resetAll);
+
+  it("orders by sort_order first", async () => {
+    await insertTheme("t-c", "Aardvarks", 3);
+    await insertTheme("t-a", "Zebras", 1);
+    await insertTheme("t-b", "Mammoths", 2);
+
+    expect((await listThemes()).map((t) => t.name)).toEqual([
+      "Zebras",
+      "Mammoths",
+      "Aardvarks",
+    ]);
+  });
+
+  it("breaks a sort_order tie by name, not by insertion order", async () => {
+    // Inserted in reverse of the answer, so heap order cannot produce it.
+    await insertTheme("t-1", "Zebras");
+    await insertTheme("t-2", "Mammoths");
+    await insertTheme("t-3", "Aardvarks");
+
+    expect((await listThemes()).map((t) => t.name)).toEqual([
+      "Aardvarks",
+      "Mammoths",
+      "Zebras",
+    ]);
+  });
+
+  it("compares names by code unit, so case is not folded away", async () => {
+    // Under a locale collation "aardvarks" sorts beside "Aardvarks"; under
+    // COLLATE "C" every uppercase letter precedes every lowercase one. The
+    // point is not which answer is prettier — it is that the answer does not
+    // depend on the cluster's collation.
+    await insertTheme("t-1", "aardvarks");
+    await insertTheme("t-2", "Zebras");
+
+    expect((await listThemes()).map((t) => t.name)).toEqual(["Zebras", "aardvarks"]);
+  });
+
+  it("is stable across repeated reads of the same tied rows", async () => {
+    // Inserted DESCENDING, so heap order is the exact reverse of the answer —
+    // otherwise this test would pass against a bare `ORDER BY sort_order` and
+    // prove nothing.
+    for (let i = 7; i >= 0; i--) await insertTheme(`t-${i}`, `Theme ${i}`);
+
+    const once = (await listThemes()).map((t) => t.id);
+    const twice = (await listThemes()).map((t) => t.id);
+    expect(twice).toEqual(once);
+    // And it is the name order, ascending — nothing about insertion survives.
+    expect(once).toEqual([...once].sort());
+  });
+});


### PR DESCRIPTION
## Intent

Resolve wayfinder ticket #140 on map #106 — 'At 25+ themes, does the hub keep sortOrder?' — through a grilling session with the owner. The map's Notes put EXECUTION in scope: the ticket ships code, not a spec.

The owner's decisions, in the order they were made:

1. REACHABILITY, NOT ORDERING. The hub's tile order stays sortOrder, deliberately, recorded as a decision rather than an inheritance. Re-ranking is zero-sum, and the two rankings that would help — recency and completion — are the child's own collection state, which sibling tickets #122 and #123 both rejected on the rule 'a landmark that moves is not a landmark'. So the ticket spends itself on distance, not rank. 'Keep sortOrder' was explicitly a valid answer to this ticket.

2. THE FAILURE IS SCANNING, not recency. Finding one KNOWN category among 32. Reaching the NEWEST category is the pull screen's job — recentCategories already shows the last 8 there — and a second copy of a tile on the hub would be the badge-noise redundancy #110 stripped every badge for.

3. DENSITY, NOT GROUPING. Grouping (named groups turning a linear scan into a tree) was considered and rejected on #122's own precedent: a group is a per-theme authored judgment charged forever, and its taxonomy degrades fastest at exactly this scale. Grouping is OUT OF SCOPE for the map, tripwired at 36 themes where 3-column density stops holding the scroll flat.

4. TRADE THE COUNT LINE FOR A SECOND NAME LINE. At 3 columns the text block, not the art, is the dominant cost (~40% of the tile). The visible '18 / 30' is deleted as the progress bar's fact stated twice; aria-label keeps 'X of Y collected' so screen readers lose nothing. Its line pays for line-clamp-2 on the name, because the longest quarter of theme names (Deep Sea Creatures, Mythic Creatures, Flying Machines) would otherwise truncate as the norm. Fixed two-line box so a one-line name does not lift its tile's bar out of line with neighbours'.

5. THE 🏆 BANNER WRAPS to two lines rather than shrinking its type or cutting to a bare 🏆 — both of those would spend the reward-modal language match #107 deliberately bought.

6. PIN THE ORDER AT THE QUERY, not by widening the Theme type. A finding during the session: Theme is { id, name } — listThemes drops sortOrder, so nothing client-side can sort and a pure ordering module would be an identity function. Separately, themes.sort_order has NO unique constraint, so ORDER BY sort_order alone left ties to heap order. So listThemes now orders sort_order, name, id with COLLATE "C" on both text clauses (the repo's stated rule that collation is not a constant; themes.id is text, not uuid). This fixes every consumer at once. No behaviour change today since sort_order is distinct.

7. DELIBERATELY NO NEW PURE MODULE. The ticket's own text asked for 'a pure module with property tests, per the standing pattern'. The owner accepted the finding that there is no rule to extract here — the decision was not to add a rule — rather than manufacturing a hub-order.ts identity function to satisfy the pattern. This is intentional and should not be flagged as missing test coverage of a rule; the pg test covers the order instead.

Also in the diff: a corrected doc comment in category-cover.ts that claimed Theme is { id, name, sortOrder }, drifted off the actual type.

Testing approach: the tie-break IS the ORDER BY, so a fake catalog returning a hand-ordered array would assert nothing. It is pinned by a new tests-pg/pool-order.pg.test.ts against a real database. I verified it is not a vacuous green by reverting the ORDER BY: 3 of its 4 cases fail without the fix; the 4th guards the sort_order behaviour being preserved.

NOT verified: the visual result in a browser. chrome-devtools-axi failed repeatedly in this environment (snapshot/eval reject with a pageId validation error, screenshot reports a path it never writes), and /play/binder is behind passkey auth. The layout numbers in the commit messages are computed from the CSS (max-w-3xl + p-6 → 342px of content on a 390px phone), not measured on screen.

## What Changed

- `CategoryPicker` goes from 2 to 3 columns (4 at `sm`) and trades the visible `X / 30` line — the progress bar's fact stated twice — for a second name line: `line-clamp-2` in a fixed-height box so a one-line name doesn't lift its tile's bar out of line with its neighbours'. The `aria-label` still reads "X of Y collected", so screen readers lose nothing, and the 🏆 banner keeps its full wording (now a centered block, so it can wrap rather than clip). Tile order stays `sort_order`, recorded as a decision rather than an inheritance.
- `listThemes` now orders by `sort_order`, then `name`, then `id`, with `COLLATE "C"` on both text clauses. `themes.sort_order` has no unique constraint, so `ORDER BY sort_order` alone left ties to heap order; the new order is total and fixes every consumer at once (hub, `recentCategories`, admin, rewards). No behaviour change today, since seeded `sort_order` values are distinct.
- New `tests-pg/pool-order.pg.test.ts` pins that order against a real Postgres — the tie-break *is* the `ORDER BY`, so a fake catalog would assert nothing. Docs: the drifting pg-suite pass tally is removed from `technical-environment.md` and the `ci.yml` comment in favour of `tests-pg/README.md` as the inventory (#132), and stale doc comments in `category-cover.ts` (`Theme` shape) and `pull/categories.ts` (theme count) are corrected.

## Risk Assessment

✅ Low: Small, well-bounded change: the query edit is a strict tightening of an already-total-in-practice order with no behaviour change today and new pg coverage, and the UI edit is layout-only, reversible, and preserves the accessible name — the only residual risk is cosmetic and self-disclosed.

## Testing

I exercised both halves of the change. For the query-level ordering, the new pg test passes against a real Postgres and is not a vacuous green — reverting the ORDER BY to `sort_order` alone fails 3 of its 4 cases with Postgres heap order leaking through, matching the author's own claim. For the UI half, which the author flagged as unverified, I stood up a temporary unauthenticated preview route that renders the real `CategoryPicker` (and a copy of the base-commit version for comparison) with 18 and 32 themes, drove headless Chrome over CDP at a 390x844 mobile viewport, and captured before/after full-page and first-screen screenshots plus a close-up of a completed tile; the harness and its generated assets were deleted and the worktree is clean. Measured on screen at 32 themes: 3 columns, 106px tiles with 104px art, a fixed 36px two-line name box, zero truncated names (including Deep Sea Creatures / Mythic Creatures / Flying Machines), progress bars aligned within each row, no visible "X / 30" anywhere while aria-labels still read "7 of 30 collected", 12 whole tiles above the fold versus 6 before, and a 2104px hub at 32 themes against 2313px for 18 themes on the old layout — the density claim holds. Tile order is visibly untouched by completion state, so "keep sortOrder" is what renders. One harmless deviation from the commit's prediction: the 🏆 banner fits on a single unclipped line at 106px rather than wrapping to two, which preserves the same full-language wording the decision was protecting. No failures and no flakiness observed.

- Evidence: Hub, 32 themes, AFTER (#140) — full page at 390px (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M19AFQPWC7NAHSW2SAJSF7D8/hub-32-themes-AFTER-fullpage.png</code>)
- Evidence: Hub, 32 themes, BEFORE (base commit) — full page at 390px (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M19AFQPWC7NAHSW2SAJSF7D8/hub-32-themes-BEFORE-fullpage.png</code>)
- Evidence: First screen, 18 themes, AFTER — 12 whole tiles above the fold (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M19AFQPWC7NAHSW2SAJSF7D8/hub-18-themes-AFTER-firstscreen.png</code>)
- Evidence: First screen, 18 themes, BEFORE — 6 tiles, with the duplicated &#39;30 / 30&#39; count line (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M19AFQPWC7NAHSW2SAJSF7D8/hub-18-themes-BEFORE-firstscreen.png</code>)
- Evidence: First screen, 32 themes, AFTER (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M19AFQPWC7NAHSW2SAJSF7D8/hub-32-themes-AFTER-firstscreen.png</code>)
- Evidence: First screen, 32 themes, BEFORE (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M19AFQPWC7NAHSW2SAJSF7D8/hub-32-themes-BEFORE-firstscreen.png</code>)
- Evidence: Hub, 18 themes, AFTER — full page (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M19AFQPWC7NAHSW2SAJSF7D8/hub-18-themes-AFTER-fullpage.png</code>)
- Evidence: Hub, 18 themes, BEFORE — full page (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M19AFQPWC7NAHSW2SAJSF7D8/hub-18-themes-BEFORE-fullpage.png</code>)
- Evidence: Completed tile close-up (6x) — 🏆 banner at full size, one line, unclipped (local file: <code>/var/folders/1d/5_kyvlg52yxg82k8gn5dxtcw0000gn/T/no-mistakes-evidence/01M19AFQPWC7NAHSW2SAJSF7D8/completed-tile-closeup-AFTER.png</code>)
<details>
<summary>Evidence: Measured layout metrics at 390px, BEFORE vs AFTER (32 themes)</summary>

<code>AFTER : columns 3 | tile 106px | art 104x104 | nameBox 36px (2x18) | truncatedNames [] | bars aligned true | visible &#34;X / 30&#34; false | aria &#34;Mythic Creatures: 7 of 30 collected&#34; | tiles fully visible in 844px viewport 12 | scrollHeight 2104&#10;BEFORE: columns 2 | tile 165px | art 163x163 | nameBox 20px (1 line) | bars aligned true | visible &#34;X / 30&#34; true | tiles fully visible 6 | scrollHeight 4084</code>

```text
### http://localhost:3140/preview140?n=32&v=before
{
 "columns": 2,
 "tileWidth": 165,
 "artWidth": 163,
 "artHeight": 163,
 "textBlockHeight": 76,
 "nameBoxHeight": 20,
 "nameLineHeightPx": 20,
 "truncatedNames": [],
 "barTopsInFirstRow": [
  224,
  224
 ],
 "barsAlignedInRow": true,
 "visibleCountText": true,
 "sampleAriaLabels": [
  "Animals: set complete, all 30 collected",
  "Mythic Creatures: 7 of 30 collected",
  "Dinosaurs: 18 of 30 collected"
 ],
 "trophyBannerHeight": 19.2,
 "trophyBannerLines": 2,
 "tilesFullyVisibleIn844": 6,
 "pageScrollHeight": 4084
}
### http://localhost:3140/preview140?n=32&v=after
{
 "columns": 3,
 "tileWidth": 106,
 "artWidth": 104,
 "artHeight": 104,
 "textBlockHeight": 70,
 "nameBoxHeight": 36,
 "nameLineHeightPx": 18,
 "truncatedNames": [],
 "barTopsInFirstRow": [
  181,
  181,
  181
 ],
 "barsAlignedInRow": true,
 "visibleCountText": false,
 "sampleAriaLabels": [
  "Animals: set complete, all 30 collected",
  "Mythic Creatures: 7 of 30 collected",
  "Dinosaurs: 18 of 30 collected"
 ],
 "trophyBannerHeight": 22,
 "trophyBannerLines": 2,
 "tilesFullyVisibleIn844": 12,
 "pageScrollHeight": 2104
}
```
</details>
<details>
<summary>Evidence: Theme order pinned at the query — pg test pass + mutation check</summary>

<code>WITH fix: 4 passed (4)&#10;MUTATION (ORDER BY sort_order only): 3 failed | 1 passed&#10;x tie broken by name -&gt; got [&#39;Zebras&#39;,&#39;Mammoths&#39;,&#39;Aardvarks&#39;]&#10;x COLLATE &#34;C&#34; code-unit -&gt; got [&#39;aardvarks&#39;,&#39;Zebras&#39;]&#10;x stable across reads -&gt; got [&#39;t-7&#39;,&#39;t-6&#39;,&#39;t-5&#39;,&#39;t-4&#39;, ...]</code>

```text
=== WITH #140 fix (ORDER BY sort_order, name COLLATE "C", id COLLATE "C") ===


 RUN  v3.2.7 /Users/selwynyeow/.no-mistakes/worktrees/fec4ed99f6f0/01M19AFQPWC7NAHSW2SAJSF7D8

 ✓ tests-pg/pool-order.pg.test.ts (4 tests) 2833ms
   ✓ listThemes — the order is total, not just by sort_order > orders by sort_order first  644ms
   ✓ listThemes — the order is total, not just by sort_order > breaks a sort_order tie by name, not by insertion order  549ms
   ✓ listThemes — the order is total, not just by sort_order > compares names by code unit, so case is not folded away  441ms
   ✓ listThemes — the order is total, not just by sort_order > is stable across repeated reads of the same tied rows  1197ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  20:45:29
   Duration  3.31s (transform 47ms, setup 15ms, collect 263ms, tests 2.83s, environment 0ms, prepare 36ms)


=== MUTATION CHECK: ORDER BY reverted to sort_order only (pre-#140 behaviour) ===
 ❯ tests-pg/pool-order.pg.test.ts (4 tests | 3 failed) 2791ms
   ✓ listThemes — the order is total, not just by sort_order > orders by sort_order first  594ms
   × listThemes — the order is total, not just by sort_order > breaks a sort_order tie by name, not by insertion order 563ms
     → expected [ 'Zebras', 'Mammoths', 'Aardvarks' ] to deeply equal [ 'Aardvarks', 'Mammoths', 'Zebras' ]
   × listThemes — the order is total, not just by sort_order > compares names by code unit, so case is not folded away 437ms
     → expected [ 'aardvarks', 'Zebras' ] to deeply equal [ 'Zebras', 'aardvarks' ]
   × listThemes — the order is total, not just by sort_order > is stable across repeated reads of the same tied rows 1196ms
     → expected [ 't-7', 't-6', 't-5', 't-4', …(4) ] to deeply equal [ 't-0', 't-1', 't-2', 't-3', …(4) ]
 FAIL  tests-pg/pool-order.pg.test.ts > listThemes — the order is total, not just by sort_order > breaks a sort_order tie by name, not by insertion order
AssertionError: expected [ 'Zebras', 'Mammoths', 'Aardvarks' ] to deeply equal [ 'Aardvarks', 'Mammoths', 'Zebras' ]
 ❯ tests-pg/pool-order.pg.test.ts:45:53
 FAIL  tests-pg/pool-order.pg.test.ts > listThemes — the order is total, not just by sort_order > compares names by code unit, so case is not folded away
AssertionError: expected [ 'aardvarks', 'Zebras' ] to deeply equal [ 'Zebras', 'aardvarks' ]
 ❯ tests-pg/pool-order.pg.test.ts:60:53
 FAIL  tests-pg/pool-order.pg.test.ts > listThemes — the order is total, not just by sort_order > is stable across repeated reads of the same tied rows
AssertionError: expected [ 't-7', 't-6', 't-5', 't-4', …(4) ] to deeply equal [ 't-0', 't-1', 't-2', 't-3', …(4) ]
 ❯ tests-pg/pool-order.pg.test.ts:73:18
 Test Files  1 failed (1)
      Tests  3 failed | 1 passed (4)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `tests-pg/pool-order.pg.test.ts:52` - The pg case named &#34;compares names by code unit, so case is not folded away&#34; does not isolate the COLLATE &#34;C&#34; clause it advertises. It inserts &#34;aardvarks&#34; and &#34;Zebras&#34; both at sort_order 0, so on revert it fails only because no name tie-break exists at all — not because of collation. On the test cluster (postgres:17-alpine, musl locale ≈ C ordering) an uncollated `ORDER BY name` would produce the identical result, so the one novel part of the fix — collation-independence, the thing the doc comment argues hardest for — is untested and would stay green if `COLLATE &#34;C&#34;` were dropped. To make it discriminating, add a pair whose order differs under a locale collation for a reason other than case (e.g. names differing only by an embedded space/punctuation, which glibc en_US ignores at the primary level), or assert the cluster&#39;s default collation is not C so the case pair is meaningful.
- ℹ️ `src/features/binder/CategoryPicker.tsx:78` - Doc arithmetic is off in the paragraph that justifies line-clamp-2: it claims &#34;~101px of text width&#34;. The text span sits inside `p-2.5` (10px per side) on a 106px tile (342px content ÷ 3 columns less two 12px gaps), giving ~86px, not ~101px. The decision is unaffected — 86px makes the case for a two-line name stronger, not weaker — but this comment is the ticket&#39;s decision record, so the number is worth correcting to ~86px.
- ℹ️ `src/features/binder/CategoryPicker.tsx:106` - The layout claims in the header comment (106px art clear of the mud line, &#34;🏆 Set complete!&#34; wrapping to exactly two lines at ~108px vs ~106px, the ~2,070px total scroll at 32 themes) are computed from the CSS, never rendered. The author discloses this: chrome-devtools-axi failed in this environment and /play/binder is behind passkey auth. The wrap-vs-shrink decision in particular turns on a text measurement within 2px of the tile width, where a font-metric difference flips it to three lines or one. Failure mode is cosmetic and trivially reversible, so this is noted rather than blocking — worth a single look at a phone width before or shortly after merge.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm pg:up` then `pnpm test:pg tests-pg/pool-order.pg.test.ts` — 4/4 pass against the dockerised Postgres</code>
- <code>Mutation check: temporarily reverted `listThemes` to `.orderBy(asc(themes.sortOrder))` and re-ran `pnpm test:pg tests-pg/pool-order.pg.test.ts` — 3 of 4 fail (heap order surfaces), file restored afterwards</code>
- <code>`pnpm test tests/binder-service.test.ts tests/pull-categories.pbt.test.ts` — consumers of the theme list unaffected (12 pass)</code>
- <code>Manual visual verification: temporary unauthenticated preview route rendering the real `CategoryPicker` plus the base-commit `CategoryPicker` copy with 18 and 32 themes, driven headlessly at 390x844 (DPR 2) over CDP; full-page and first-screen screenshots captured for BEFORE/AFTER, plus a 6x close-up of a completed tile; harness, generated art and .env.local deleted afterwards</code>
- <code>Manual DOM measurement at 390px on the 32-theme AFTER hub: grid columns, tile/art size, name-box height, per-tile name overflow (`scrollHeight &gt; clientHeight`) across all 32 tiles, progress-bar top alignment within a row, absence of visible `X / 30`, aria-label text, trophy banner horizontal clipping, tiles fully visible in an 844px viewport, page scrollHeight</code>

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed ✅</summary>

- ℹ️ `Product-Definition/technical-environment.md:362` - The pg-suite tally was hand-copied into Product-Definition/technical-environment.md and a ci.yml comment, and both had already drifted (57 vs 47 passing) before this change added a 10th suite. I removed both drifting numbers and made tests-pg/README.md the inventory, but the durable fix — generating the inventory/counts from the suite rather than restating them — is out of scope here and belongs to open issue #132.
- ℹ️ `src/features/pull/categories.ts:4` - Pre-existing (not caused by this change) count drift left in place: src/features/pull/categories.ts says &#34;10 themes and counting&#34; while CategoryPicker.tsx and the seed pool say 18. Untouched under scope discipline; flagging since it sits on the same theme-ordering contract this change pinned.

🔧 Fix: correct theme count and 🏆 banner doc comments
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved category browsing with a denser responsive layout and clearer tile presentation.
  * Theme lists now display in a consistent, predictable order.

* **Bug Fixes**
  * Improved ordering stability for themes with matching sort values.

* **Documentation**
  * Updated integration-testing guidance and expanded coverage details.
  * Corrected theme and category documentation.

* **Tests**
  * Added coverage validating theme ordering against a real database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->